### PR TITLE
Fix URL for the documentation, now available at RTD.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Main features
 Documentation
 *************
 
-A detailled `documentation <http://docs.modoboa.org/>`_ will help you
+A detailled `documentation <https://modoboa.readthedocs.org/>`_ will help you
 to install, use or extend Modoboa.
 
 ******


### PR DESCRIPTION
The URL doc.modoboa.orgis only for 0.9.5, but settings.py have change in 1.0.0
