### PR TITLE
Improve travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,19 @@ services:
 
 before_install:
   - pip install codecov
+  - if [[ $DB = 'POSTGRESQL' ]]; then pip install -q psycopg2; fi
+  - if [[ $DB = 'MYSQL' ]]; then pip install -q mysqlclient; fi
 
 install:
   - python setup.py -q develop
-  - pip install -q psycopg2 mysqlclient
   - pip install -q -r ldap-requirements.txt
   - pip install -q -r test-requirements.txt
 
 before_script:
-  - psql -c 'create database modoboa_test;' -U postgres
-  - mysql -e "create database IF NOT EXISTS modoboa_test;" -uroot
-  - mysql -e "CREATE USER 'modoboa'@'localhost' IDENTIFIED BY 'modoboa'" -uroot;
-  - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'modoboa'@'localhost';" -uroot;
+  - if [[ $DB = 'POSTGRESQL' ]]; then psql -c 'create database modoboa_test;' -U postgres; fi
+  - if [[ $DB = 'MYSQL' ]]; then mysql -e "create database IF NOT EXISTS modoboa_test;" -uroot; fi
+  - if [[ $DB = 'MYSQL' ]]; then mysql -e "CREATE USER 'modoboa'@'localhost' IDENTIFIED BY 'modoboa'" -uroot; fi
+  - if [[ $DB = 'MYSQL' ]]; then mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'modoboa'@'localhost';" -uroot; fi
   - mkdir /tmp/slapd
   - slapd -f test_data/slapd.conf -h ldap://localhost:3389 &
   - sleep 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+cache: pip
 python:
   - "2.7"
 addons:

--- a/modoboa/test_settings.py
+++ b/modoboa/test_settings.py
@@ -21,7 +21,7 @@ if DB == 'MYSQL':
         },
 
     }
-if DB == 'SQLITE':
+elif DB == 'SQLITE':
     DATABASES = {
 
         'default': {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Travis test create MySQL database when test PostgreSQL and vice versa

Current behavior before PR:

Lose 6s to install psycopg2 when testing MySQL

Desired behavior after PR is merged:

Improve speed, and remove the unnecessary library