### PR TITLE
Impossible to enable domain on creation or update with coreapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ dj-database-url
 
 coreapi==2.3.1
 coreapi-cli==1.0.6
-djangorestframework==3.6.3
+djangorestframework==3.7.1
 
 argparse
 # bcrypt requires libffi-dev


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I found a bug in the coreapi to create a domain
this problem is on the djangorestframework and fix ten days ago 

see: https://github.com/mozilla/mozillians/pull/1892
       https://github.com/encode/django-rest-framework/issues/1101
Fix: https://github.com/encode/django-rest-framework/pull/5038/files


Current behavior before PR:

![capture d ecran 2017-10-26 a 16 12 42](https://user-images.githubusercontent.com/337842/32059240-cfff50ee-ba6b-11e7-9c21-8fa7baccf575.png)


