### PR TITLE
Improved email parser

### DIFF
--- a/modoboa/lib/tests/sample_messages/multipart-input.txt
+++ b/modoboa/lib/tests/sample_messages/multipart-input.txt
@@ -1,0 +1,130 @@
+Return-Path: <me@example.net>
+X-Original-To: someone@example.net
+Delivered-To: me@example.net
+Received: from mail.example.net (localhost [127.0.0.1])
+	by mail.example.net (Postfix) with ESMTP id 4BD531AF130
+	for <someone@example.net>; Sun, 17 Dec 2017 03:11:30 +0000 (GMT)
+Authentication-Results: mail.example.net (amavisd-new);
+	dkim=pass (1024-bit key) reason="pass (just generated, assumed good)"
+	header.d=example.net
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=example.net; h=
+	content-language:content-type:content-type:mime-version
+	:user-agent:date:date:message-id:subject:subject:from:from
+	:received:received; s=mail; t=1513480289; bh=wAmt0wg2Yk04321B
+	Q63uWL5f67PEBB2EEGONiFUrIvk=; b=UZUzPqH8TUk/bMZm1ofkjwatNCQftZKK
+	C91uIuX3mmjvngNwbVjx4m7jFZItZscNqigyGJN5HCOl8tC/LJmmWzRdhIisFtLA
+	uXRiBuWps82rbV4ciFU8N30i9UXvtWvMywwL6pYSESqixiwylzbddjMjKXXdyqaT
+	DTyR16ZK8IE=
+X-Virus-Scanned: amavisd-new at example.net
+X-Spam-Flag: NO
+X-Spam-Score: -0.988
+X-Spam-Level:
+X-Spam-Status: No, score=-0.988 tagged_above=-999 required=3.9
+	tests=[ALL_TRUSTED=-1, HTML_MESSAGE=0.001, T_HTML_ATTACH=0.01,
+	URIBL_BLOCKED=0.001] autolearn=no autolearn_force=no
+Received: from mail.example.net ([127.0.0.1])
+	by mail.example.net (mail.example.net [127.0.0.1]) (amavisd-new, port 10026)
+	with LMTP id BSCmm59DxNvB for <someone@example.net>;
+	Sun, 17 Dec 2017 03:11:29 +0000 (GMT)
+Received: from [10.0.0.1] (my-pc.example.net [10.0.0.1])
+	by mail.example.net (Postfix) with ESMTPSA id 641171AF12D
+	for <someone@example.net>; Sun, 17 Dec 2017 03:11:29 +0000 (GMT)
+To: Someone <someone@example.net>
+From: Me <me@example.net>
+X-Clacks-Overhead: GNU Terry Pratchett
+Subject: A test message
+Message-ID: <5294ad7a-e966-f1a0-3431-8c4b1b76f5a3@example.net>
+Date: Sun, 17 Dec 2017 03:11:33 +0000
+User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101
+ Thunderbird/52.5.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------7EB9EDC10414C906CC3C2CEA"
+Content-Language: en-GB
+
+This is a multi-part message in MIME format.
+--------------7EB9EDC10414C906CC3C2CEA
+Content-Type: multipart/alternative;
+ boundary="------------87B289699A48D5D0D61BABCC"
+
+
+--------------87B289699A48D5D0D61BABCC
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+This is an *html* /test /_message._
+
+:-)
+
+
+-- 
+Someone
+someone@example.net
+
+
+--------------87B289699A48D5D0D61BABCC
+Content-Type: multipart/related;
+ boundary="------------D585B241EEF60F0F44EC20E5"
+
+
+--------------D585B241EEF60F0F44EC20E5
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  </head>
+  <body text="#000000" bgcolor="#FFFFFF">
+    <p>This is an <b>html</b> <i>test </i><u>message.</u></p>
+    <span class="moz-smiley-s1"><span>:-)</span></span><br>
+    <br>
+    <img moz-do-not-send="false"
+      src="cid:part1.D56823CE.7959DBD4@example.net" alt="" height="10"
+      width="10"><br>
+    <pre class="moz-signature" cols="72">-- 
+someone
+<a class="moz-txt-link-abbreviated" href="mailto:someone@example.net">someone@example.net</a></pre>
+  </body>
+</html>
+
+--------------D585B241EEF60F0F44EC20E5
+Content-Type: image/png;
+ name="image.png"
+Content-Transfer-Encoding: base64
+Content-ID: <part1.D56823CE.7959DBD4@example.net>
+Content-Disposition: inline;
+ filename="image.png"
+
+iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAACXBIWXMAAAsTAAALEwEAmpwY
+AAAAF0lEQVQY02NgYGD4//8/ThKfHASMRN0AfaqVa6MQxIQAAAAASUVORK5CYII=
+--------------D585B241EEF60F0F44EC20E5--
+
+--------------87B289699A48D5D0D61BABCC--
+
+--------------7EB9EDC10414C906CC3C2CEA
+Content-Type: text/html;
+ name="test.html"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="test.html"
+
+//48AHMAcABhAG4APgA8AGIAPgBTAG8AbQBlACAAPABpAD4ASABUAE0ATAA8AC8AaQA+ACAA
+dABlAHgAdAA8AC8AYgA+ACwAIABhACAAPABhACAAaAByAGUAZgA9ACIAaAB0AHQAcAA6AC8A
+LwBlAHgAYQBtAHAAbABlAC4AbgBlAHQAIgAgAHQAYQByAGcAZQB0AD0AIgBfAGIAbABhAG4A
+awAiACAAcgBlAGwAPQAiAG4AbwBmAG8AbABsAG8AdwAiAD4AbABpAG4AawA8AC8AYQA+ACwA
+IABhAG4AJgAjADEAMwA7AA0ACgBlAG0AYgBlAGQAZABlAGQAIABpAG0AYQBnAGUAIABhAG4A
+ZAAgAGEAbgAgAGUAeAB0AGUAcgBuAGEAbAAgAGkAbQBhAGcAZQAuADwAYgByAD4AJgAjADEA
+MwA7AA0ACgA8AGkAbQBnACAAcwByAGMAPQAiAGQAYQB0AGEAOgBpAG0AYQBnAGUALwBwAG4A
+ZwA7AGIAYQBzAGUANgA0ACwAaQBWAEIATwBSAHcAMABLAEcAZwBvAEEAQQBBAEEATgBTAFUA
+aABFAFUAZwBBAEEAQQBBAG8AQQBBAEEAQQBLAEMAQQBJAEEAQQBBAEEAQwBVAEYAagBxAEEA
+QQBBAEEAQwBYAEIASQBXAFgATQBBAEEAQQBzAFQAQQBBAEEATABFAHcARQBBAG0AcAB3AFkA
+QQBBAEEAQQBGADAAbABFAFEAVgBRAFkAMAAyAE4AZwBZAEcARAA0AC8ALwA4AC8AVABoAEsA
+ZgBIAEEAUwBNAFIATgAwAEEAZgBhAHEAVgBhADYATQBRAHgASQBRAEEAQQBBAEEAQQBTAFUA
+VgBPAFIASwA1AEMAWQBJAEkAPQAiACAAdABhAHIAZwBlAHQAPQAiAF8AYgBsAGEAbgBrACIA
+PgA8AGIAcgA+ACYAIwAxADMAOwANAAoAPABpAG0AZwAgAHMAcgBjAD0AIgBoAHQAdABwADoA
+LwAvAGUAeABhAG0AcABsAGUALgBuAGUAdAAvAGkAbQBhAGcAZQAuAHAAbgBnACIAIAB0AGEA
+cgBnAGUAdAA9ACIAXwBiAGwAYQBuAGsAIgA+ADwAYgByAD4AJgAjADEAMwA7AA0ACgBOAGkA
+ZgB0AHkAIQA8AC8AcwBwAGEAbgA+AA0ACgA=
+--------------7EB9EDC10414C906CC3C2CEA--

--- a/modoboa/lib/tests/sample_messages/multipart-output-html_links.txt
+++ b/modoboa/lib/tests/sample_messages/multipart-output-html_links.txt
@@ -1,0 +1,16 @@
+<div>
+  
+
+    
+  
+  <body>
+    <p>This is an <b>html</b> <i>test </i><u>message.</u></p>
+    <span class="moz-smiley-s1"><span>:-)</span></span><br>
+    <br>
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAF0lEQVQY02NgYGD4//8/ThKfHASMRN0AfaqVa6MQxIQAAAAASUVORK5CYII=" alt="" height="10" width="10" target="_blank"><br>
+    <pre class="moz-signature" cols="72">-- 
+someone
+<a class="moz-txt-link-abbreviated" href="mailto:someone@example.net" target="_blank" rel="nofollow">someone@example.net</a></pre>
+  </body>
+<p>
+&#65533;&#65533;</p></div>

--- a/modoboa/lib/tests/sample_messages/multipart-output-html_nolinks.txt
+++ b/modoboa/lib/tests/sample_messages/multipart-output-html_nolinks.txt
@@ -1,0 +1,16 @@
+<div>
+  
+
+    
+  
+  <body>
+    <p>This is an <b>html</b> <i>test </i><u>message.</u></p>
+    <span class="moz-smiley-s1"><span>:-)</span></span><br>
+    <br>
+    <img alt="" height="10" width="10"><br>
+    <pre class="moz-signature" cols="72">-- 
+someone
+<a class="moz-txt-link-abbreviated">someone@example.net</a></pre>
+  </body>
+<p>
+&#65533;&#65533;</p></div>

--- a/modoboa/lib/tests/sample_messages/multipart-output-plain_nolinks.txt
+++ b/modoboa/lib/tests/sample_messages/multipart-output-plain_nolinks.txt
@@ -1,0 +1,7 @@
+<pre>This is an *html* /test /_message._
+
+:-)
+
+-- 
+Someone
+someone@example.net</pre>

--- a/modoboa/lib/tests/sample_messages/text_plain-input.txt
+++ b/modoboa/lib/tests/sample_messages/text_plain-input.txt
@@ -1,0 +1,51 @@
+Return-Path: <someone@example.net>
+X-Original-To: me@example.net Delivered-To: someone@example.net
+Received: from mail.example.net (localhost [127.0.0.1])
+	by mail.example.net (Postfix) with ESMTP id A142E1AF12D
+	for <me@example.net>; Sun, 17 Dec 2017 13:10:10 +0000 (GMT)
+Authentication-Results: mail.example.net (amavisd-new);
+	dkim=pass (1024-bit key) reason="pass (just generated, assumed good)"
+	header.d=example.net
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=example.net; h=
+	content-transfer-encoding:content-language:content-type
+	:content-type:mime-version:user-agent:date:date:message-id
+	:subject:subject:from:from:received:received; s=mail; t=
+	1513516210; bh=yyFHETi2jtS7bFMEIArr53VnJMNNjltuXCFTOqs/cL0=; b=X
+	nMo4pMsaH7EO9A55i0SOv5RGP4Sp4eukaXXQJgMWahcfUn4mM2+pSdc+8ZMaXX7y
+	ITQdCzI0LL9WGfX7bbMA49hYtIELjQ/AochqABTUsMxnq0Sgf1FE37bA3NS1pBtp
+	TBKehpGjr86y0V247Okmf2faEkO9dMvmwWz8QBI0N4=
+X-Virus-Scanned: amavisd-new at example.net
+X-Spam-Flag: NO
+X-Spam-Score: -0.999
+X-Spam-Level:
+X-Spam-Status: No, score=-0.999 tagged_above=-999 required=3.9
+	tests=[ALL_TRUSTED=-1, URIBL_BLOCKED=0.001]
+	autolearn=no autolearn_force=no
+Received: from mail.example.net ([127.0.0.1])
+	by mail.example.net (mail.example.net [127.0.0.1]) (amavisd-new, port 10026)
+	with LMTP id j0UYMNn7ZprP for <me@example.net>;
+	Sun, 17 Dec 2017 13:10:10 +0000 (GMT)
+Received: from [10.0.0.1] (my-pc.example.net [10.0.0.1])
+	by mail.example.net (Postfix) with ESMTPSA id E66201AF132
+	for <me@example.net>; Sun, 17 Dec 2017 13:10:09 +0000 (GMT)
+To: Me <me@example.net>
+From: Someone <someone@example.net>
+X-Clacks-Overhead: GNU Terry Pratchett
+Subject: =?UTF-8?Q?T=c3=a9st_message?=
+Message-ID: <8626caea-4c05-8dc5-c687-bcfb7a329d18@example.net>
+Date: Sun, 17 Dec 2017 13:10:14 +0000
+User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101
+ Thunderbird/52.5.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Language: en-GB
+Content-Transfer-Encoding: 7bit
+X-rAnDoM-cAsE-hEaDeR: fOoBaR
+X-UPPER-CASE-HEADER: FOOBAR
+x-lower-case-header: foobar
+
+This is a plain text e-mail message.
+
+-- 
+Someone
+someone@example.net

--- a/modoboa/lib/tests/sample_messages/text_plain-output-plain_nolinks.txt
+++ b/modoboa/lib/tests/sample_messages/text_plain-output-plain_nolinks.txt
@@ -1,0 +1,5 @@
+<pre>This is a plain text e-mail message.
+
+-- 
+Someone
+someone@example.net</pre>

--- a/modoboa/lib/tests/test_email_utils.py
+++ b/modoboa/lib/tests/test_email_utils.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for email_utils."""
+
+from __future__ import unicode_literals
+
+import os
+
+from django.test import SimpleTestCase
+from django.utils.encoding import smart_bytes, smart_text
+
+from ..email_utils import Email
+
+SAMPLES_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), "sample_messages"))
+
+
+class EmailTestImplementation(Email):
+
+    def _fetch_message(self):
+        message_path = os.path.join(SAMPLES_DIR, "%s-input.txt" % self.mailid)
+        assert os.path.isfile(message_path), "%s does not exist." % message_path
+
+        with open(message_path, "rb") as fp:
+            mail_text = smart_bytes(fp.read())
+
+        return mail_text
+
+
+class EmailTests(SimpleTestCase):
+    """Tests for modoboa.lib.email_utils.Email
+
+    When writing new sample messages use the following naming convention for
+    the sample files stored in sample_messages:
+
+    input:  {message_id}-input.txt
+    output: {message_id}-output-{dformat}_{no,}links.txt
+    """
+
+    def _get_expected_output(self, message_id, **kwargs):
+        ext = kwargs["dformat"] if "dformat" in kwargs else "plain"
+        ext += "_links" if "links" in kwargs and kwargs["links"] else "_nolinks"
+        message_path = os.path.join(SAMPLES_DIR,
+                                    "%s-output-%s.txt" % (message_id, ext))
+        assert os.path.isfile(message_path), "%s does not exist." % message_path
+
+        with open(message_path, "rb") as fp:
+            # output should always be unicode (py2) or str (py3)
+            mail_text = smart_text(fp.read())
+
+        return mail_text
+
+    def _test_email(self, message_id, **kwargs):
+        """Boiler plate code for testing e-mails."""
+        expected_output = self._get_expected_output(message_id, **kwargs)
+        output = EmailTestImplementation(message_id, **kwargs).body
+        self.assertEqual(output, expected_output)
+
+    def test_invalid_links_value(self):
+        """modoboa-amavis set links = "0"; in python "0" == True, fixed in PR 79
+           https://github.com/modoboa/modoboa-amavis/pull/79"""
+        with self.assertRaises(TypeError) as cm:
+            EmailTestImplementation("text_plain", links="0")
+
+            ex_message = cm.exception.messages
+            self.assertEqual(ex_message,
+                             "links == \"0\" is not valid, did you mean True or "
+                             "False?")
+
+    def test_links_value_for_webmail(self):
+        """modoboa-webmail sets links = 0 or 1
+           TODO: this should be fixed in modoboa-webmail to use True/False"""
+        email = EmailTestImplementation("text_plain", links=0)
+        self.assertFalse(email.links)
+
+        email = EmailTestImplementation("text_plain", links=1)
+        self.assertTrue(email.links)
+
+    def test_headers(self):
+        email = EmailTestImplementation("text_plain")
+        # test header names are case insensative
+        self.assertEqual(email.msg["x-upper-case-header"], "FOOBAR")
+        self.assertEqual(email.msg["X-Lower-Case-Header"], "foobar")
+        self.assertEqual(email.msg["x-random-case-header"], "fOoBaR")
+
+        expected_output = [
+            {"name": "From", "value": "Someone <someone@example.net>"},
+            {"name": "To", "value": "Me <me@example.net>"},
+            {"name": "Cc", "value": ""},
+            {"name": "Date", "value": "Sun, 17 Dec 2017 13:10:14 +0000"},
+            {"name": "Subject", "value": "Tést message"},
+        ]
+        self.assertEqual(email.headers, expected_output)
+
+    def test_email_text_plain(self):
+        self._test_email("text_plain")
+
+    def test_email_multipart_as_text(self):
+        """display the text/plain part of a multipart message"""
+        self._test_email("multipart")
+
+    def test_email_multipart_with_links(self):
+        """display the text/html part of a multipart message"""
+        self._test_email("multipart", dformat="html", links=True)
+
+    def test_email_multipart_without_links(self):
+        """display the text/html part of a multipart message with links removed"""
+        self._test_email("multipart", dformat="html", links=False)

--- a/modoboa/lib/tests/test_u2u_decode.py
+++ b/modoboa/lib/tests/test_u2u_decode.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for u2u_decode."""
+
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from .. import u2u_decode
+
+
+class U2UTestCase(TestCase):
+    """Test RFC1342 decoding utilities."""
+
+    def test_header_decoding(self):
+        """Simple decoding."""
+        samples = [
+            ("=?ISO-8859-15?Q?=20Profitez de tous les services en ligne sur "
+             "impots.gouv.fr?=",
+             "Profitez de tous les services en ligne sur impots.gouv.fr"),
+            ("=?ISO-8859-1?Q?Accus=E9?= de =?ISO-8859-1?Q?r=E9ception?= de "
+             "votre annonce",
+             "Accusé de réception de votre annonce"),
+            ("Sm=?ISO-8859-1?B?9g==?=rg=?ISO-8859-1?B?5Q==?=sbord",
+             "Sm\xf6rg\xe5sbord"),
+            # The following case currently fails because of the way we split
+            # encoded words to parse them separately, which can lead to
+            # unexpected unicode decode errors... I think it will work fine on
+            # Python3
+            # ("=?utf-8?B?VMOpbMOpcMOpYWdlIFZJTkNJIEF1dG9yb3V0ZXMgLSBFeHDD?=\n"
+            #  "=?utf-8?B?qWRpdGlvbiBkZSB2b3RyZSBjb21tYW5kZSBOwrAgMjAxNzEyMDcw"
+            #  "MDA1?=\n=?utf-8?B?MyBkdSAwNy8xMi8yMDE3IDE0OjQ5OjQx?=",
+            #  "")
+        ]
+        for sample in samples:
+            self.assertEqual(u2u_decode.u2u_decode(sample[0]), sample[1])
+
+    def test_address_header_decoding(self):
+        """Check address decoding."""
+        mailsploit_sample = (
+            "=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?==?utf-8?Q?=00?="
+            "=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?=@mailsploit.com")
+        expected_result = (
+            "=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?==?utf-8?Q??="
+            "=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?=@mailsploit.com")
+        self.assertEqual(
+            u2u_decode.decode_address(mailsploit_sample),
+            ("", expected_result)
+        )
+        mailsploit_sample = (
+            '"=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?==?utf-8?Q?=0A=00?="\n'
+            '<=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?==?utf-8?Q?=0A=00?='
+            '@mailsploit.com>')
+        expected_result = (
+            'potus@whitehouse.gov',
+            '=?utf-8?b?cG90dXNAd2hpdGVob3VzZS5nb3Y=?==?utf-8?Q??='
+            '@mailsploit.com')
+        self.assertEqual(
+            u2u_decode.decode_address(mailsploit_sample),
+            expected_result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ cryptography
 pytz
 requests
 rfc6266
+lxml


### PR DESCRIPTION
This is a refactor of `moboboa.lib.email_utils.Email`, currently it has some dead code (`__save_image`) and it has trouble parsing messages containing certain attachemnt types.

73bceee splits `modoboa/lib/tests.py` into separate files so that each file only tests one component. The code in `modoboa/lib/tests/__init__.py` is there so as not to break everything that imports `modoboa.lib.tests`

ce02d24 adds python 3 support for landscape.io and simplifies codecov ignore paths

c67f685 and e38cfb7 adds the improved `Email` class and tests.

**This PR depends on a similar PR for modoboa/modoboa-amavis#80 as it depends on moboboa.lib.email_utils.Email.**

modoboa-webmail isn't affected as it implements it's own parser to fetch e-mails from IMAP.