### PR TITLE
Added missing comma in settings.py.tpl

### DIFF
--- a/modoboa/core/templates/settings.py.tpl
+++ b/modoboa/core/templates/settings.py.tpl
@@ -212,7 +212,7 @@ LOGGING = {
             'class': 'logging.handlers.SysLogHandler',
             'facility': SysLogHandler.LOG_CRON,
             'formatter': 'syslog'
-        }
+        },
         'modoboa': {
             'class': 'modoboa.lib.logutils.SQLHandler',
         }


### PR DESCRIPTION
A missing comma in settings.py.tpl breaks new deployments.
