### PR TITLE
Update Installation Doc

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -27,7 +27,7 @@ To use it, just run the following commands in your terminal:
   > sudo ./run.py <your domain>
   
   
-if you get this warning - '/usr/bin/env: ‘python’: No such file or directory', do make sure sure python is installed on your server. Sometimes python is installed but the installer can detect it or which python version to run, for example on a debian based system. Then run this command first.
+if you get this warning - '/usr/bin/env: ‘python’: No such file or directory', do make sure sure python is installed on your server. Sometimes python is installed but the installer can't detect it or which python version to run, especially on a debian based system. Then run this command first.
 
 .. sourcecode:: bash
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -25,6 +25,14 @@ To use it, just run the following commands in your terminal:
   > git clone https://github.com/modoboa/modoboa-installer
   > cd modoboa-installer
   > sudo ./run.py <your domain>
+  
+
+if you get this warning - '/usr/bin/env: ‘python’: No such file or directory'. Run this command first
+
+.. sourcecode:: bash
+
+   > sudo apt-get install python-virtualenv python-pip
+
 
 Wait a few minutes and you're done \o/
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -26,8 +26,8 @@ To use it, just run the following commands in your terminal:
   > cd modoboa-installer
   > sudo ./run.py <your domain>
   
-
-if you get this warning - '/usr/bin/env: ‘python’: No such file or directory'. Run this command first
+  
+if you get this warning - '/usr/bin/env: ‘python’: No such file or directory', do make sure sure python is installed on your server. Sometimes python is installed but the installer can detect it or which python version to run, for example on a debian based system. Then run this command first.
 
 .. sourcecode:: bash
 


### PR DESCRIPTION
Update Installation Doc to fix missing python path error

Description of the issue/feature this PR addresses: Resolution of the modoboa installer not being able to find the appropriate python installed

Current behavior before PR: Installation breaks with the error '/usr/bin/env: ‘python’: No such file or directory'

Desired behavior after PR is merged: Installation runs smooth
