### PR TITLE
Delete extra "not" that changes meaning...

### DIFF
--- a/doc/manual_installation/dovecot.rst
+++ b/doc/manual_installation/dovecot.rst
@@ -75,7 +75,7 @@ example, when you rename an e-mail address through the web UI, the
 associated mailbox on the file system is not modified
 directly. Instead of that, a *rename* order is created for this
 mailbox. The mailbox will be considered unavailable until the order is
-not executed (see :ref:`Postfix configuration <postfix_config>`).
+executed (see :ref:`Postfix configuration <postfix_config>`).
 
 Edit the crontab of the user who owns the mailboxes on the file system::
 


### PR DESCRIPTION
I believe that the sentence describing renaming a mailbox should read '...considered unavailable until the order is executed...'.

g.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
