### PR TITLE
Update manual installation doc to recommend mysqlclient

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -89,7 +89,7 @@ Install the corresponding Python binding:
 
 .. sourcecode:: bash
 
-  (env)> pip install MySQL-Python
+  (env)> pip install mysqlclient
 
 Then, create a user and a database:
 


### PR DESCRIPTION
From pypi page:
---------------
mysqlclient is a fork of MySQL-python. It adds Python 3 support
and fixed many bugs.
...
MySQL-5.5 through 5.7 and Python 2.7, 3.4+ are currently supported.

**Description of the issue/feature this PR addresses:** Recommend a better supported MySQL connector.

**Current behavior before PR:** MySQL-python doesn't support Python 3 and hasn't been updated for years.

**Desired behavior after PR is merged:** To whoever install modoboa manually have pure joy! :joy: 
