### PR TITLE
On error email admins

### DIFF
--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals, print_function
 
+import codecs
 import getpass
 import os
 import shutil
@@ -253,7 +254,7 @@ class DeployCommand(Command):
                 'extra_settings': extra_settings
             }
         )
-        with open("%s/settings.py" % path, "w") as fp:
+        with codecs.open("%s/settings.py" % path, "w", "utf-8") as fp:
             fp.write(tpl)
         shutil.copyfile(
             "%s/urls.py.tpl" % self._templates_dir, "%s/urls.py" % path

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Django settings for {{ name }} project.
 

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -39,6 +39,15 @@ ALLOWED_HOSTS = [
 
 SITE_ID = 1
 
+# A list of all the people who get code error notifications. When DEBUG=False
+# and a view raises an exception, Django will email these people with the full
+# exception information.
+# See https://docs.djangoproject.com/en/dev/ref/settings/#admins
+#ADMINS = [('Administrator', 'admin@example.net')]
+
+# The email address that error messages come from, such as those sent to ADMINS
+#SERVER_EMAIL = 'webmaster@example.net'
+
 # Security settings
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
@@ -252,6 +261,11 @@ LOGGING = {
         },
     },
     'handlers': {
+        'mail-admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'include_html': True
+        },
         'syslog-auth': {
             'class': 'logging.handlers.SysLogHandler',
             'facility': SysLogHandler.LOG_AUTH,
@@ -262,6 +276,11 @@ LOGGING = {
         }
     },
     'loggers': {
+        'django': {
+            'handlers': ['mail-admins'],
+            'level': 'ERROR',
+            'propagate': False
+        },
         'modoboa.auth': {
             'handlers': ['syslog-auth', 'modoboa'],
             'level': 'INFO',


### PR DESCRIPTION
Set ADMINS to a list of all the people who get code error notifications. When DEBUG=False Django emails these people the details of exceptions raised in the request/response cycle.

modoboa disables this by overriding `settings.LOGGING`, e5a05f2 restores this feature it's only enabled if `settings.ADMINS` is defined.

51566ce adds utf-8 support when generating `settings.py`, I might have accidentally thrown a utf-8 character into `settings.py.tpl` by accident (now removed) 😃 