### PR TITLE
make modoboa-admin deploy work with python 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ DEV
 .idea
 .ropeproject
 modoboa.iml
+.tox
+modoboa_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 script:
   - python ./tests.py
   - cd test_project
-  - coverage run --source ../modoboa manage.py test modoboa.core modoboa.admin.tests modoboa.limits modoboa.relaydomains
+  - coverage run --source ../modoboa manage.py test modoboa.core modoboa.admin modoboa.limits modoboa.relaydomains
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 script:
   - python ./tests.py
   - cd test_project
-  - coverage run --source ../modoboa manage.py test modoboa.core modoboa.admin modoboa.limits modoboa.relaydomains
+  - coverage run --source ../modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
 
 after_success:
   - codecov

--- a/bin/modoboa-admin.py
+++ b/bin/modoboa-admin.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 from modoboa.core.commands import handle_command_line
 
 if __name__ == "__main__":

--- a/ldap-requirements.txt
+++ b/ldap-requirements.txt
@@ -1,2 +1,2 @@
-python-ldap
+pyldap
 django-auth-ldap

--- a/ldap-requirements.txt
+++ b/ldap-requirements.txt
@@ -1,2 +1,1 @@
-pyldap
 django-auth-ldap

--- a/modoboa/__init__.py
+++ b/modoboa/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/__init__.py
+++ b/modoboa/admin/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import unicode_literals
+
 default_app_config = "modoboa.admin.apps.AdminConfig"

--- a/modoboa/admin/api.py
+++ b/modoboa/admin/api.py
@@ -1,5 +1,7 @@
 """Admin API."""
 
+from __future__ import unicode_literals
+
 from django import http
 
 from django.contrib.contenttypes.models import ContentType

--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -7,6 +7,7 @@ import os
 from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy
+from django.utils.encoding import force_text
 
 from modoboa.lib.form_utils import YesNoField, SeparatorField
 from modoboa.lib.sysutils import exec_cmd
@@ -129,6 +130,7 @@ class AdminParametersForm(param_forms.AdminParametersForm):
             except OSError:
                 hide_fields = True
             else:
+                version = force_text(version)
                 if code or not version.strip().startswith("2"):
                     hide_fields = True
         else:

--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -1,5 +1,7 @@
 """Modoboa admin settings."""
 
+from __future__ import unicode_literals
+
 import os
 
 from django import forms

--- a/modoboa/admin/apps.py
+++ b/modoboa/admin/apps.py
@@ -1,5 +1,7 @@
 """AppConfig for admin."""
 
+from __future__ import unicode_literals
+
 from django.apps import AppConfig
 
 from .app_settings import load_admin_settings

--- a/modoboa/admin/constants.py
+++ b/modoboa/admin/constants.py
@@ -1,5 +1,7 @@
 """Admin constants."""
 
+from __future__ import unicode_literals
+
 DNSBL_PROVIDERS = [
     "aspews.ext.sorbs.net",
     "b.barracudacentral.org",

--- a/modoboa/admin/factories.py
+++ b/modoboa/admin/factories.py
@@ -1,6 +1,9 @@
 """
 Fixtures factories.
 """
+
+from __future__ import unicode_literals
+
 import factory
 
 from modoboa.core.factories import PermissionFactory, UserFactory

--- a/modoboa/admin/forms/__init__.py
+++ b/modoboa/admin/forms/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .domain import (
     DomainFormGeneral, DomainFormOptions, DomainForm, DomainWizard
 )

--- a/modoboa/admin/forms/account.py
+++ b/modoboa/admin/forms/account.py
@@ -1,5 +1,7 @@
 """Forms related to accounts management."""
 
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 from functools import reduce
 

--- a/modoboa/admin/forms/alias.py
+++ b/modoboa/admin/forms/alias.py
@@ -1,5 +1,7 @@
 """Forms related to aliases management."""
 
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from django import forms

--- a/modoboa/admin/forms/domain.py
+++ b/modoboa/admin/forms/domain.py
@@ -1,5 +1,7 @@
 """Forms related to domains management."""
 
+from __future__ import unicode_literals
+
 from functools import reduce
 
 from django import forms

--- a/modoboa/admin/forms/domain.py
+++ b/modoboa/admin/forms/domain.py
@@ -8,6 +8,7 @@ from django import forms
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.encoding import force_text
 
 from modoboa.core import signals as core_signals
 from modoboa.core.models import User
@@ -98,7 +99,7 @@ class DomainFormGeneral(forms.ModelForm, DynamicForm):
         if label is not None:
             self.add_error(
                 "name", _("A %s with this name already exists")
-                % unicode(label)
+                % force_text(label)
             )
         condition = (
             self.cleaned_data["quota"] != 0 and
@@ -120,7 +121,8 @@ class DomainFormGeneral(forms.ModelForm, DynamicForm):
                 if default_mailbox_quota == 0:
                     self.add_error("default_mailbox_quota", msg)
         self.aliases = []
-        for k in cleaned_data.keys():
+        copied_data = cleaned_data.copy()
+        for k in copied_data.keys():
             if not k.startswith("aliases"):
                 continue
             if cleaned_data[k] == "":
@@ -137,7 +139,7 @@ class DomainFormGeneral(forms.ModelForm, DynamicForm):
             if label is not None:
                 self.add_error(
                     k, _("A %s with this name already exists")
-                    % unicode(label)
+                    % force_text(label)
                 )
             else:
                 self.aliases.append(cleaned_data[k])

--- a/modoboa/admin/forms/export.py
+++ b/modoboa/admin/forms/export.py
@@ -25,12 +25,12 @@ class ExportDataForm(forms.Form):
     def clean_sepchar(self):
         if self.cleaned_data["sepchar"] == "":
             return ";"
-        return str(self.cleaned_data["sepchar"])
+        return self.cleaned_data["sepchar"]
 
     def clean_filename(self):
         if self.cleaned_data["filename"] == "":
             return self.fields["filename"].initial
-        return str(self.cleaned_data["filename"])
+        return self.cleaned_data["filename"]
 
 
 class ExportDomainsForm(ExportDataForm):

--- a/modoboa/admin/forms/export.py
+++ b/modoboa/admin/forms/export.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy
 

--- a/modoboa/admin/forms/forward.py
+++ b/modoboa/admin/forms/forward.py
@@ -1,5 +1,7 @@
 """Forms related to forwards management."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.core import validators
 from django.utils.translation import ugettext_lazy

--- a/modoboa/admin/forms/import_.py
+++ b/modoboa/admin/forms/import_.py
@@ -29,7 +29,7 @@ class ImportDataForm(forms.Form):
     def clean_sepchar(self):
         if self.cleaned_data["sepchar"] == "":
             return ";"
-        return str(self.cleaned_data["sepchar"])
+        return self.cleaned_data["sepchar"]
 
 
 class ImportIdentitiesForm(ImportDataForm):

--- a/modoboa/admin/forms/import_.py
+++ b/modoboa/admin/forms/import_.py
@@ -1,5 +1,7 @@
 """Forms related to import operations."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy
 

--- a/modoboa/admin/handlers.py
+++ b/modoboa/admin/handlers.py
@@ -1,5 +1,7 @@
 """Django signal handlers for admin."""
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.db.models import signals
 from django.dispatch import receiver

--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -2,6 +2,8 @@
 
 """Internal library for admin."""
 
+from __future__ import unicode_literals
+
 from functools import wraps
 from itertools import chain
 

--- a/modoboa/admin/management/__init__.py
+++ b/modoboa/admin/management/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/management/commands/__init__.py
+++ b/modoboa/admin/management/commands/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/management/commands/handle_mailbox_operations.py
+++ b/modoboa/admin/management/commands/handle_mailbox_operations.py
@@ -1,6 +1,6 @@
 """A management command to apply mailbox operations."""
 
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 
 import logging
 import os

--- a/modoboa/admin/management/commands/modo.py
+++ b/modoboa/admin/management/commands/modo.py
@@ -1,5 +1,7 @@
 """Modoboa main management command."""
 
+from __future__ import unicode_literals
+
 from subcommand.base import SubcommandCommand
 
 from .subcommands._mx import CheckMXRecords

--- a/modoboa/admin/management/commands/subcommands/__init__.py
+++ b/modoboa/admin/management/commands/subcommands/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/management/commands/subcommands/_export.py
+++ b/modoboa/admin/management/commands/subcommands/_export.py
@@ -1,5 +1,7 @@
 """Django management command to export admin objects."""
 
+from __future__ import unicode_literals
+
 import csv
 import sys
 

--- a/modoboa/admin/management/commands/subcommands/_import.py
+++ b/modoboa/admin/management/commands/subcommands/_import.py
@@ -1,5 +1,7 @@
 """Django management command to import admin objects."""
 
+from __future__ import unicode_literals
+
 import csv
 import os
 

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -1,6 +1,6 @@
 """Management command to check defined domains."""
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 from datetime import timedelta
 import ipaddress

--- a/modoboa/admin/management/commands/subcommands/_repair.py
+++ b/modoboa/admin/management/commands/subcommands/_repair.py
@@ -4,6 +4,7 @@ from __future__ import print_function, unicode_literals
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.utils.encoding import smart_str
 
 from modoboa.lib.permissions import grant_access_to_object
 from modoboa.lib.permissions import get_object_owner
@@ -112,7 +113,7 @@ class Repair(BaseCommand):
         # Load known problems from extensions.
         for ext in settings.MODOBOA_APPS:
             try:
-                __import__(ext, locals(), globals(), ["known_problems"])
+                __import__(ext, locals(), globals(), [smart_str("known_problems")])
             except ImportError:
                 pass
         for func in known_problems:

--- a/modoboa/admin/management/commands/subcommands/_repair.py
+++ b/modoboa/admin/management/commands/subcommands/_repair.py
@@ -1,6 +1,6 @@
 """Management command to check and fix known problems."""
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 from django.conf import settings
 from django.core.management.base import BaseCommand

--- a/modoboa/admin/migrations/__init__.py
+++ b/modoboa/admin/migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/models/__init__.py
+++ b/modoboa/admin/models/__init__.py
@@ -1,5 +1,7 @@
 """Admin models."""
 
+from __future__ import unicode_literals
+
 from .base import AdminObject
 from .domain import Domain, MXRecord, DNSBLResult
 from .domain_alias import DomainAlias

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -7,7 +7,9 @@ import random
 
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import (
+    python_2_unicode_compatible, smart_text, force_str, force_bytes
+)
 from django.utils.translation import ugettext as _, ugettext_lazy
 
 from reversion import revisions as reversion
@@ -64,7 +66,7 @@ class Alias(AdminObject):
         """Generate a random address (local part)."""
         m = hashlib.md5()
         for x in random.sample(range(10000000), 60):
-            m.update(str(x))
+            m.update(force_bytes(x))
         return m.hexdigest()[:20]
 
     @property
@@ -111,7 +113,6 @@ class Alias(AdminObject):
           is defined on the associated domain
 
         """
-        to_create = []
         for address in set(address_list):
             if not address:
                 continue
@@ -195,9 +196,10 @@ class Alias(AdminObject):
         self.post_create(user)
 
     def to_csv(self, csvwriter):
-        row = ["alias", self.address.encode("utf-8"), self.enabled]
+        row = ["alias", force_str(self.address), self.enabled]
         row += self.recipients
         csvwriter.writerow(row)
+
 
 reversion.register(Alias)
 

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -1,5 +1,7 @@
 """Models related to aliases management."""
 
+from __future__ import unicode_literals
+
 import hashlib
 import random
 

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -63,7 +63,7 @@ class Alias(AdminObject):
     def generate_random_address(cls):
         """Generate a random address (local part)."""
         m = hashlib.md5()
-        for x in random.sample(xrange(10000000), 60):
+        for x in random.sample(range(10000000), 60):
             m.update(str(x))
         return m.hexdigest()[:20]
 

--- a/modoboa/admin/models/base.py
+++ b/modoboa/admin/models/base.py
@@ -1,5 +1,7 @@
 """Base admin models."""
 
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils import timezone
 

--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -1,5 +1,7 @@
 """Models related to domains management."""
 
+from __future__ import unicode_literals
+
 import datetime
 from functools import reduce
 

--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -8,7 +8,9 @@ from functools import reduce
 from django.db import models
 from django.db.models.manager import Manager
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import (
+    python_2_unicode_compatible, smart_text, force_text
+)
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _, ugettext_lazy
 
@@ -281,7 +283,10 @@ class Domain(AdminObject):
     def to_csv(self, csvwriter):
         """Export domain and domain aliases to CSV format."""
         csvwriter.writerow([
-            "domain", self.name, self.quota, self.default_mailbox_quota,
+            "domain",
+            force_text(self.name),
+            self.quota,
+            self.default_mailbox_quota,
             self.enabled
         ])
         for dalias in self.domainalias_set.all():
@@ -295,6 +300,7 @@ class Domain(AdminObject):
         super(Domain, self).post_create(creator)
         for domalias in self.domainalias_set.all():
             domalias.post_create(creator)
+
 
 reversion.register(Domain)
 

--- a/modoboa/admin/models/domain_alias.py
+++ b/modoboa/admin/models/domain_alias.py
@@ -1,5 +1,7 @@
 """Models related to domain aliases management."""
 
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.translation import ugettext as _, ugettext_lazy

--- a/modoboa/admin/models/mailbox.py
+++ b/modoboa/admin/models/mailbox.py
@@ -1,5 +1,7 @@
 """Models related to mailboxes management."""
 
+from __future__ import unicode_literals
+
 import os
 import pwd
 

--- a/modoboa/admin/postfix_maps.py
+++ b/modoboa/admin/postfix_maps.py
@@ -1,5 +1,7 @@
 """Map file definitions for postfix."""
 
+from __future__ import unicode_literals
+
 
 class DomainsMap(object):
 

--- a/modoboa/admin/serializers.py
+++ b/modoboa/admin/serializers.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.encoding import force_text
 
 from rest_framework import serializers
 from passwords import validators
@@ -77,7 +78,7 @@ class DomainAliasSerializer(serializers.ModelSerializer):
                 object_type="domain_aliases")
         except lib_exceptions.ModoboaException as inst:
             raise serializers.ValidationError({
-                "domain": unicode(inst)})
+                "domain": force_text(inst)})
         domain_alias.save(creator=creator)
         return domain_alias
 
@@ -254,7 +255,7 @@ class WritableAccountSerializer(AccountSerializer):
                 object_type="mailboxes")
         except lib_exceptions.ModoboaException as inst:
             raise serializers.ValidationError({
-                "domain": unicode(inst)})
+                "domain": force_text(inst)})
         quota = data.pop("quota", None)
         mb = admin_models.Mailbox(
             user=account, address=address, domain=domain, **data)
@@ -347,7 +348,7 @@ class AliasSerializer(serializers.ModelSerializer):
                 sender=self.__class__, context=self.domain,
                 object_type="mailbox_aliases")
         except lib_exceptions.ModoboaException as inst:
-            raise serializers.ValidationError(unicode(inst))
+            raise serializers.ValidationError(force_text(inst))
         recipients = validated_data.pop("recipients", None)
         alias = admin_models.Alias(domain=self.domain, **validated_data)
         alias.save(creator=creator)

--- a/modoboa/admin/serializers.py
+++ b/modoboa/admin/serializers.py
@@ -1,5 +1,7 @@
 """Admin serializers."""
 
+from __future__ import unicode_literals
+
 from django.core.exceptions import ValidationError
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _, ugettext_lazy

--- a/modoboa/admin/signals.py
+++ b/modoboa/admin/signals.py
@@ -1,5 +1,7 @@
 """Modoboa admin signals."""
 
+from __future__ import unicode_literals
+
 import django.dispatch
 
 check_extra_account_form = django.dispatch.Signal(

--- a/modoboa/admin/templatetags/__init__.py
+++ b/modoboa/admin/templatetags/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/templatetags/admin_tags.py
+++ b/modoboa/admin/templatetags/admin_tags.py
@@ -1,5 +1,7 @@
 """Admin extension tags."""
 
+from __future__ import unicode_literals
+
 from functools import reduce
 
 from django import template

--- a/modoboa/admin/tests/__init__.py
+++ b/modoboa/admin/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/admin/tests/test_account.py
+++ b/modoboa/admin/tests/test_account.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 from unittest import skipIf
 
 from django.core.urlresolvers import reverse

--- a/modoboa/admin/tests/test_account.py
+++ b/modoboa/admin/tests/test_account.py
@@ -243,12 +243,12 @@ class AccountTestCase(ModoTestCase):
         url = reverse("admin:account_detail", args=[account.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Summary", response.content)
-        self.assertIn("Administered domains", response.content)
-        self.assertNotIn("Resources usage", response.content)
+        self.assertIn("Summary", response.content.decode())
+        self.assertIn("Administered domains", response.content.decode())
+        self.assertNotIn("Resources usage", response.content.decode())
         self.set_global_parameter("enable_admin_limits", True, app="limits")
         response = self.client.get(url)
-        self.assertIn("Resources usage", response.content)
+        self.assertIn("Resources usage", response.content.decode())
 
 
 @skipIf(NO_LDAP, "No ldap module installed")

--- a/modoboa/admin/tests/test_alias.py
+++ b/modoboa/admin/tests/test_alias.py
@@ -265,8 +265,8 @@ class AliasTestCase(ModoTestCase):
         url = reverse("admin:alias_detail", args=[account.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Summary", response.content)
-        self.assertIn("Recipients", response.content)
+        self.assertIn("Summary", response.content.decode())
+        self.assertIn("Recipients", response.content.decode())
 
     def test_domainadmin_restrictions(self):
         """Check that restrictions are applied."""

--- a/modoboa/admin/tests/test_alias.py
+++ b/modoboa/admin/tests/test_alias.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 """Admin test cases."""
 
 from django.core.urlresolvers import reverse

--- a/modoboa/admin/tests/test_api.py
+++ b/modoboa/admin/tests/test_api.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Admin API related tests."""
 
+from __future__ import unicode_literals
+
 import copy
 import json
 

--- a/modoboa/admin/tests/test_api.py
+++ b/modoboa/admin/tests/test_api.py
@@ -148,7 +148,7 @@ class DomainAliasAPITestCase(ModoAPITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 201)
 
-        dalias = json.loads(response.content)
+        dalias = response.json()
         dalias = models.DomainAlias.objects.filter(
             pk=dalias["pk"]).first()
         self.assertEqual(dalias.target, target)
@@ -217,17 +217,17 @@ class AccountAPITestCase(ModoAPITestCase):
         url = reverse("api:account-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response = json.loads(response.content)
+        response = response.json()
         self.assertEqual(len(response), 5)
 
         response = self.client.get("{}?domain=test.com".format(url))
         self.assertEqual(response.status_code, 200)
-        response = json.loads(response.content)
+        response = response.json()
         self.assertEqual(len(response), 2)
 
         response = self.client.get("{}?domain=pouet.com".format(url))
         self.assertEqual(response.status_code, 200)
-        response = json.loads(response.content)
+        response = response.json()
         self.assertEqual(len(response), 0)
 
     def test_create_account(self):
@@ -236,7 +236,7 @@ class AccountAPITestCase(ModoAPITestCase):
         response = self.client.post(url, self.ACCOUNT_DATA, format="json")
         self.assertEqual(response.status_code, 201)
 
-        account = json.loads(response.content)
+        account = response.json()
         user = core_models.User.objects.filter(pk=account["pk"]).first()
         self.assertIsNot(user, None)
         self.assertIsNot(user.mailbox, None)
@@ -260,7 +260,7 @@ class AccountAPITestCase(ModoAPITestCase):
         self.assertEqual(response.status_code, 201)
         domain = admin_models.Domain.objects.get(name="test.com")
         admin = core_models.User.objects.get(
-            pk=json.loads(response.content)["pk"])
+            pk=response.json()["pk"])
         self.assertIn(admin, domain.admins)
 
         data["username"] = "domain_admin"
@@ -275,7 +275,7 @@ class AccountAPITestCase(ModoAPITestCase):
         url = reverse("api:account-list")
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 201)
-        account = json.loads(response.content)
+        account = response.json()
         user = core_models.User.objects.filter(pk=account["pk"]).first()
         self.assertIsNot(user, None)
         self.assertIsNot(user.mailbox, None)
@@ -302,7 +302,7 @@ class AccountAPITestCase(ModoAPITestCase):
         url = reverse("api:account-list")
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 400)
-        errors = json.loads(response.content)
+        errors = response.json()
         self.assertIn("password", errors)
 
     def test_create_account_as_domadmin(self):
@@ -320,7 +320,7 @@ class AccountAPITestCase(ModoAPITestCase):
         url = reverse("api:account-list")
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 400)
-        errors = json.loads(response.content)
+        errors = response.json()
         self.assertIn("domain", errors)
 
     def test_create_account_bad_master_user(self):
@@ -330,7 +330,7 @@ class AccountAPITestCase(ModoAPITestCase):
         url = reverse("api:account-list")
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 400)
-        errors = json.loads(response.content)
+        errors = response.json()
         self.assertIn("master_user", errors)
 
     def test_update_account(self):
@@ -432,12 +432,12 @@ class AccountAPITestCase(ModoAPITestCase):
         response = self.client.get(
             "{}?email={}".format(url, "user@test.com"))
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        content = response.json()
         self.assertTrue(content["exists"])
         response = self.client.get(
             "{}?email={}".format(url, "pipo@test.com"))
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        content = response.json()
         self.assertFalse(content["exists"])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
@@ -487,12 +487,12 @@ class AliasAPITestCase(ModoAPITestCase):
         url = reverse("api:alias-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response = json.loads(response.content)
+        response = response.json()
         self.assertEqual(len(response), 3)
 
         response = self.client.get("{}?domain=test.com".format(url))
         self.assertEqual(response.status_code, 200)
-        response = json.loads(response.content)
+        response = response.json()
         self.assertEqual(len(response), 3)
 
     def test_get_alias(self):
@@ -501,7 +501,7 @@ class AliasAPITestCase(ModoAPITestCase):
         url = reverse("api:alias-detail", args=[al.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response = json.loads(response.content)
+        response = response.json()
         self.assertEqual(response["recipients"], ["user@test.com"])
 
     def test_create_alias(self):
@@ -510,7 +510,7 @@ class AliasAPITestCase(ModoAPITestCase):
         response = self.client.post(url, self.ALIAS_DATA, format="json")
         self.assertEqual(response.status_code, 201)
 
-        alias = json.loads(response.content)
+        alias = json.loads(response.content.decode('utf-8'))
         alias = models.Alias.objects.filter(pk=alias["pk"]).first()
         domadmin = core_models.User.objects.get(username="admin@test.com")
         self.assertTrue(domadmin.can_access(alias))
@@ -541,7 +541,7 @@ class AliasAPITestCase(ModoAPITestCase):
         data["address"] = "alias_fromapi@test2.com"
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 400)
-        errors = json.loads(response.content)
+        errors = response.json()
         self.assertIn("address", errors)
 
     def test_update_alias(self):

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 
 """Domain related test cases."""
 
-import json
-
 from django.core.urlresolvers import reverse
 
 from modoboa.core.models import User
@@ -213,7 +211,7 @@ class DomainTestCase(ModoTestCase):
         """Test the 'domain_flat_list' view."""
         response = self.client.get(reverse("admin:domain_flat_list"))
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        content = response.json()
         self.assertIn("test.com", content)
         self.assertIn("test2.com", content)
 

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 """Domain related test cases."""
 
 import json

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -236,11 +236,12 @@ class DomainTestCase(ModoTestCase):
         url = reverse("core:dashboard")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Global statistics", response.content)
+        self.assertIn("Global statistics", response.content.decode('utf-8'))
 
         self.client.force_login(
             User.objects.get(username="admin@test.com"))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("Global statistics", response.content)
-        self.assertIn("Per-domain statistics", response.content)
+        content = response.content.decode('utf-8')
+        self.assertNotIn("Global statistics", content)
+        self.assertIn("Per-domain statistics", content)

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -222,12 +222,12 @@ class DomainTestCase(ModoTestCase):
         url = reverse("admin:domain_detail", args=[domain.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Summary", response.content)
-        self.assertIn("Administrators", response.content)
-        self.assertNotIn("Resources usage", response.content)
+        self.assertIn("Summary", response.content.decode())
+        self.assertIn("Administrators", response.content.decode())
+        self.assertNotIn("Resources usage", response.content.decode())
         self.set_global_parameter("enable_domain_limits", True, app="limits")
         response = self.client.get(url)
-        self.assertIn("Resources usage", response.content)
+        self.assertIn("Resources usage", response.content.decode())
 
     def test_statitics_widget(self):
         """Test statistics display in dashboard."""

--- a/modoboa/admin/tests/test_domain_alias.py
+++ b/modoboa/admin/tests/test_domain_alias.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 
 from modoboa.lib.tests import ModoTestCase

--- a/modoboa/admin/tests/test_export.py
+++ b/modoboa/admin/tests/test_export.py
@@ -1,5 +1,7 @@
 """Export related test cases."""
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 
 from modoboa.lib.tests import ModoTestCase

--- a/modoboa/admin/tests/test_export.py
+++ b/modoboa/admin/tests/test_export.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
+from django.utils.encoding import force_text
 
 from modoboa.lib.tests import ModoTestCase
 
@@ -38,8 +39,8 @@ class ExportTestCase(ModoTestCase):
         )
 
     def assertListEqual(self, list1, list2):
-        list1 = list1.split("\r\n")
-        list2 = list2.split("\r\n")
+        list1 = force_text(list1).split("\r\n")
+        list2 = force_text(list2).split("\r\n")
         self.assertEqual(len(list1), len(list2))
         for entry in list1:
             if not entry:
@@ -85,7 +86,7 @@ class ExportTestCase(ModoTestCase):
         response = self.__export_identities(
             idtfilter="account", grpfilter="SuperAdmins"
         )
-        elements = response.content.strip().split(";")
+        elements = response.content.decode().strip().split(";")
         self.assertEqual(len(elements), 9)
         elements[2] = ""
         self.assertEqual(
@@ -104,6 +105,6 @@ class ExportTestCase(ModoTestCase):
     def test_export_aliases(self):
         response = self.__export_identities(idtfilter="alias")
         self.assertEqual(
-            response.content.strip(),
+            response.content.decode().strip(),
             "alias;alias@test.com;True;user@test.com\r\nalias;forward@test.com;True;user@external.com\r\nalias;postmaster@test.com;True;test@truc.fr;toto@titi.com"
         )

--- a/modoboa/admin/tests/test_import_.py
+++ b/modoboa/admin/tests/test_import_.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+
+from __future__ import unicode_literals
+
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 

--- a/modoboa/admin/tests/test_import_.py
+++ b/modoboa/admin/tests/test_import_.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
+from django.utils.encoding import force_bytes
 
 from modoboa.core.models import User
 from modoboa.lib.tests import ModoTestCase
@@ -26,7 +27,7 @@ class ImportTestCase(ModoTestCase):
     def test_domains_import(self):
         response = self.client.get(reverse("admin:domain_import"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Provide a CSV", response.content)
+        self.assertIn("Provide a CSV", response.content.decode())
 
         f = ContentFile(b"""domain; domain1.com; 1000; 100; True
 domain; domain2.com; 1000; 200; False
@@ -88,7 +89,7 @@ domainalias;test.alias;test.com;True
     def test_identities_import(self):
         response = self.client.get(reverse("admin:identity_import"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Provide a CSV", response.content)
+        self.assertIn("Provide a CSV", response.content.decode())
 
         f = ContentFile(b"""
 account; user1@test.com; toto; User; One; True; SimpleUsers; user1@test.com; 0
@@ -179,7 +180,7 @@ account; user1@test.com; toto; User; One; True; SimpleUsers; user1@test.com; ; t
             reverse("admin:identity_import"),
             {"sourcefile": f, "crypt_password": True}
         )
-        self.assertIn('wrong quota value', resp.content)
+        self.assertIn('wrong quota value', resp.content.decode())
 
     def test_import_domain_by_domainadmin(self):
         """Check if a domain admin is not allowed to import a domain."""
@@ -213,7 +214,7 @@ account; user1@test.com; toto; User; One; True; SimpleUsers; user1@test.com; 40
             reverse("admin:identity_import"),
             {"sourcefile": f, "crypt_password": True}
         )
-        self.assertIn("Domain quota exceeded", resp.content)
+        self.assertIn("Domain quota exceeded", resp.content.decode())
 
     def test_import_missing_quota(self):
         f = ContentFile(b"""

--- a/modoboa/admin/tests/test_import_.py
+++ b/modoboa/admin/tests/test_import_.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
-from django.utils.encoding import force_bytes
 
 from modoboa.core.models import User
 from modoboa.lib.tests import ModoTestCase
@@ -84,14 +83,14 @@ domainalias;test.alias;test.com;True
                 "sourcefile": f
             }
         )
-        self.assertIn('Object already exists: domainalias', resp.content)
+        self.assertIn('Object already exists: domainalias', resp.content.decode())
 
     def test_identities_import(self):
         response = self.client.get(reverse("admin:identity_import"))
         self.assertEqual(response.status_code, 200)
         self.assertIn("Provide a CSV", response.content.decode())
 
-        f = ContentFile(b"""
+        f = ContentFile("""
 account; user1@test.com; toto; User; One; True; SimpleUsers; user1@test.com; 0
 account; Truc@test.com; toto; René; Truc; True; DomainAdmins; truc@test.com; 5; test.com
 alias; alias1@test.com; True; user1@test.com
@@ -193,7 +192,7 @@ domain; domain2.com; 1000; 200; False
             reverse("admin:identity_import"),
             {"sourcefile": f, "crypt_password": True}
         )
-        self.assertIn("You are not allowed to import domains", resp.content)
+        self.assertIn("You are not allowed to import domains", resp.content.decode())
         f = ContentFile(b"""
 domainalias; domalias1.com; test.com; True
 """, name="identities.csv")
@@ -202,7 +201,7 @@ domainalias; domalias1.com; test.com; True
             {"sourcefile": f, "crypt_password": True}
         )
         self.assertIn(
-            "You are not allowed to import domain aliases", resp.content)
+            "You are not allowed to import domain aliases", resp.content.decode())
 
     def test_import_quota_too_big(self):
         self.client.logout()
@@ -231,7 +230,7 @@ account; user1@test.com; toto; User; One; True; SimpleUsers; user1@test.com
         )
 
     def test_import_duplicate(self):
-        f = ContentFile(b"""
+        f = ContentFile("""
 account; admin@test.com; toto; Admin; ; True; DomainAdmins; admin@test.com; 0; test.com
 account; truc@test.com; toto; René; Truc; True; DomainAdmins; truc@test.com; 0; test.com
 """, name="identities.csv")

--- a/modoboa/admin/tests/test_mailbox_operations.py
+++ b/modoboa/admin/tests/test_mailbox_operations.py
@@ -1,5 +1,7 @@
 """Management command tests."""
 
+from __future__ import unicode_literals
+
 import os
 import shutil
 import tempfile

--- a/modoboa/admin/tests/test_mapfiles.py
+++ b/modoboa/admin/tests/test_mapfiles.py
@@ -1,5 +1,7 @@
 """Test map files generation."""
 
+from __future__ import unicode_literals
+
 import os
 
 from django.conf import settings

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -1,5 +1,7 @@
 """DNSBL related tests."""
 
+from __future__ import unicode_literals
+
 from django.core import management
 from django.core.urlresolvers import reverse
 from django.test import override_settings

--- a/modoboa/admin/tests/test_password_schemes.py
+++ b/modoboa/admin/tests/test_password_schemes.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 
 from modoboa.core.models import User

--- a/modoboa/admin/tests/test_repair.py
+++ b/modoboa/admin/tests/test_repair.py
@@ -1,4 +1,7 @@
 """Repair command tests"""
+
+from __future__ import unicode_literals
+
 from django.core import management
 
 from modoboa.lib.permissions import get_object_owner

--- a/modoboa/admin/tests/test_user.py
+++ b/modoboa/admin/tests/test_user.py
@@ -1,5 +1,7 @@
 """User related tests."""
 
+from __future__ import unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/modoboa/admin/tests/test_user.py
+++ b/modoboa/admin/tests/test_user.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-import json
-
 from django.core.urlresolvers import reverse
 
 from modoboa.core.models import User
@@ -30,7 +28,7 @@ class ForwardTestCase(ModoTestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        content = response.json()
         self.assertIn("user@extdomain.com", content["content"])
         self.assertNotIn("user@test.com", content["content"])
         forward = Alias.objects.get(address="user@test.com", internal=False)
@@ -43,5 +41,5 @@ class ForwardTestCase(ModoTestCase):
         self.ajax_post(url, {"dest": "", "keepcopies": False})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        content = response.json()
         self.assertNotIn("user@extdomain.com", content["content"])

--- a/modoboa/admin/urls.py
+++ b/modoboa/admin/urls.py
@@ -1,6 +1,8 @@
 # pylint: disable=invalid-name, protected-access
 """Admin urls."""
 
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 
 from . import views

--- a/modoboa/admin/urls_api.py
+++ b/modoboa/admin/urls_api.py
@@ -1,5 +1,7 @@
 """Admin API urls."""
 
+from __future__ import unicode_literals
+
 from rest_framework import routers
 
 from . import api

--- a/modoboa/admin/views/__init__.py
+++ b/modoboa/admin/views/__init__.py
@@ -1,5 +1,7 @@
 """Shortcuts."""
 
+from __future__ import unicode_literals
+
 from .alias import AliasDetailView
 from .identity import AccountDetailView
 from .dns import DNSBLDomainDetailView, MXDomainDetailView

--- a/modoboa/admin/views/alias.py
+++ b/modoboa/admin/views/alias.py
@@ -1,5 +1,7 @@
 """Alias related views."""
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError
 from django.shortcuts import render

--- a/modoboa/admin/views/dns.py
+++ b/modoboa/admin/views/dns.py
@@ -1,5 +1,7 @@
 """DNSBL related views."""
 
+from __future__ import unicode_literals
+
 from django.views import generic
 
 from django.utils.translation import ugettext as _

--- a/modoboa/admin/views/domain.py
+++ b/modoboa/admin/views/domain.py
@@ -1,5 +1,7 @@
 """Domain related views."""
 
+from __future__ import unicode_literals
+
 from functools import reduce
 
 from django.core.urlresolvers import reverse

--- a/modoboa/admin/views/export.py
+++ b/modoboa/admin/views/export.py
@@ -14,6 +14,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
+from django.utils.encoding import smart_str
 
 from ..forms import ExportIdentitiesForm, ExportDomainsForm
 from ..lib import get_domains, get_identities
@@ -50,7 +51,9 @@ def export_identities(request):
         form = ExportIdentitiesForm(request.POST)
         form.is_valid()
         fp = io.BytesIO()
-        csvwriter = csv.writer(fp, delimiter=form.cleaned_data["sepchar"])
+        csvwriter = csv.writer(
+            fp, delimiter=smart_str(form.cleaned_data["sepchar"])
+        )
         identities = get_identities(
             request.user, **request.session['identities_filters'])
         for ident in identities:
@@ -78,7 +81,9 @@ def export_domains(request):
         form = ExportDomainsForm(request.POST)
         form.is_valid()
         fp = io.BytesIO()
-        csvwriter = csv.writer(fp, delimiter=form.cleaned_data["sepchar"])
+        csvwriter = csv.writer(
+            fp, delimiter=smart_str(form.cleaned_data["sepchar"])
+        )
         for dom in get_domains(request.user,
                                **request.session['domains_filters']):
             dom.to_csv(csvwriter)

--- a/modoboa/admin/views/export.py
+++ b/modoboa/admin/views/export.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import csv
-import io
 
 from rfc6266 import build_header
 
@@ -15,6 +14,7 @@ from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str
+from django.utils import six
 
 from ..forms import ExportIdentitiesForm, ExportDomainsForm
 from ..lib import get_domains, get_identities
@@ -50,7 +50,7 @@ def export_identities(request):
     if request.method == "POST":
         form = ExportIdentitiesForm(request.POST)
         form.is_valid()
-        fp = io.BytesIO()
+        fp = six.StringIO()
         csvwriter = csv.writer(
             fp, delimiter=smart_str(form.cleaned_data["sepchar"])
         )
@@ -80,7 +80,7 @@ def export_domains(request):
     if request.method == "POST":
         form = ExportDomainsForm(request.POST)
         form.is_valid()
-        fp = io.BytesIO()
+        fp = six.StringIO()
         csvwriter = csv.writer(
             fp, delimiter=smart_str(form.cleaned_data["sepchar"])
         )

--- a/modoboa/admin/views/export.py
+++ b/modoboa/admin/views/export.py
@@ -1,5 +1,7 @@
 """Export related views."""
 
+from __future__ import unicode_literals
+
 import csv
 import io
 

--- a/modoboa/admin/views/identity.py
+++ b/modoboa/admin/views/identity.py
@@ -1,5 +1,7 @@
 """Identity related views."""
 
+from __future__ import unicode_literals
+
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _, ungettext

--- a/modoboa/admin/views/import_.py
+++ b/modoboa/admin/views/import_.py
@@ -14,6 +14,7 @@ from django.db import transaction
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str, force_text
+from django.utils import six
 
 from reversion import revisions as reversion
 
@@ -39,8 +40,14 @@ def importdata(request, formclass=ImportDataForm):
     form = formclass(request.POST, request.FILES)
     if form.is_valid():
         try:
+            if six.PY2:
+                infile = request.FILES['sourcefile']
+            else:
+                infile = StringIO(
+                    force_text(request.FILES['sourcefile'].read())
+                )
             reader = csv.reader(
-                request.FILES['sourcefile'],
+                infile,
                 delimiter=smart_str(form.cleaned_data['sepchar'])
             )
         except csv.Error as inst:

--- a/modoboa/admin/views/import_.py
+++ b/modoboa/admin/views/import_.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 import csv
 
+from io import StringIO
+
 from django.contrib.auth.decorators import (
     login_required, permission_required, user_passes_test
 )
@@ -11,7 +13,7 @@ from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_str, force_text
 
 from reversion import revisions as reversion
 

--- a/modoboa/admin/views/import_.py
+++ b/modoboa/admin/views/import_.py
@@ -1,5 +1,7 @@
 """Import related views."""
 
+from __future__ import unicode_literals
+
 import csv
 
 from django.contrib.auth.decorators import (

--- a/modoboa/admin/views/import_.py
+++ b/modoboa/admin/views/import_.py
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
+from django.utils.encoding import smart_str
 
 from reversion import revisions as reversion
 
@@ -36,8 +37,10 @@ def importdata(request, formclass=ImportDataForm):
     form = formclass(request.POST, request.FILES)
     if form.is_valid():
         try:
-            reader = csv.reader(request.FILES['sourcefile'],
-                                delimiter=form.cleaned_data['sepchar'])
+            reader = csv.reader(
+                request.FILES['sourcefile'],
+                delimiter=smart_str(form.cleaned_data['sepchar'])
+            )
         except csv.Error as inst:
             error = str(inst)
 

--- a/modoboa/admin/views/user.py
+++ b/modoboa/admin/views/user.py
@@ -1,5 +1,7 @@
 """SimpleUsers views."""
 
+from __future__ import unicode_literals
+
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 

--- a/modoboa/core/__init__.py
+++ b/modoboa/core/__init__.py
@@ -1,3 +1,5 @@
 """App config for core."""
 
+from __future__ import unicode_literals
+
 default_app_config = "modoboa.core.apps.CoreConfig"

--- a/modoboa/core/app_settings.py
+++ b/modoboa/core/app_settings.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+
+from __future__ import unicode_literals
+
 from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext as _, ugettext_lazy

--- a/modoboa/core/apps.py
+++ b/modoboa/core/apps.py
@@ -1,5 +1,7 @@
 """Core config for admin."""
 
+from __future__ import unicode_literals
+
 from django.apps import AppConfig
 from django.db.models import signals
 from django.utils.translation import ugettext_lazy

--- a/modoboa/core/commands/__init__.py
+++ b/modoboa/core/commands/__init__.py
@@ -8,7 +8,7 @@ import sys
 
 from django.conf import settings
 from django.template import Context, Template
-from django.utils import six
+from django.utils.encoding import smart_str
 
 
 class Command(object):
@@ -66,12 +66,8 @@ def scan_for_commands(dirname=""):
         if os.path.isfile(f):
             continue
         cmdname = f.replace(".py", "")
-        if six.PY2:
-            fromlist = [cmdname.encode()]
-        else:
-            fromlist = [cmdname]
         cmdmod = __import__("modoboa.core.commands", globals(), locals(),
-                            fromlist)
+                            [smart_str(cmdname)])
         cmdmod = getattr(cmdmod, cmdname)
         if "_" in cmdname:
             cmdclassname = "".join(

--- a/modoboa/core/commands/__init__.py
+++ b/modoboa/core/commands/__init__.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 from __future__ import print_function
-from builtins import object
 
 import argparse
 import os

--- a/modoboa/core/commands/__init__.py
+++ b/modoboa/core/commands/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 
 import argparse
 import os
@@ -8,6 +8,7 @@ import sys
 
 from django.conf import settings
 from django.template import Context, Template
+from django.utils import six
 
 
 class Command(object):
@@ -65,8 +66,12 @@ def scan_for_commands(dirname=""):
         if os.path.isfile(f):
             continue
         cmdname = f.replace(".py", "")
+        if six.PY2:
+            fromlist = [cmdname.encode()]
+        else:
+            fromlist = [cmdname]
         cmdmod = __import__("modoboa.core.commands", globals(), locals(),
-                            [cmdname])
+                            fromlist)
         cmdmod = getattr(cmdmod, cmdname)
         if "_" in cmdname:
             cmdclassname = "".join(

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -11,6 +11,8 @@ import shutil
 import subprocess
 import sys
 
+from os.path import isfile
+
 try:
     import pip
 except ImportError:
@@ -108,8 +110,10 @@ class DeployCommand(Command):
             output = None
         if p.returncode:
             if output:
-                print("\n".join(
-                    [l for l in output if l is not None]), file=sys.stderr)
+                print(
+                    "\n".join([l.decode() for l in output if l is not None]),
+                    file=sys.stderr
+                )
             print("%s failed, check your configuration" % cmd, file=sys.stderr)
 
     def ask_db_info(self, name='default'):
@@ -250,7 +254,8 @@ class DeployCommand(Command):
         )
         os.mkdir("%s/media" % parsed_args.name)
 
-        os.unlink("%s/settings.pyc" % path)
+        if isfile("%s/settings.pyc" % path):
+            os.unlink("%s/settings.pyc" % path)
         self._exec_django_command(
             "migrate", parsed_args.name, '--noinput'
         )

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -2,7 +2,7 @@
 
 """A shortcut to deploy a fresh modoboa instance."""
 
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 
 import getpass
 import os
@@ -21,6 +21,7 @@ except ImportError:
 import django
 from django.core import management
 from django.template import Context, Template
+from django.utils import six
 import dj_database_url
 
 from modoboa.core.commands import Command
@@ -231,7 +232,11 @@ class DeployCommand(Command):
             os.path.join(os.path.dirname(__file__), "../../bower_components")
         )
 
-        mod = __import__(parsed_args.name, globals(), locals(), ['settings'])
+        if six.PY2:
+            fromlist = ['settings'.encode()]
+        else:
+            fromlist = ['settings']
+        mod = __import__(parsed_args.name, globals(), locals(), fromlist)
         tpl = self._render_template(
             "%s/settings.py.tpl" % self._templates_dir, {
                 'db_connections': connections,

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -4,7 +4,6 @@
 
 from __future__ import print_function
 
-from builtins import input
 import getpass
 import os
 import shutil

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -21,7 +21,7 @@ except ImportError:
 import django
 from django.core import management
 from django.template import Context, Template
-from django.utils import six
+from django.utils.encoding import smart_str
 import dj_database_url
 
 from modoboa.core.commands import Command
@@ -232,11 +232,9 @@ class DeployCommand(Command):
             os.path.join(os.path.dirname(__file__), "../../bower_components")
         )
 
-        if six.PY2:
-            fromlist = ['settings'.encode()]
-        else:
-            fromlist = ['settings']
-        mod = __import__(parsed_args.name, globals(), locals(), fromlist)
+        mod = __import__(
+            parsed_args.name, globals(), locals(), [smart_str('settings')]
+        )
         tpl = self._render_template(
             "%s/settings.py.tpl" % self._templates_dir, {
                 'db_connections': connections,

--- a/modoboa/core/commands/help.py
+++ b/modoboa/core/commands/help.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 
 import sys
 

--- a/modoboa/core/constants.py
+++ b/modoboa/core/constants.py
@@ -2,6 +2,8 @@
 
 """Core application constants."""
 
+from __future__ import unicode_literals
+
 from django.utils.translation import ugettext_lazy
 
 SIMPLEUSERS_ROLE = ("SimpleUsers", ugettext_lazy("Simple user"))

--- a/modoboa/core/context_processors.py
+++ b/modoboa/core/context_processors.py
@@ -1,5 +1,7 @@
 """Custom context processors."""
 
+from __future__ import unicode_literals
+
 from functools import reduce
 
 from . import signals

--- a/modoboa/core/dev_settings.py
+++ b/modoboa/core/dev_settings.py
@@ -1,4 +1,7 @@
 # Development settings
+
+from __future__ import unicode_literals
+
 import os
 
 BOWER_COMPONENTS_ROOT = os.path.join(

--- a/modoboa/core/extensions.py
+++ b/modoboa/core/extensions.py
@@ -1,7 +1,10 @@
 """Extension management."""
 
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.conf.urls import include, url
+from django.utils import six
 
 
 class ModoExtension(object):
@@ -76,7 +79,11 @@ class ExtensionsPool(object):
 
     def load_extension(self, name):
         """Load a registered extension."""
-        __import__(name, locals(), globals(), ["modo_extension"])
+        if six.PY2:
+            fromlist = ["modo_extension".encode()]
+        else:
+            fromlist = ["modo_extension"]
+        __import__(name, locals(), globals(), fromlist)
         extinstance = self.get_extension(name)
         if extinstance is None:
             return None

--- a/modoboa/core/extensions.py
+++ b/modoboa/core/extensions.py
@@ -1,7 +1,5 @@
 """Extension management."""
 
-from builtins import object
-
 from django.conf import settings
 from django.conf.urls import include, url
 

--- a/modoboa/core/extensions.py
+++ b/modoboa/core/extensions.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url
-from django.utils import six
+from django.utils.encoding import smart_str
 
 
 class ModoExtension(object):
@@ -79,11 +79,7 @@ class ExtensionsPool(object):
 
     def load_extension(self, name):
         """Load a registered extension."""
-        if six.PY2:
-            fromlist = ["modo_extension".encode()]
-        else:
-            fromlist = ["modo_extension"]
-        __import__(name, locals(), globals(), fromlist)
+        __import__(name, locals(), globals(), [smart_str('modo_extension')])
         extinstance = self.get_extension(name)
         if extinstance is None:
             return None
@@ -136,5 +132,6 @@ class ExtensionsPool(object):
             infos["id"] = extname
             result += [infos]
         return sorted(result, key=lambda i: i["name"])
+
 
 exts_pool = ExtensionsPool()

--- a/modoboa/core/factories.py
+++ b/modoboa/core/factories.py
@@ -1,7 +1,5 @@
 """Factories for core application."""
 
-from builtins import object
-
 import factory
 
 from django.contrib.auth.models import Group

--- a/modoboa/core/factories.py
+++ b/modoboa/core/factories.py
@@ -1,5 +1,7 @@
 """Factories for core application."""
 
+from __future__ import unicode_literals
+
 import factory
 
 from django.contrib.auth.models import Group

--- a/modoboa/core/forms.py
+++ b/modoboa/core/forms.py
@@ -2,6 +2,8 @@
 
 """Core forms."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext as _, ugettext_lazy
 

--- a/modoboa/core/forms.py
+++ b/modoboa/core/forms.py
@@ -2,8 +2,6 @@
 
 """Core forms."""
 
-from builtins import object
-
 from django import forms
 from django.utils.translation import ugettext as _, ugettext_lazy
 

--- a/modoboa/core/handlers.py
+++ b/modoboa/core/handlers.py
@@ -1,5 +1,7 @@
 """Modoboa core signal handlers."""
 
+from __future__ import unicode_literals
+
 import logging
 
 from django.core.urlresolvers import reverse

--- a/modoboa/core/loggers.py
+++ b/modoboa/core/loggers.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 

--- a/modoboa/core/management/__init__.py
+++ b/modoboa/core/management/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/management/commands/__init__.py
+++ b/modoboa/core/management/commands/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/management/commands/cleanlogs.py
+++ b/modoboa/core/management/commands/cleanlogs.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import datetime
 import logging

--- a/modoboa/core/management/commands/communicate_with_public_api.py
+++ b/modoboa/core/management/commands/communicate_with_public_api.py
@@ -1,5 +1,7 @@
 """Management command to communicate with public API."""
 
+from __future__ import unicode_literals
+
 from django.core.management.base import BaseCommand, CommandError
 
 from modoboa.admin import models as admin_models

--- a/modoboa/core/management/commands/generate_postfix_maps.py
+++ b/modoboa/core/management/commands/generate_postfix_maps.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template import Context, Template
 from django.utils import timezone
+from django.utils.encoding import force_bytes
 
 import dj_database_url
 
@@ -68,7 +69,7 @@ class Command(BaseCommand):
             fname not in self.__checksums)
         if condition:
             return True
-        with open(path) as fp:
+        with open(path, mode="rb") as fp:
             checksum = hashlib.md5(fp.read()).hexdigest()
         return checksum == self.__checksums[fname]["checksum"]
 
@@ -142,7 +143,7 @@ query = {{ query|safe }}
         fullpath = os.path.join(destdir, mapobject.filename)
         with open(fullpath, "w") as fp:
             fp.write(content)
-        return hashlib.md5(content).hexdigest()
+        return hashlib.md5(force_bytes(content)).hexdigest()
 
     def handle(self, *args, **options):
         """Command entry point."""

--- a/modoboa/core/management/commands/generate_postfix_maps.py
+++ b/modoboa/core/management/commands/generate_postfix_maps.py
@@ -1,5 +1,5 @@
 """Management command to generate/update postfix map files."""
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import copy
 import hashlib

--- a/modoboa/core/management/commands/load_initial_data.py
+++ b/modoboa/core/management/commands/load_initial_data.py
@@ -5,6 +5,8 @@
 
 """
 
+from __future__ import unicode_literals
+
 from functools import reduce
 
 from django.contrib.auth.models import Group

--- a/modoboa/core/management/commands/set_default_site.py
+++ b/modoboa/core/management/commands/set_default_site.py
@@ -5,6 +5,8 @@ A simple managemenent command to update the default site.
 See `https://docs.djangoproject.com/en/dev/ref/contrib/sites/`_.
 """
 
+from __future__ import unicode_literals
+
 from django.core.management.base import BaseCommand, CommandError
 
 from django.contrib.sites.models import Site

--- a/modoboa/core/middleware.py
+++ b/modoboa/core/middleware.py
@@ -1,7 +1,5 @@
 """Core middlewares."""
 
-from builtins import object
-
 from . import models
 
 

--- a/modoboa/core/middleware.py
+++ b/modoboa/core/middleware.py
@@ -1,5 +1,7 @@
 """Core middlewares."""
 
+from __future__ import unicode_literals
+
 from . import models
 
 

--- a/modoboa/core/migrations/__init__.py
+++ b/modoboa/core/migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/mocks.py
+++ b/modoboa/core/mocks.py
@@ -1,5 +1,7 @@
 """Mocks used for testing."""
 
+from __future__ import unicode_literals
+
 import httmock
 
 

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -1,5 +1,7 @@
 """Core models."""
 
+from __future__ import unicode_literals
+
 from email.header import Header
 import re
 

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -9,7 +9,8 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import (
-    python_2_unicode_compatible, smart_bytes, smart_text, force_str)
+    python_2_unicode_compatible, smart_bytes, smart_text, force_str, force_text
+)
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _, ugettext_lazy
 
@@ -411,13 +412,13 @@ class User(PermissionsMixin):
         """
         row = [
             "account",
-            smart_bytes(self.username),
-            smart_bytes(self.password),
-            smart_bytes(self.first_name),
-            smart_bytes(self.last_name),
-            self.is_active,
-            self.role,
-            smart_bytes(self.email)
+            force_text(self.username),
+            force_text(self.password),
+            force_text(self.first_name),
+            force_text(self.last_name),
+            force_text(self.is_active),
+            force_text(self.role),
+            force_text(self.email)
         ]
         results = signals.account_exported.send(
             sender=self.__class__, user=self)

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import (
-    python_2_unicode_compatible, smart_bytes, smart_text)
+    python_2_unicode_compatible, smart_bytes, smart_text, force_str)
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _, ugettext_lazy
 
@@ -154,7 +154,7 @@ class User(PermissionsMixin):
         match = self.password_expr.match(self.password)
         if match is None:
             return False
-        raw_value = smart_bytes(raw_value)
+        raw_value = force_str(raw_value)
         scheme = match.group(1)
         val2 = match.group(2)
         hasher = get_password_hasher(scheme)
@@ -424,6 +424,7 @@ class User(PermissionsMixin):
         for result in results:
             row += result[1]
         csvwriter.writerow(row)
+
 
 reversion.register(User)
 

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -1,6 +1,5 @@
 """Core models."""
 
-from builtins import object
 from email.header import Header
 import re
 

--- a/modoboa/core/password_hashers/__init__.py
+++ b/modoboa/core/password_hashers/__init__.py
@@ -1,6 +1,9 @@
 """
 Password hashers for Modoboa.
 """
+
+from __future__ import unicode_literals
+
 from modoboa.core.password_hashers.base import (
     PLAINHasher, CRYPTHasher, MD5Hasher, SHA256Hasher
 )

--- a/modoboa/core/password_hashers/advanced.py
+++ b/modoboa/core/password_hashers/advanced.py
@@ -4,6 +4,8 @@ Advanced (ie. stronger) password hashers.
 This module relies on `passlib` to provide more secure hashers.
 """
 
+from __future__ import unicode_literals
+
 from passlib.hash import bcrypt, md5_crypt, sha256_crypt, sha512_crypt
 
 from modoboa.parameters import tools as param_tools

--- a/modoboa/core/password_hashers/base.py
+++ b/modoboa/core/password_hashers/base.py
@@ -4,6 +4,8 @@ Base password hashers.
 Contains weak hashers (the original ones) available with Modoboa.
 """
 
+from __future__ import unicode_literals
+
 import base64
 import crypt
 import hashlib

--- a/modoboa/core/password_hashers/base.py
+++ b/modoboa/core/password_hashers/base.py
@@ -92,7 +92,7 @@ class CRYPTHasher(PasswordHasher):
 
     def _encrypt(self, clearvalue, salt=None):
         if salt is None:
-            salt = "".join(Random().sample(string.letters + string.digits, 2))
+            salt = "".join(Random().sample(string.ascii_letters + string.digits, 2))
         return crypt.crypt(clearvalue, salt)
 
 

--- a/modoboa/core/password_hashers/base.py
+++ b/modoboa/core/password_hashers/base.py
@@ -13,7 +13,7 @@ from random import Random
 import string
 
 from django.utils.crypto import constant_time_compare
-from django.utils.encoding import force_text
+from django.utils.encoding import force_text, force_bytes
 
 
 class PasswordHasher(object):
@@ -36,7 +36,7 @@ class PasswordHasher(object):
         """
         if self._target == 'ldap':
             return base64.b64encode(pwhash)
-        return force_text(pwhash)
+        return pwhash
 
     def encrypt(self, clearvalue):
         """Encrypt a password.
@@ -51,8 +51,8 @@ class PasswordHasher(object):
         :rtype: str
         :return: encrypted password
         """
-        pwhash = self._b64encode(self._encrypt(clearvalue))
-        return '%s%s' % (self.scheme, pwhash)
+        pwhash = self._b64encode(self._encrypt(force_text(clearvalue)))
+        return '%s%s' % (self.scheme, force_text(pwhash))
 
     def verify(self, clearvalue, hashed_value):
         """Verify a password against a hashed value.
@@ -109,7 +109,7 @@ class MD5Hasher(PasswordHasher):
         return '{MD5}'
 
     def _encrypt(self, clearvalue, salt=None):
-        obj = hashlib.md5(clearvalue)
+        obj = hashlib.md5(force_bytes(clearvalue))
         return obj.hexdigest()
 
 
@@ -125,7 +125,7 @@ class SHA256Hasher(PasswordHasher):
         return '{SHA256}'
 
     def _encrypt(self, clearvalue, salt=None):
-        return hashlib.sha256(clearvalue).digest()
+        return hashlib.sha256(force_bytes(clearvalue)).digest()
 
     def _b64encode(self, pwhash):
         """Encode :keyword:`pwhash` using base64.

--- a/modoboa/core/password_hashers/base.py
+++ b/modoboa/core/password_hashers/base.py
@@ -5,7 +5,6 @@ Contains weak hashers (the original ones) available with Modoboa.
 """
 
 import base64
-from builtins import object
 import crypt
 import hashlib
 from random import Random

--- a/modoboa/core/password_hashers/base.py
+++ b/modoboa/core/password_hashers/base.py
@@ -13,6 +13,7 @@ from random import Random
 import string
 
 from django.utils.crypto import constant_time_compare
+from django.utils.encoding import force_text
 
 
 class PasswordHasher(object):
@@ -35,7 +36,7 @@ class PasswordHasher(object):
         """
         if self._target == 'ldap':
             return base64.b64encode(pwhash)
-        return pwhash
+        return force_text(pwhash)
 
     def encrypt(self, clearvalue):
         """Encrypt a password.

--- a/modoboa/core/signals.py
+++ b/modoboa/core/signals.py
@@ -1,5 +1,7 @@
 """Modoboa core signals."""
 
+from __future__ import unicode_literals
+
 import django.dispatch
 
 account_auto_created = django.dispatch.Signal(providing_args=["user"])

--- a/modoboa/core/templatetags/__init__.py
+++ b/modoboa/core/templatetags/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/templatetags/core_tags.py
+++ b/modoboa/core/templatetags/core_tags.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Custom tags for Core application."""
 
+from __future__ import unicode_literals
+
 from functools import reduce
 import os
 import pkg_resources

--- a/modoboa/core/tests/__init__.py
+++ b/modoboa/core/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/tests/stupid_extension_1/__init__.py
+++ b/modoboa/core/tests/stupid_extension_1/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/tests/stupid_extension_1/modo_extension.py
+++ b/modoboa/core/tests/stupid_extension_1/modo_extension.py
@@ -1,5 +1,7 @@
 """A stupid extension used for tests."""
 
+from __future__ import unicode_literals
+
 from modoboa.core import extensions
 
 

--- a/modoboa/core/tests/stupid_extension_2/__init__.py
+++ b/modoboa/core/tests/stupid_extension_2/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/core/tests/stupid_extension_2/modo_extension.py
+++ b/modoboa/core/tests/stupid_extension_2/modo_extension.py
@@ -1,5 +1,7 @@
 """A stupid extension used for tests."""
 
+from __future__ import unicode_literals
+
 from modoboa.core import extensions
 
 
@@ -10,5 +12,6 @@ class StupidExtension2(extensions.ModoExtension):
     label = "Stupid extension"
     version = "1.0.0"
     description = "A stupid extension"
+
 
 extensions.exts_pool.register_extension(StupidExtension2, show=False)

--- a/modoboa/core/tests/stupid_extension_2/urls.py
+++ b/modoboa/core/tests/stupid_extension_2/urls.py
@@ -1,5 +1,7 @@
 """Custom urls."""
 
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 
 from . import views

--- a/modoboa/core/tests/stupid_extension_2/views.py
+++ b/modoboa/core/tests/stupid_extension_2/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import http
 
 

--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -1,5 +1,7 @@
 """Tests for core application."""
 
+from __future__ import unicode_literals
+
 import smtplib
 
 from mock import patch

--- a/modoboa/core/tests/test_core.py
+++ b/modoboa/core/tests/test_core.py
@@ -1,5 +1,7 @@
 """Tests for core application."""
 
+from __future__ import unicode_literals
+
 import httmock
 
 from dateutil.relativedelta import relativedelta

--- a/modoboa/core/tests/test_extensions.py
+++ b/modoboa/core/tests/test_extensions.py
@@ -1,12 +1,13 @@
 """Extensions management related test cases."""
 
+from __future__ import unicode_literals
+
 import os
 import sys
 
 from testfixtures import compare
 
 from django.core import management
-from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
 
 from .. import extensions

--- a/modoboa/core/tests/test_ldap.py
+++ b/modoboa/core/tests/test_ldap.py
@@ -1,7 +1,5 @@
 """Tests for core application."""
 
-from builtins import object
-
 from unittest import skipIf
 
 from django.core.urlresolvers import reverse

--- a/modoboa/core/tests/test_ldap.py
+++ b/modoboa/core/tests/test_ldap.py
@@ -1,5 +1,7 @@
 """Tests for core application."""
 
+from __future__ import unicode_literals
+
 from unittest import skipIf
 
 from django.core.urlresolvers import reverse

--- a/modoboa/core/tests/test_views.py
+++ b/modoboa/core/tests/test_views.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-import json
-
 from testfixtures import compare
 
 from django import forms
@@ -53,12 +51,12 @@ class DashboardTestCase(ModoTestCase):
         url = reverse("core:dashboard")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Latest news", str(response.content))
+        self.assertIn("Latest news", response.content.decode('utf-8'))
         self.client.logout()
         self.client.login(username=self.dadmin.username, password="toto")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Latest news", str(response.content))
+        self.assertIn("Latest news", response.content.decode('utf-8'))
         self.client.logout()
         self.client.login(username=self.user.username, password="toto")
         response = self.client.get(url)

--- a/modoboa/core/tests/test_views.py
+++ b/modoboa/core/tests/test_views.py
@@ -1,5 +1,7 @@
 """Core views test cases."""
 
+from __future__ import unicode_literals
+
 import json
 
 from testfixtures import compare

--- a/modoboa/core/urls.py
+++ b/modoboa/core/urls.py
@@ -1,5 +1,7 @@
 """Core urls."""
 
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 
 from . import views

--- a/modoboa/core/utils.py
+++ b/modoboa/core/utils.py
@@ -1,5 +1,7 @@
 """Utility functions."""
 
+from __future__ import unicode_literals
+
 from django.utils.translation import ugettext as _
 
 from versionfield.constants import DEFAULT_NUMBER_BITS

--- a/modoboa/core/views/__init__.py
+++ b/modoboa/core/views/__init__.py
@@ -1,5 +1,7 @@
 """Core views."""
 
+from __future__ import unicode_literals
+
 from .admin import (
     check_top_notifications, information, logs, logs_page, parameters,
     viewsettings)

--- a/modoboa/core/views/admin.py
+++ b/modoboa/core/views/admin.py
@@ -1,5 +1,7 @@
 """Views available to super administrators only."""
 
+from __future__ import unicode_literals
+
 from functools import reduce
 
 from django.contrib.auth.decorators import (

--- a/modoboa/core/views/auth.py
+++ b/modoboa/core/views/auth.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Core authentication views."""
 
+from __future__ import unicode_literals
+
 import logging
 
 from django.core.urlresolvers import reverse

--- a/modoboa/core/views/base.py
+++ b/modoboa/core/views/base.py
@@ -1,5 +1,7 @@
 """Base core views."""
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.views import generic
 

--- a/modoboa/core/views/dashboard.py
+++ b/modoboa/core/views/dashboard.py
@@ -1,5 +1,7 @@
 """Core dashboard views."""
 
+from __future__ import unicode_literals
+
 from dateutil import parser
 import feedparser
 import requests

--- a/modoboa/core/views/user.py
+++ b/modoboa/core/views/user.py
@@ -1,5 +1,7 @@
 """Simple user views."""
 
+from __future__ import unicode_literals
+
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils import translation

--- a/modoboa/core/views/user.py
+++ b/modoboa/core/views/user.py
@@ -6,6 +6,7 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import ugettext as _
+from django.utils.encoding import force_text
 
 from django.contrib.auth.decorators import login_required, user_passes_test
 
@@ -41,8 +42,9 @@ def profile(request, tplname='core/user_profile.html'):
         if form.is_valid():
             form.save()
             if update_password and form.cleaned_data["confirmation"] != "":
-                request.session["password"] = encrypt(
-                    form.cleaned_data["confirmation"])
+                request.session["password"] = force_text(encrypt(
+                    form.cleaned_data["confirmation"]
+                ))
             translation.activate(request.user.language)
             request.session[translation.LANGUAGE_SESSION_KEY] = (
                 request.user.language)

--- a/modoboa/lib/__init__.py
+++ b/modoboa/lib/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/lib/api_client.py
+++ b/modoboa/lib/api_client.py
@@ -1,5 +1,7 @@
 """A client for Modoboa's public API."""
 
+from __future__ import unicode_literals
+
 import os
 import pkg_resources
 

--- a/modoboa/lib/authbackends.py
+++ b/modoboa/lib/authbackends.py
@@ -1,5 +1,7 @@
 """Custom authentication backends."""
 
+from __future__ import unicode_literals
+
 import smtplib
 
 from django.conf import settings

--- a/modoboa/lib/connections.py
+++ b/modoboa/lib/connections.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from modoboa.lib.cryptutils import decrypt
 
 

--- a/modoboa/lib/cryptutils.py
+++ b/modoboa/lib/cryptutils.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Crypto related utilities."""
 
+from __future__ import unicode_literals
+
 import base64
 import random
 import string
@@ -17,7 +19,7 @@ def random_key(l=16):
     :return: a string
     """
     punctuation = """!#$%&'()*+,-./:;<=>?@[]^_`{|}~"""
-    population = string.digits + string.letters + punctuation
+    population = string.digits + string.ascii_letters + punctuation
     while True:
         key = "".join(random.sample(population * l, l))
         if len(key) == l:
@@ -27,7 +29,7 @@ def random_key(l=16):
 def encrypt(clear):
     key = param_tools.get_global_parameter("secret_key", app="core")
     obj = AES.new(key, AES.MODE_ECB)
-    if type(clear) is unicode:
+    if type(clear) is str:
         clear = clear.encode("utf-8")
     if len(clear) % AES.block_size:
         clear += " " * (AES.block_size - len(clear) % AES.block_size)

--- a/modoboa/lib/cryptutils.py
+++ b/modoboa/lib/cryptutils.py
@@ -7,6 +7,8 @@ import base64
 import random
 import string
 
+from django.utils.encoding import force_bytes
+
 from Crypto.Cipher import AES
 
 from modoboa.parameters import tools as param_tools
@@ -32,7 +34,9 @@ def encrypt(clear):
     if type(clear) is str:
         clear = clear.encode("utf-8")
     if len(clear) % AES.block_size:
-        clear += " " * (AES.block_size - len(clear) % AES.block_size)
+        clear += (
+            force_bytes(" ") * (AES.block_size - len(clear) % AES.block_size)
+        )
     ciph = obj.encrypt(clear)
     ciph = base64.b64encode(ciph)
     return ciph

--- a/modoboa/lib/cryptutils.py
+++ b/modoboa/lib/cryptutils.py
@@ -7,7 +7,7 @@ import base64
 import random
 import string
 
-from django.utils.encoding import force_bytes
+from django.utils.encoding import force_bytes, force_text
 
 from Crypto.Cipher import AES
 
@@ -39,7 +39,7 @@ def encrypt(clear):
         )
     ciph = obj.encrypt(clear)
     ciph = base64.b64encode(ciph)
-    return ciph
+    return force_text(ciph)
 
 
 def decrypt(ciph):

--- a/modoboa/lib/db_utils.py
+++ b/modoboa/lib/db_utils.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.db import connection
 from django.utils.translation import ugettext as _

--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 from email.header import Header, decode_header
 from email.mime.text import MIMEText
 from email.utils import make_msgid, formatdate, parseaddr

--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -12,6 +12,7 @@ import time
 from django.conf import settings
 from django.utils.encoding import smart_text
 from django.template.loader import render_to_string
+from django.utils import six
 
 from modoboa.lib import u2u_decode
 
@@ -77,7 +78,7 @@ class Email(object):
         """
         fname = msg.get_filename()
         if fname is not None:
-            if type(fname) is unicode:
+            if type(fname) is six.text_type:
                 fname = fname.encode("utf-8")
             decoded = decode_header(fname)
             value = (

--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from builtins import object
 from email.header import Header, decode_header
 from email.mime.text import MIMEText
 from email.utils import make_msgid, formatdate, parseaddr

--- a/modoboa/lib/exceptions.py
+++ b/modoboa/lib/exceptions.py
@@ -4,6 +4,9 @@
 -----------------------------------------------
 
 """
+
+from __future__ import unicode_literals
+
 from django.utils.translation import ugettext as _
 
 

--- a/modoboa/lib/fields.py
+++ b/modoboa/lib/fields.py
@@ -1,5 +1,7 @@
 """Custom form fields."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy
 

--- a/modoboa/lib/form_utils.py
+++ b/modoboa/lib/form_utils.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import abc
-from builtins import object, range
 from collections import OrderedDict
 import re
 
@@ -22,7 +21,7 @@ from django.utils.translation import ugettext as _, ugettext_lazy
 from modoboa.lib.exceptions import BadRequest
 from modoboa.lib.web_utils import render_to_json_response
 
-ABC = abc.ABCMeta("ABC", (object,), {})  # compatible with Python 2 *and* 3
+ABC = abc.ABCMeta(b"ABC", (object,), {})  # compatible with Python 2 *and* 3
 
 
 class WizardStep(object):

--- a/modoboa/lib/form_utils.py
+++ b/modoboa/lib/form_utils.py
@@ -13,8 +13,7 @@ from django.forms.fields import Field
 from django.forms.widgets import RadioSelect
 from django.forms.widgets import RadioChoiceInput
 from django.shortcuts import render
-from django.utils import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_text, force_str
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_lazy
@@ -22,11 +21,8 @@ from django.utils.translation import ugettext as _, ugettext_lazy
 from modoboa.lib.exceptions import BadRequest
 from modoboa.lib.web_utils import render_to_json_response
 
-if six.PY2:
-    meta_name = b"ABC"
-else:
-    meta_name = "ABC"
-ABC = abc.ABCMeta(meta_name, (object,), {})  # compatible with Python 2 *and* 3
+
+ABC = abc.ABCMeta(force_str('ABC'), (object,), {})
 
 
 class WizardStep(object):

--- a/modoboa/lib/form_utils.py
+++ b/modoboa/lib/form_utils.py
@@ -2,6 +2,8 @@
 
 """Form management utilities."""
 
+from __future__ import unicode_literals
+
 import abc
 from builtins import object, range
 from collections import OrderedDict
@@ -12,7 +14,7 @@ from django.forms.fields import Field
 from django.forms.widgets import RadioSelect
 from django.forms.widgets import RadioChoiceInput
 from django.shortcuts import render
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_lazy
@@ -376,7 +378,7 @@ class CustomRadioInput(RadioChoiceInput):
             label_for = ' for="%s"' % self.attrs["id"]
         else:
             label_for = ""
-        choice_label = conditional_escape(force_unicode(self.choice_label))
+        choice_label = conditional_escape(force_text(self.choice_label))
         return mark_safe(
             u"<label class='radio-inline' %s>%s %s</label>"
             % (label_for, self.tag(), choice_label)
@@ -394,7 +396,7 @@ class InlineRadioRenderer(RadioSelect.renderer):
 
     def render(self):
         return mark_safe(
-            u"\n".join([u"%s\n" % force_unicode(w) for w in self])
+            u"\n".join([u"%s\n" % force_text(w) for w in self])
         )
 
 

--- a/modoboa/lib/form_utils.py
+++ b/modoboa/lib/form_utils.py
@@ -13,6 +13,7 @@ from django.forms.fields import Field
 from django.forms.widgets import RadioSelect
 from django.forms.widgets import RadioChoiceInput
 from django.shortcuts import render
+from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
@@ -21,7 +22,11 @@ from django.utils.translation import ugettext as _, ugettext_lazy
 from modoboa.lib.exceptions import BadRequest
 from modoboa.lib.web_utils import render_to_json_response
 
-ABC = abc.ABCMeta(b"ABC", (object,), {})  # compatible with Python 2 *and* 3
+if six.PY2:
+    meta_name = b"ABC"
+else:
+    meta_name = "ABC"
+ABC = abc.ABCMeta(meta_name, (object,), {})  # compatible with Python 2 *and* 3
 
 
 class WizardStep(object):

--- a/modoboa/lib/imap_utf7.py
+++ b/modoboa/lib/imap_utf7.py
@@ -51,7 +51,7 @@ Found here:
 http://svn.plone.org/svn/collective/mxmImapClient/trunk/imapUTF7.py
 
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import binascii
 import codecs

--- a/modoboa/lib/imap_utf7.py
+++ b/modoboa/lib/imap_utf7.py
@@ -53,6 +53,8 @@ http://svn.plone.org/svn/collective/mxmImapClient/trunk/imapUTF7.py
 """
 from __future__ import print_function, unicode_literals
 
+from django.utils.encoding import force_text
+
 import binascii
 import codecs
 
@@ -91,7 +93,7 @@ def encoder(s):
 
 def modified_unbase64(s):
     b = binascii.a2b_base64(s.replace(',', '/') + '===')
-    return unicode(b, 'utf-16be')
+    return force_text(b, encoding='utf-16be')
 
 
 def decoder(s):
@@ -129,6 +131,8 @@ class StreamWriter(codecs.StreamWriter):
 def imap4_utf_7(name):
     if name == 'imap4-utf-7':
         return (encoder, decoder, StreamReader, StreamWriter)
+
+
 codecs.register(imap4_utf_7)
 
 

--- a/modoboa/lib/ldap_utils.py
+++ b/modoboa/lib/ldap_utils.py
@@ -33,6 +33,8 @@ Extracted from `this blog
 
 """
 
+from __future__ import unicode_literals
+
 import ldap
 
 from django.conf import settings

--- a/modoboa/lib/ldap_utils.py
+++ b/modoboa/lib/ldap_utils.py
@@ -40,6 +40,7 @@ import ldap
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.utils.encoding import force_bytes
+from django.utils import six
 
 from modoboa.core.password_hashers import get_password_hasher
 from modoboa.lib.exceptions import InternalError

--- a/modoboa/lib/ldap_utils.py
+++ b/modoboa/lib/ldap_utils.py
@@ -39,7 +39,7 @@ import ldap
 
 from django.conf import settings
 from django.utils.translation import ugettext as _
-from django.utils.encoding import smart_bytes
+from django.utils.encoding import force_bytes
 
 from modoboa.core.password_hashers import get_password_hasher
 from modoboa.lib.exceptions import InternalError
@@ -69,7 +69,7 @@ class LDAPAuthBackend(object):
 
     def _get_conn(self, dn, password):
         """Get a connection from the server."""
-        conn = ldap.initialize(self.server_uri)
+        conn = ldap.initialize(self.server_uri, bytes_mode=False)
         conn.set_option(ldap.OPT_X_TLS_DEMAND, True)
         conn.set_option(ldap.OPT_DEBUG_LEVEL, 255)
         conn.simple_bind_s(dn, password)
@@ -120,8 +120,8 @@ class LDAPAuthBackend(object):
                 ('"%s"' % newpassword).encode('utf-16').lstrip('\377\376')
             )
         ldif = [(ldap.MOD_REPLACE,
-                 smart_bytes(self.pwd_attr),
-                 smart_bytes(self._crypt_password(newpassword)))]
+                 self.pwd_attr,
+                 force_bytes(self._crypt_password(newpassword)))]
         try:
             self.conn.modify_s(user_dn, ldif)
         except ldap.LDAPError as e:

--- a/modoboa/lib/ldap_utils.py
+++ b/modoboa/lib/ldap_utils.py
@@ -69,7 +69,10 @@ class LDAPAuthBackend(object):
 
     def _get_conn(self, dn, password):
         """Get a connection from the server."""
-        conn = ldap.initialize(self.server_uri, bytes_mode=False)
+        kwargs = {}
+        if six.PY3:
+            kwargs['bytes_mode'] = False
+        conn = ldap.initialize(self.server_uri, **kwargs)
         conn.set_option(ldap.OPT_X_TLS_DEMAND, True)
         conn.set_option(ldap.OPT_DEBUG_LEVEL, 255)
         conn.simple_bind_s(dn, password)

--- a/modoboa/lib/ldap_utils.py
+++ b/modoboa/lib/ldap_utils.py
@@ -33,8 +33,6 @@ Extracted from `this blog
 
 """
 
-from builtins import object
-
 import ldap
 
 from django.conf import settings

--- a/modoboa/lib/ldap_utils.py
+++ b/modoboa/lib/ldap_utils.py
@@ -39,6 +39,7 @@ import ldap
 
 from django.conf import settings
 from django.utils.translation import ugettext as _
+from django.utils.encoding import smart_bytes
 
 from modoboa.core.password_hashers import get_password_hasher
 from modoboa.lib.exceptions import InternalError
@@ -119,8 +120,8 @@ class LDAPAuthBackend(object):
                 ('"%s"' % newpassword).encode('utf-16').lstrip('\377\376')
             )
         ldif = [(ldap.MOD_REPLACE,
-                 self.pwd_attr,
-                 self._crypt_password(newpassword))]
+                 smart_bytes(self.pwd_attr),
+                 smart_bytes(self._crypt_password(newpassword)))]
         try:
             self.conn.modify_s(user_dn, ldif)
         except ldap.LDAPError as e:

--- a/modoboa/lib/listing.py
+++ b/modoboa/lib/listing.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from modoboa.parameters import tools as param_tools

--- a/modoboa/lib/middleware.py
+++ b/modoboa/lib/middleware.py
@@ -2,6 +2,8 @@
 
 """Custom middlewares."""
 
+from __future__ import unicode_literals
+
 from django.http import HttpResponseRedirect
 from django.utils.encoding import smart_text
 

--- a/modoboa/lib/middleware.py
+++ b/modoboa/lib/middleware.py
@@ -2,8 +2,6 @@
 
 """Custom middlewares."""
 
-from builtins import object
-
 from django.http import HttpResponseRedirect
 from django.utils.encoding import smart_text
 

--- a/modoboa/lib/migrations/__init__.py
+++ b/modoboa/lib/migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/lib/paginator.py
+++ b/modoboa/lib/paginator.py
@@ -2,8 +2,6 @@
 Custom pagination tools.
 """
 
-from builtins import object
-
 
 class Page(object):
 

--- a/modoboa/lib/paginator.py
+++ b/modoboa/lib/paginator.py
@@ -2,6 +2,8 @@
 Custom pagination tools.
 """
 
+from __future__ import unicode_literals
+
 
 class Page(object):
 

--- a/modoboa/lib/permissions.py
+++ b/modoboa/lib/permissions.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Object level permissions."""
 
+from __future__ import unicode_literals
+
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
@@ -143,7 +145,7 @@ def get_object_owner(obj):
 
 def add_permissions_to_group(group, permissions):
     """Add the specified permissions to a django group."""
-    if isinstance(group, basestring):
+    if isinstance(group, str):
         group = Group.objects.get(name=group)
 
     for appname, modelname, permname in permissions:

--- a/modoboa/lib/signals.py
+++ b/modoboa/lib/signals.py
@@ -1,5 +1,7 @@
 """Custom signals."""
 
+from __future__ import unicode_literals
+
 from threading import local
 
 _local_store = local()

--- a/modoboa/lib/singleton.py
+++ b/modoboa/lib/singleton.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 
 # works in Python 2 & 3
 class _Singleton(type):

--- a/modoboa/lib/sysutils.py
+++ b/modoboa/lib/sysutils.py
@@ -4,6 +4,9 @@
 This module extra functions/shortcuts to communicate with the system
 (executing commands, etc.)
 """
+
+from __future__ import unicode_literals
+
 import subprocess
 import inspect
 import re

--- a/modoboa/lib/templatetags/__init__.py
+++ b/modoboa/lib/templatetags/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/lib/templatetags/form_tags.py
+++ b/modoboa/lib/templatetags/form_tags.py
@@ -2,6 +2,8 @@
 Form rendering tags.
 """
 
+from __future__ import unicode_literals
+
 from django import forms
 from django import template
 from django.utils.encoding import smart_text

--- a/modoboa/lib/templatetags/lib_tags.py
+++ b/modoboa/lib/templatetags/lib_tags.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Custom template tags."""
 
+from __future__ import unicode_literals
+
 from datetime import datetime
 
 from django import template

--- a/modoboa/lib/test_utils.py
+++ b/modoboa/lib/test_utils.py
@@ -1,7 +1,5 @@
 """Tools for top level testing (ie. when ran by Travis)."""
 
-from builtins import object
-
 import os
 import shutil
 import tempfile

--- a/modoboa/lib/test_utils.py
+++ b/modoboa/lib/test_utils.py
@@ -1,5 +1,7 @@
 """Tools for top level testing (ie. when ran by Travis)."""
 
+from __future__ import unicode_literals
+
 import os
 import shutil
 import tempfile

--- a/modoboa/lib/tests.py
+++ b/modoboa/lib/tests.py
@@ -3,8 +3,6 @@
 
 from __future__ import unicode_literals
 
-import json
-
 from django.core import management
 from django.test import TestCase
 

--- a/modoboa/lib/tests.py
+++ b/modoboa/lib/tests.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Testing utilities."""
 
+from __future__ import unicode_literals
+
 import json
 
 from django.core import management

--- a/modoboa/lib/tests.py
+++ b/modoboa/lib/tests.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 """Testing utilities."""
 
-from builtins import object
 import json
 
 from django.core import management

--- a/modoboa/lib/u2u_decode.py
+++ b/modoboa/lib/u2u_decode.py
@@ -2,6 +2,8 @@
 
 """Unstructured rfc2047 header to unicode."""
 
+from __future__ import unicode_literals
+
 from email.header import decode_header, make_header
 import re
 

--- a/modoboa/lib/u2u_decode.py
+++ b/modoboa/lib/u2u_decode.py
@@ -33,7 +33,7 @@ def decode_mime(m):
 
 
 def u2u_decode(s):
-    ur"""utility function for (final) decoding of mime header
+    """utility function for (final) decoding of mime header
 
     note: resulting string is in one line (no \n within)
     note2: spaces between enc_words are stripped (see RFC2047)

--- a/modoboa/lib/validators.py
+++ b/modoboa/lib/validators.py
@@ -1,6 +1,5 @@
 """Field validators."""
 
-from builtins import object
 import re
 
 from django.core.exceptions import ValidationError

--- a/modoboa/lib/validators.py
+++ b/modoboa/lib/validators.py
@@ -45,9 +45,9 @@ class UTF8EmailValidator(EmailValidator):
     ascii_set = u"-!#$%&'*+/=?^_`{}|~0-9A-Z"
     user_regex_raw = (
         # dot-atom
-        ur"^[" + ascii_set + ul + "]+(\.[" + ascii_set + ul + "]+)*\Z"
+        r"^[" + ascii_set + ul + "]+(\.[" + ascii_set + ul + "]+)*\Z"
         # quoted-string
-        ur'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)'
+        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)'
     )
     user_regex = re.compile("(" + user_regex_raw, re.IGNORECASE)
 
@@ -59,6 +59,6 @@ class UTF8AndEmptyUserEmailValidator(UTF8EmailValidator):
     """Same as upper + allows empty local part."""
 
     user_regex = re.compile(
-        ur"(^$|" + UTF8EmailValidator.user_regex_raw, re.IGNORECASE)
+        r"(^$|" + UTF8EmailValidator.user_regex_raw, re.IGNORECASE)
 
 validate_utf8_and_empty_user_email = UTF8AndEmptyUserEmailValidator()

--- a/modoboa/lib/validators.py
+++ b/modoboa/lib/validators.py
@@ -1,5 +1,7 @@
 """Field validators."""
 
+from __future__ import unicode_literals
+
 import re
 
 from django.core.exceptions import ValidationError

--- a/modoboa/lib/web_utils.py
+++ b/modoboa/lib/web_utils.py
@@ -4,8 +4,6 @@
 This module contains extra functions/shortcuts used to render HTML.
 """
 
-from builtins import object
-
 import json
 import re
 import sys

--- a/modoboa/lib/web_utils.py
+++ b/modoboa/lib/web_utils.py
@@ -4,6 +4,8 @@
 This module contains extra functions/shortcuts used to render HTML.
 """
 
+from __future__ import unicode_literals
+
 import json
 import re
 import sys

--- a/modoboa/limits/__init__.py
+++ b/modoboa/limits/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import unicode_literals
+
 default_app_config = "modoboa.limits.apps.LimitsConfig"

--- a/modoboa/limits/app_settings.py
+++ b/modoboa/limits/app_settings.py
@@ -1,5 +1,7 @@
 """Custom settings."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/modoboa/limits/apps.py
+++ b/modoboa/limits/apps.py
@@ -1,5 +1,7 @@
 """App config for limits."""
 
+from __future__ import unicode_literals
+
 from django.apps import AppConfig
 from django.utils.translation import ugettext as _
 

--- a/modoboa/limits/constants.py
+++ b/modoboa/limits/constants.py
@@ -1,5 +1,7 @@
 """Modoboa limits constants."""
 
+from __future__ import unicode_literals
+
 import collections
 
 from django.utils.translation import ugettext_lazy as _

--- a/modoboa/limits/forms.py
+++ b/modoboa/limits/forms.py
@@ -2,6 +2,8 @@
 
 """Custom forms."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext as _
 

--- a/modoboa/limits/handlers.py
+++ b/modoboa/limits/handlers.py
@@ -1,5 +1,7 @@
 """Django signal handlers for limits."""
 
+from __future__ import unicode_literals
+
 from django.db.models import signals
 from django.dispatch import receiver
 from django.template.loader import render_to_string

--- a/modoboa/limits/lib.py
+++ b/modoboa/limits/lib.py
@@ -4,6 +4,9 @@
 -------------------------------
 
 """
+
+from __future__ import unicode_literals
+
 from django.utils.translation import ugettext as _
 
 from modoboa.lib.exceptions import ModoboaException

--- a/modoboa/limits/migrations/__init__.py
+++ b/modoboa/limits/migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/limits/models.py
+++ b/modoboa/limits/models.py
@@ -2,6 +2,8 @@
 
 """Models for the limits extensions."""
 
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible

--- a/modoboa/limits/models.py
+++ b/modoboa/limits/models.py
@@ -2,8 +2,6 @@
 
 """Models for the limits extensions."""
 
-from builtins import object
-
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible

--- a/modoboa/limits/serializers.py
+++ b/modoboa/limits/serializers.py
@@ -1,5 +1,7 @@
 """Limits serializers."""
 
+from __future__ import unicode_literals
+
 from rest_framework import serializers
 
 from . import lib

--- a/modoboa/limits/tests/__init__.py
+++ b/modoboa/limits/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/limits/tests/test_api.py
+++ b/modoboa/limits/tests/test_api.py
@@ -114,7 +114,7 @@ class APIAdminLimitsTestCase(lib_tests.ModoAPITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response.content,
+            response.content.decode(),
             '"You\'re not allowed to define unlimited values"')
 
     def test_domain_aliases_limit(self):

--- a/modoboa/limits/tests/test_api.py
+++ b/modoboa/limits/tests/test_api.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Test cases for the limits extension."""
 
+from __future__ import unicode_literals
+
 from testfixtures import compare
 
 from django.core.urlresolvers import reverse

--- a/modoboa/limits/tests/test_api.py
+++ b/modoboa/limits/tests/test_api.py
@@ -103,7 +103,9 @@ class APIAdminLimitsTestCase(lib_tests.ModoAPITestCase):
         data["name"] = "test5.com"
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.content, '"Domains: limit reached"')
+        self.assertEqual(
+            response.content.decode('utf-8'), '"Domains: limit reached"'
+        )
 
         self.client.delete(
             reverse("api:domain-detail",

--- a/modoboa/limits/tests/test_domain_limits.py
+++ b/modoboa/limits/tests/test_domain_limits.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Test cases for the limits extension."""
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 
 from modoboa.admin import factories as admin_factories

--- a/modoboa/limits/tests/test_import.py
+++ b/modoboa/limits/tests/test_import.py
@@ -31,7 +31,7 @@ class LimitImportTestCase(ModoTestCase):
         """Check domain aliases limit."""
         self.client.force_login(self.reseller)
         self.assertFalse(limit.is_exceeded())
-        f = ContentFile(b"""domainalias; domalias1.com; {domain}; True
+        f = ContentFile("""domainalias; domalias1.com; {domain}; True
 domainalias; domalias2.com; {domain}; True
 """.format(domain=self.domain), name="domains.csv")
         self.client.post(
@@ -70,7 +70,7 @@ domainalias; domalias2.com; {domain}; True
         )
         self.assertTrue(limit.is_exceeded())
 
-        f = ContentFile(b"""account; admin3@{domain}; toto; User; One; True; DomainAdmins; admin3@{domain}; 5; {domain}
+        f = ContentFile("""account; admin3@{domain}; toto; User; One; True; DomainAdmins; admin3@{domain}; 5; {domain}
 """.format(domain=self.domain), name="domain_admins.csv")
         response = self.client.post(
             reverse("admin:identity_import"), {
@@ -111,7 +111,7 @@ account; user3@{domain}; toto; User; One; True; SimpleUsers; user3@{domain}; 5
         """Check mailbox aliases limit."""
         self.client.force_login(self.dadmin)
         self.assertFalse(limit.is_exceeded())
-        f = ContentFile(b"""alias; alias1@{domain}; True; user@{domain}
+        f = ContentFile("""alias; alias1@{domain}; True; user@{domain}
 alias; alias2@{domain}; True; user@{domain}
 """.format(domain=self.domain), name="aliases.csv")
         response = self.client.post(

--- a/modoboa/limits/tests/test_import.py
+++ b/modoboa/limits/tests/test_import.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from builtins import range
-
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 

--- a/modoboa/limits/tests/test_import.py
+++ b/modoboa/limits/tests/test_import.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import unicode_literals
+
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 

--- a/modoboa/limits/tests/test_user_limits.py
+++ b/modoboa/limits/tests/test_user_limits.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Test cases for the limits extension."""
 
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
 
 from modoboa.admin.factories import populate_database

--- a/modoboa/limits/urls_api.py
+++ b/modoboa/limits/urls_api.py
@@ -1,5 +1,7 @@
 """Limits API urls."""
 
+from __future__ import unicode_literals
+
 from rest_framework import routers
 
 from . import viewsets

--- a/modoboa/limits/utils.py
+++ b/modoboa/limits/utils.py
@@ -1,5 +1,7 @@
 """Modoboa limits utilities."""
 
+from __future__ import unicode_literals
+
 from . import constants
 
 

--- a/modoboa/limits/views.py
+++ b/modoboa/limits/views.py
@@ -1,1 +1,3 @@
 # coding: utf-8
+
+from __future__ import unicode_literals

--- a/modoboa/limits/viewsets.py
+++ b/modoboa/limits/viewsets.py
@@ -1,5 +1,7 @@
 """Limits API."""
 
+from __future__ import unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 
 from rest_framework import mixins, viewsets

--- a/modoboa/parameters/__init__.py
+++ b/modoboa/parameters/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/parameters/forms.py
+++ b/modoboa/parameters/forms.py
@@ -1,5 +1,7 @@
 """Parameters forms."""
 
+from __future__ import unicode_literals
+
 from django import forms
 
 from modoboa.lib import db_utils

--- a/modoboa/parameters/tests.py
+++ b/modoboa/parameters/tests.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.test import TestCase
 
 # Create your tests here.

--- a/modoboa/parameters/tools.py
+++ b/modoboa/parameters/tools.py
@@ -1,5 +1,7 @@
 """Parameters management."""
 
+from __future__ import unicode_literals
+
 import copy
 
 from modoboa.lib import exceptions

--- a/modoboa/parameters/tools.py
+++ b/modoboa/parameters/tools.py
@@ -1,6 +1,5 @@
 """Parameters management."""
 
-from builtins import object
 import copy
 
 from modoboa.lib import exceptions

--- a/modoboa/relaydomains/__init__.py
+++ b/modoboa/relaydomains/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import unicode_literals
+
 default_app_config = "modoboa.relaydomains.apps.RelayDomainsConfig"

--- a/modoboa/relaydomains/app_settings.py
+++ b/modoboa/relaydomains/app_settings.py
@@ -1,5 +1,7 @@
 """Relay domains settings definition."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy
 

--- a/modoboa/relaydomains/apps.py
+++ b/modoboa/relaydomains/apps.py
@@ -1,5 +1,7 @@
 """AppConfig for relaydomains."""
 
+from __future__ import unicode_literals
+
 from django.apps import AppConfig
 from django.utils.translation import ugettext as _
 

--- a/modoboa/relaydomains/constants.py
+++ b/modoboa/relaydomains/constants.py
@@ -1,5 +1,7 @@
 """Relaydomains app constants."""
 
+from __future__ import unicode_literals
+
 PERMISSIONS = {
     "Resellers": [
         ("relaydomains", "relaydomain", "add_relaydomain"),

--- a/modoboa/relaydomains/forms.py
+++ b/modoboa/relaydomains/forms.py
@@ -1,7 +1,5 @@
 """Postfix relay domains extension forms."""
 
-from builtins import object
-
 from django import forms
 from django.core import validators
 from django.utils.translation import ugettext as _

--- a/modoboa/relaydomains/forms.py
+++ b/modoboa/relaydomains/forms.py
@@ -1,5 +1,7 @@
 """Postfix relay domains extension forms."""
 
+from __future__ import unicode_literals
+
 from django import forms
 from django.core import validators
 from django.utils.translation import ugettext as _

--- a/modoboa/relaydomains/handlers.py
+++ b/modoboa/relaydomains/handlers.py
@@ -1,5 +1,7 @@
 """Django signal handlers for relaydomains."""
 
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.db.models import signals
 from django.dispatch import receiver

--- a/modoboa/relaydomains/lib.py
+++ b/modoboa/relaydomains/lib.py
@@ -1,5 +1,7 @@
 """Internal library."""
 
+from __future__ import unicode_literals
+
 from .models import RelayDomain
 
 

--- a/modoboa/relaydomains/migrations/__init__.py
+++ b/modoboa/relaydomains/migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/modoboa/relaydomains/models.py
+++ b/modoboa/relaydomains/models.py
@@ -1,7 +1,5 @@
 """Relay domain related models."""
 
-from builtins import object
-
 from django.db import models
 from django.db.models.manager import Manager
 from django.utils.translation import ugettext as _, ugettext_lazy

--- a/modoboa/relaydomains/models.py
+++ b/modoboa/relaydomains/models.py
@@ -1,5 +1,7 @@
 """Relay domain related models."""
 
+from __future__ import unicode_literals
+
 from django.db import models
 from django.db.models.manager import Manager
 from django.utils.translation import ugettext as _, ugettext_lazy

--- a/modoboa/relaydomains/postfix_maps.py
+++ b/modoboa/relaydomains/postfix_maps.py
@@ -1,5 +1,7 @@
 """Map file definitions for postfix."""
 
+from __future__ import unicode_literals
+
 
 class RelayDomainsMap(object):
 

--- a/modoboa/relaydomains/postfix_maps.py
+++ b/modoboa/relaydomains/postfix_maps.py
@@ -1,7 +1,5 @@
 """Map file definitions for postfix."""
 
-from builtins import object
-
 
 class RelayDomainsMap(object):
 

--- a/modoboa/relaydomains/tests.py
+++ b/modoboa/relaydomains/tests.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-import json
-
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -88,7 +86,7 @@ class RelayDomainsTestCase(ModoTestCase, Operations):
         url = reverse("admin:_domain_list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        content = response.json()
         self.assertIn("relaydomain.tld", content["rows"])
         self.assertIn("Relay Domain", content["rows"])
 

--- a/modoboa/relaydomains/tests.py
+++ b/modoboa/relaydomains/tests.py
@@ -1,6 +1,5 @@
 """relaydomains unit tests."""
 
-from builtins import object
 import json
 
 from django.core.files.base import ContentFile

--- a/modoboa/relaydomains/tests.py
+++ b/modoboa/relaydomains/tests.py
@@ -1,5 +1,7 @@
 """relaydomains unit tests."""
 
+from __future__ import unicode_literals
+
 import json
 
 from django.core.files.base import ContentFile

--- a/modoboa/relaydomains/urls.py
+++ b/modoboa/relaydomains/urls.py
@@ -1,5 +1,7 @@
 """Relay domains urls."""
 
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 
 from . import views

--- a/modoboa/relaydomains/views.py
+++ b/modoboa/relaydomains/views.py
@@ -1,7 +1,5 @@
 """Custom views."""
 
-from builtins import str
-
 from django.contrib.auth.decorators import (
     login_required, permission_required
 )

--- a/modoboa/relaydomains/views.py
+++ b/modoboa/relaydomains/views.py
@@ -1,5 +1,7 @@
 """Custom views."""
 
+from __future__ import unicode_literals
+
 from django.contrib.auth.decorators import (
     login_required, permission_required
 )

--- a/modoboa/test_settings.py
+++ b/modoboa/test_settings.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 import os
 
 # Database

--- a/modoboa/urls.py
+++ b/modoboa/urls.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from functools import reduce
+
 from django.conf import settings
 from django.conf.urls import include, url
 from django.views.i18n import JavaScriptCatalog

--- a/modoboa/urls_api.py
+++ b/modoboa/urls_api.py
@@ -1,5 +1,7 @@
 """External API urls."""
 
+from __future__ import unicode_literals
+
 from django.conf.urls import include, url
 
 from modoboa.core.extensions import exts_pool

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ djangorestframework==3.6.2
 argparse
 # bcrypt requires libffi-dev
 bcrypt==2.0.0
-dnspython==1.12.0
+dnspython==1.15.0
 feedparser==5.2.1
 gevent==1.2.1
 ipaddress

--- a/test_project/manage.py
+++ b/test_project/manage.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+from __future__ import unicode_literals
+
 import os
 import sys
 

--- a/test_project/test_project/__init__.py
+++ b/test_project/test_project/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -8,6 +8,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
+from __future__ import unicode_literals
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 from logging.handlers import SysLogHandler

--- a/test_project/test_project/urls.py
+++ b/test_project/test_project/urls.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf.urls import include, url
 
 urlpatterns = [

--- a/test_project/test_project/wsgi.py
+++ b/test_project/test_project/wsgi.py
@@ -7,6 +7,8 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
 
+from __future__ import unicode_literals
+
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@ envlist = py27,py34
 [testenv]
 changedir=test_project
 commands =
+;    python ../tests.py
+;    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
     coverage run --source modoboa manage.py test modoboa.admin
+
     coverage report --show-missing
 deps =
     -r{toxinidir}/test-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ envlist = py27,py34
 [testenv]
 changedir=test_project
 commands =
-    python ../tests.py
-    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
+    coverage run --source modoboa manage.py test modoboa.admin
     coverage report --show-missing
 deps =
     -r{toxinidir}/test-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py34
 changedir=test_project
 commands =
     python ../tests.py
-    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin.tests modoboa.limits modoboa.relaydomains
+    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
     coverage report --show-missing
 deps =
     -r{toxinidir}/test-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@ envlist = py27,py34
 [testenv]
 changedir=test_project
 commands =
-;    python ../tests.py
-;    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
-    coverage run --source modoboa manage.py test modoboa.admin
+    python ../tests.py
+    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
 
     coverage report --show-missing
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27,py34
 
 [testenv]
 changedir=test_project


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The command `modoboa-admin.py deploy --collectstatic --dburl default:postgres://localhost/modoboa_test --domain localhost --admin-username admin modoboa_test` failed with a lot of errrors when launched with python 3.4. The PR aims to  fix that.

Current behavior before PR:
Errors when launching ; return code != 0

Desired behavior after PR is merged:
No errors ; return code == 0