### PR TITLE
fix postfix documentation

### DIFF
--- a/doc/manual_installation/postfix.rst
+++ b/doc/manual_installation/postfix.rst
@@ -36,15 +36,12 @@ Use the following configuration in the :file:`/etc/postfix/main.cf` file
   # Stuff before
   virtual_transport = lmtp:unix:private/dovecot-lmtp
 
-  relay_domains =
   virtual_mailbox_domains = <driver>:/etc/postfix/sql-domains.cf
   virtual_alias_domains = <driver>:/etc/postfix/sql-domain-aliases.cf
   virtual_alias_maps = <driver>:/etc/postfix/sql-aliases.cf
 
   relay_domains = <driver>:/etc/postfix/sql-relaydomains.cf
-  transport_maps =
-      <driver>:/etc/postfix/sql-spliteddomains-transport.cf
-      <driver>:/etc/postfix/sql-relaydomains-transport.cf
+  transport_maps = <driver>:/etc/postfix/sql-spliteddomains-transport.cf
 
   smtpd_recipient_restrictions =
         # ...
@@ -56,10 +53,7 @@ Use the following configuration in the :file:`/etc/postfix/main.cf` file
         reject_unverified_recipient
         # ...
 
-  smtpd_sender_login_maps =
-        <driver>:/etc/postfix/sql-sender-login-mailboxes.cf
-        <driver>:/etc/postfix/sql-sender-login-aliases.cf
-        <driver>:/etc/postfix/sql-sender-login-mailboxes-extra.cf
+  smtpd_sender_login_maps = <driver>:/etc/postfix/sql-sender-login-map.cf
 
   smtpd_sender_restrictions =
         reject_sender_login_mismatch

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -89,6 +89,21 @@ Rebuild Virtual Environment
 Specific instructions
 *********************
 
+1.10.0
+======
+
+First of all, update postfix map files as follows:
+
+.. sourcecode:: bash
+
+   > python manage.py generate_postfix_maps --destdir <path>
+                
+Then, modify postfix's configuration as follows::
+
+If transport_maps contains sql-relaydomains-transport.cf, remove it.
+
+Finally, reload postfix.
+
 1.9.2
 =====
 


### PR DESCRIPTION
Fix instructions for a new installs, and upgrades to reflect recent changes.

- #1309 removed `sql-relaydomains-transport.cf`

- #1322 merged `sql-sender-login-*.cf` into `sql-sender-login-map.cf`

- remove duplicate `relay_domains`
