### PR TITLE
Fix cleanlogs command.

### DIFF
--- a/modoboa/core/management/commands/cleanlogs.py
+++ b/modoboa/core/management/commands/cleanlogs.py
@@ -4,7 +4,7 @@ import datetime
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.utils import timezone
-from modoboa.core import load_settings
+from modoboa.core import load_core_settings
 from modoboa.core.models import Log
 from modoboa.lib import parameters
 
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             l.addHandler(logging.StreamHandler())
         self.verbose = options["verbose"]
 
-        load_settings()
+        load_core_settings()
         log_maximum_age = int(parameters.get_admin("LOG_MAXIMUM_AGE"))
         self.__vprint("Deleting logs older than %d days..." % log_maximum_age)
         limit = timezone.now() - datetime.timedelta(log_maximum_age)


### PR DESCRIPTION
Fix for  #511.

Looks like the method **load_settings** of `modoboa/core/__init__.py` was renamed in commit _a11e690_ to **load_core_settings**.
