### PR TITLE
docs: Mention WSGIPassAuthorization in Apache config

### DIFF
--- a/doc/manual_installation/webserver.rst
+++ b/doc/manual_installation/webserver.rst
@@ -40,7 +40,9 @@ following content inside::
     </Directory>
 
     WSGIScriptAlias / <modoboa_instance_path>/<instance_name>/wsgi.py
-  
+
+    # Pass Authorization header to enable API usage:
+    WSGIPassAuthorization On
   </VirtualHost>
 
 This is just one possible configuration.


### PR DESCRIPTION
This is needed to have the Authorization header passed to the API.
Took me a while to figure this out, so it would probably be good to document it.