### PR TITLE
Dovecot MySQL queries update

### DIFF
--- a/doc/manual_installation/dovecot.rst
+++ b/doc/manual_installation/dovecot.rst
@@ -147,11 +147,11 @@ MySQL users
 
   default_pass_scheme = CRYPT
 
-  password_query = SELECT email AS user, password FROM core_user WHERE email='%u' and is_active=1
+  password_query = SELECT email AS user, password FROM core_user, admin_domain WHERE ecore_user.mail='%Lu' AND core_user.is_active=1 AND admin_domain.name='%Ld' AND admin_domain.enabled=1
 
-  user_query = SELECT '<mailboxes storage directory>/%Ld/%Ln' AS home, <uid> as uid, <gid> as gid, concat('*:bytes=', mb.quota, 'M') AS quota_rule FROM admin_mailbox mb INNER JOIN admin_domain dom ON mb.domain_id=dom.id WHERE mb.address='%Ln' AND dom.name='%Ld'
+  user_query = SELECT '<mailboxes storage directory>/%Ld/%Ln' AS home, <uid> AS uid, <gid> AS gid, concat('*:bytes=', mb.quota, 'M') AS quota_rule FROM admin_mailbox mb INNER JOIN admin_domain dom ON mb.domain_id=dom.id WHERE mb.address='%Ln' AND dom.name='%Ld'
 
-  iterate_query = SELECT email AS username FROM core_user WHERE email<>''
+  iterate_query = SELECT email AS user FROM core_user WHERE email='%Lu'
 
 .. _dovecot_pg_queries:
 

--- a/doc/manual_installation/dovecot.rst
+++ b/doc/manual_installation/dovecot.rst
@@ -147,7 +147,7 @@ MySQL users
 
   default_pass_scheme = CRYPT
 
-  password_query = SELECT email AS user, password FROM core_user, admin_domain WHERE ecore_user.mail='%Lu' AND core_user.is_active=1 AND admin_domain.name='%Ld' AND admin_domain.enabled=1
+  password_query = SELECT email AS user, password FROM core_user, admin_domain WHERE core_user.email='%Lu' AND core_user.is_active=1 AND admin_domain.name='%Ld' AND admin_domain.enabled=1
 
   user_query = SELECT '<mailboxes storage directory>/%Ld/%Ln' AS home, <uid> AS uid, <gid> AS gid, concat('*:bytes=', mb.quota, 'M') AS quota_rule FROM admin_mailbox mb INNER JOIN admin_domain dom ON mb.domain_id=dom.id WHERE mb.address='%Ln' AND dom.name='%Ld'
 


### PR DESCRIPTION
Using the MySQL password query for Dovecot found in Modoboa documentation, the user is still able to authenticate when his domain (and not his email) is disabled. Updated query prevents that.

Also, iterate query should select email as user instead of username since doveadm command applies to whole email address.

And cosmetic changes for user query.