### PR TITLE
Under Debian with dovecot > 2.x, dovecot-dict-sql.conf breaking config

### DIFF
--- a/doc/integration/imap_and_smtp.rst
+++ b/doc/integration/imap_and_smtp.rst
@@ -185,7 +185,7 @@ Inside *conf.d/90-quota.conf*, activate the *quota dictionary* backend::
 
 It will tell Dovecot to keep quota usage in the SQL dictionary.
 
-Finally, edit the *dovecot-dict-sql.conf* file and put the following content inside::
+Finally, edit the *dovecot-dict-sql.conf.ext* file and put the following content inside::
 
   connect = host=<db host> dbname=<db name> user=<db user> password=<password>
 


### PR DESCRIPTION
Under Debian with dovecot > 2.x, dovecot-dict-sql.con is take as a configuration file and broke the configuration, and CPU come to 100% since the service is shutdown
