### PR TITLE
Add title tag for dashboard

### DIFF
--- a/modoboa/core/templates/core/dashboard.html
+++ b/modoboa/core/templates/core/dashboard.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block pagetitle %}{% trans "Dashboard" %}{% endblock %}
+
 {% block container_content %}
 
   <div class="row">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
#1114

Current behavior before PR:
Dashboard has empty title tag

Desired behavior after PR is merged:
Dashboard has "Dashboard" title tag