### PR TITLE
escape html in plain text messages

### DIFF
--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -11,6 +11,7 @@ import time
 
 from django.conf import settings
 from django.utils.encoding import smart_text
+from django.utils.html import conditional_escape
 from django.template.loader import render_to_string
 from django.utils import six
 
@@ -198,6 +199,7 @@ class Email(object):
         })
 
     def viewmail_plain(self, content, **kwargs):
+        content = conditional_escape(content)
         return "<pre>%s</pre>" % content
 
     def viewmail_html(self, content, **kwargs):


### PR DESCRIPTION
Currently SQLemail ([modoboa-amavis](https://github.com/modoboa/modoboa-amavis/blob/master/modoboa_amavis/sql_email.py#L18)) does not escape html characters in plain text messages which can potentially allow harmful html to be displayed when viewing quarantined messages.

ImapEmail ([modoboa-webmail](https://github.com/modoboa/modoboa-webmail/blob/master/modoboa_webmail/lib/imapemail.py#L131)) overrides viewmail_plain() and escapes the message prior to calling Email.viewmail_plain(). This should be done in the Email() class as it's beneficial for all sub classes of Email and I can't think of an occasion when you wouldn't want to escape HTML when viewing a plain text message.

conditional_escape is used to prevent double escaping when called by ImapEmail.viewmail_plain().
