### PR TITLE
Python3 compatibility: add __str__ functions in addition to __unicode__ function

### DIFF
--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -315,6 +315,7 @@ class MXQuerySet(models.QuerySet):
         return self.exists()
 
 
+@python_2_unicode_compatible
 class MXRecord(models.Model):
     """A model used to store MX records for Domain."""
 
@@ -330,9 +331,6 @@ class MXRecord(models.Model):
         if not param_tools.get_global_parameter("enable_mx_checks"):
             return False
         return bool(param_tools.get_global_parameter("valid_mxs").strip())
-
-    def __unicode__(self):
-        return u"{0.name} ({0.address}) for {0.domain} ".format(self)
 
     def __str__(self):
         return "{0.name} ({0.address}) for {0.domain} ".format(self)

--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -334,6 +334,9 @@ class MXRecord(models.Model):
     def __unicode__(self):
         return u"{0.name} ({0.address}) for {0.domain} ".format(self)
 
+    def __str__(self):
+        return "{0.name} ({0.address}) for {0.domain} ".format(self)
+
 
 class DNSBLQuerySet(models.QuerySet):
     """Custom manager for DNSBLResultManager."""

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -405,6 +405,7 @@ def populate_callback(user, group="SimpleUsers"):
         sender="populate_callback", user=user)
 
 
+@python_2_unicode_compatible
 class ObjectAccess(models.Model):
     user = models.ForeignKey(User)
     content_type = models.ForeignKey(ContentType)
@@ -414,11 +415,6 @@ class ObjectAccess(models.Model):
 
     class Meta(object):
         unique_together = (("user", "content_type", "object_id"),)
-
-    def __unicode__(self):
-        return "%s => %s (%s)" % (
-            self.user, self.content_object, self.content_type
-        )
 
     def __str__(self):
         return "%s => %s (%s)" % (

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -420,6 +420,11 @@ class ObjectAccess(models.Model):
             self.user, self.content_object, self.content_type
         )
 
+    def __str__(self):
+        return "%s => %s (%s)" % (
+            self.user, self.content_object, self.content_type
+        )
+
 
 class Log(models.Model):
     """Simple log in database."""

--- a/modoboa/lib/form_utils.py
+++ b/modoboa/lib/form_utils.py
@@ -384,6 +384,17 @@ class CustomRadioInput(RadioChoiceInput):
             % (label_for, self.tag(), choice_label)
         )
 
+    def __str__(self):
+        if "id" in self.attrs:
+            label_for = ' for="%s"' % self.attrs["id"]
+        else:
+            label_for = ""
+        choice_label = conditional_escape(force_text(self.choice_label))
+        return mark_safe(
+            "<label class='radio-inline' %s>%s %s</label>"
+            % (label_for, self.tag(), choice_label)
+        )
+
 
 class InlineRadioRenderer(RadioSelect.renderer):
     """Custom inline radio renderer."""

--- a/modoboa/lib/form_utils.py
+++ b/modoboa/lib/form_utils.py
@@ -13,7 +13,7 @@ from django.forms.fields import Field
 from django.forms.widgets import RadioSelect
 from django.forms.widgets import RadioChoiceInput
 from django.shortcuts import render
-from django.utils.encoding import force_text, force_str
+from django.utils.encoding import python_2_unicode_compatible, force_text, force_str
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_lazy
@@ -370,19 +370,9 @@ class TabForms(object):
 #
 
 
+@python_2_unicode_compatible
 class CustomRadioInput(RadioChoiceInput):
     """Custom radio input."""
-
-    def __unicode__(self):
-        if "id" in self.attrs:
-            label_for = ' for="%s"' % self.attrs["id"]
-        else:
-            label_for = ""
-        choice_label = conditional_escape(force_text(self.choice_label))
-        return mark_safe(
-            u"<label class='radio-inline' %s>%s %s</label>"
-            % (label_for, self.tag(), choice_label)
-        )
 
     def __str__(self):
         if "id" in self.attrs:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Python 3 doesn't interpret __unicode__ function, but use __str__ function instead.

Current behavior before PR:
So, for example, in DNSBL summary, instead of the domain name and IP in the second column, we have "MXRecord object"...

Desired behavior after PR is merged:
Restore the view of domain name and IP, like python2 version.

I also add a __str__ function beside every __unicode__ function. Note that python3 uses unicode by default, so I remove in str function the "u" prefix for strings.

The change in file modoboa/admin/models/domain.py fixes the problem described above. The other changes have not been tested by my. Please check they are correct.