### PR TITLE
Fix redirect url

### DIFF
--- a/modoboa/core/views/base.py
+++ b/modoboa/core/views/base.py
@@ -18,7 +18,7 @@ def find_nextlocation(request, user):
         return reverse("core:user_index")
     nextlocation = request.POST.get("next", request.GET.get("next"))
     condition = (
-        nextlocation is not None and nextlocation != "" and
+        nextlocation is not None and nextlocation != "" and nextlocation != "None" and
         is_safe_url(nextlocation, host=request.get_host())
     )
     if condition:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When we logout, the new url has not the "next" get parameter. nextlocation is not None in this case, but "None" (the string). 

Current behavior before PR:
So if we re-login, we are redirected to accounts/login/None, that does not exists (404).

Desired behavior after PR is merged:
I add ' != "None" ' to the conditions, so now the re-login works.