### PR TITLE
Create rebuild_virtual_env.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,8 +69,10 @@ Table of contents
 
    installation
    upgrade
+   rebuild_virtual_env
    configuration
    moving
    rest_api
    contributing
    contributors
+

--- a/doc/manual_installation/rebuild_virtual_env.rst
+++ b/doc/manual_installation/rebuild_virtual_env.rst
@@ -1,0 +1,52 @@
+Sometimes when upgrading your Operating System (eg from Ubuntu 17.04 to Ubuntu 17.10) your virtual environment running modoboa can get corrupted. Your first response will be to panic but fear not! The solution is in this document.
+
+First things first:
+
+Recover your database password
+============================
+You will need to recover your database password (if using mysql or postgresql). You will find this in ``/etc/postfix/sql-aliases.cf`` or any file with ``sql-*.cf`` in the ``/etc/postfix`` directory.
+
+Make note of this as you will need it when reconfiguring modoboa.
+
+Reinstall Modoboa
+================
+Start out by backup up your modoboa settings file located in the ``modoboa instance`` directory (for me this was ``/srv/modoboa/instance/instance/settings.py``. This contains your current configuration.
+
+Next, you want to remove all current modoboa files.
+
+After doing this, follow the `manual installation instructions **for modoboa only** <http://modoboa.readthedocs.io/en/latest/manual_installation/modoboa.html>`_ as everything should be working properly.
+
+After this completes, simply restore your backed up settings file to ``/srv/instance/instance/settings.py``. You will then need to reinstall your extensions (a list can be `found here <http://modoboa.readthedocs.io/en/latest/index.html>`_).
+
+You can find which plugins you had in your ``settings.py`` file under the **MODOBOA_APPS** variable.
+
+Instructions to install extensions can also be `found here <http://modoboa.readthedocs.io/en/latest/installation.html#extensions>`_.
+
+Once you have completed this step, you will need to run the following commands:
+
+.. sourcecode:: bash
+  > (env) $ cd <instance_dir>
+  > (env) $ python manage.py migrate
+  > (env) $ python manage.py collectstatic
+  
+You will then see a message similar to
+
+.. sourcecode:: text
+
+  You have requested to collect static files at the destination
+  location as specified in your settings:
+
+      /srv/modoboa/instance/sitestatic
+
+  This will overwrite existing files!
+  Are you sure you want to do this?
+
+  Type 'yes' to continue, or 'no' to cancel:
+  
+You will want to answer ``yes`` here then simply restart the ``uwsgi`` process with ``service uwsgi restart`` and you should be up and running again.
+
+Simply log into your modoboa web panel and verify that your extensions and webmail box is working.
+
+Information
+***********
+Rebuild instructions from: `https://help.pythonanywhere.com/pages/RebuildingVirtualenvs/ <https://help.pythonanywhere.com/pages/RebuildingVirtualenvs/>`_

--- a/doc/rebuild_virtual_env.rst
+++ b/doc/rebuild_virtual_env.rst
@@ -1,3 +1,7 @@
+############
+Rebuild The Virtual Environment
+############
+
 Sometimes when upgrading your Operating System (eg from Ubuntu 17.04 to Ubuntu 17.10) your virtual environment running modoboa can get corrupted. Your first response will be to panic but fear not! The solution is in this document.
 
 First things first:


### PR DESCRIPTION
After upgrading to Ubuntu 17.10 my virtualenv was trashed. I rebuilt it using instructions on pythonanywhere.com but felt that the modoboa documentation should have a file for rebuilding the instance.

Description of the issue/feature this PR addresses:
Adds a documentation entry for rebuilding the virtualenv running modoboa.

Current behavior before PR: N/A

Desired behavior after PR is merged:
Provide instructions on rebuilding the virtualenv.