### PR TITLE
Add IPv6 support to mx checks

### DIFF
--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 """Internal library for admin."""
 
@@ -222,7 +222,7 @@ def domain_has_authorized_mx(name):
     valid_mxs = [ipaddress.ip_network(smart_text(v.strip()))
                  for v in valid_mxs.split() if v.strip()]
     domain_mxs = get_domain_mx_list(name)
-    for mx_addr, mx_ip_addr in domain_mxs:
+    for mx_addr, mx_ip_addr in domain_mxs:  # noqa:B007
         for subnet in valid_mxs:
             if mx_ip_addr in subnet:
                 return True

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -12,6 +12,7 @@ from django.core import mail
 from django.core.mail import EmailMessage
 from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
+from django.utils.encoding import smart_text
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 
@@ -41,7 +42,7 @@ class CheckMXRecords(BaseCommand):
     def valid_mxs(self):
         """Return valid MXs set in admin."""
         valid_mxs = param_tools.get_global_parameter("valid_mxs")
-        return [ipaddress.ip_network(u"{}".format(v.strip()))
+        return [ipaddress.ip_network(smart_text(v.strip()))
                 for v in valid_mxs.split() if v.strip()]
 
     def add_arguments(self, parser):

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Management command to check defined domains."""
 
 from __future__ import print_function, unicode_literals
@@ -24,7 +26,7 @@ from modoboa.parameters import tools as param_tools
 class CheckMXRecords(BaseCommand):
     """Command class."""
 
-    help = "Check defined domains."
+    help = "Check defined domains."  # noqa:A003
 
     @cached_property
     def providers(self):

--- a/modoboa/admin/tests/test_api.py
+++ b/modoboa/admin/tests/test_api.py
@@ -1,4 +1,5 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
 """Admin API related tests."""
 
 from __future__ import unicode_literals
@@ -27,7 +28,7 @@ class DomainAPITestCase(ModoAPITestCase):
     """Check API."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(DomainAPITestCase, cls).setUpTestData()
         factories.populate_database()
@@ -137,7 +138,7 @@ class DomainAliasAPITestCase(ModoAPITestCase):
     """Check DomainAlias API."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(DomainAliasAPITestCase, cls).setUpTestData()
         factories.populate_database()
@@ -231,7 +232,7 @@ class AccountAPITestCase(ModoAPITestCase):
     }
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(AccountAPITestCase, cls).setUpTestData()
         factories.populate_database()
@@ -544,7 +545,7 @@ class AliasAPITestCase(ModoAPITestCase):
     }
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(AliasAPITestCase, cls).setUpTestData()
         cls.localconfig.parameters.set_value(
@@ -667,7 +668,7 @@ class SenderAddressAPITestCase(ModoAPITestCase):
     """Check SenderAddress API."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(SenderAddressAPITestCase, cls).setUpTestData()
         cls.localconfig.parameters.set_value(

--- a/modoboa/admin/tests/test_api.py
+++ b/modoboa/admin/tests/test_api.py
@@ -73,11 +73,11 @@ class DomainAPITestCase(ModoAPITestCase):
         self.assertEqual(response.status_code, 403)
 
     @patch.object(dns.resolver.Resolver, "query")
-    @patch("socket.gethostbyname")
-    def test_create_domain_with_mx_check(self, mock_gethostbyname, mock_query):
+    @patch("socket.getaddrinfo")
+    def test_create_domain_with_mx_check(self, mock_getaddrinfo, mock_query):
         """Check domain creation when MX check is activated."""
         self.set_global_parameter("enable_admin_limits", False, app="limits")
-        self.set_global_parameter("valid_mxs", "1.2.3.4")
+        self.set_global_parameter("valid_mxs", "192.0.2.1 2001:db8::1")
         self.set_global_parameter("domains_must_have_authorized_mx", True)
         reseller = core_factories.UserFactory(
             username="reseller", groups=("Resellers", ))
@@ -85,19 +85,19 @@ class DomainAPITestCase(ModoAPITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
 
         url = reverse("api:domain-list")
-        mock_query.return_value = [utils.FakeDNSAnswer("mail.ok.com")]
-        mock_gethostbyname.return_value = "1.2.3.5"
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
         response = self.client.post(
-            url, {"name": "test3.com", "quota": 0, "default_mailbox_quota": 10}
+            url, {"name": "no-mx.example.com", "quota": 0, "default_mailbox_quota": 10}
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["name"][0],
             "No authorized MX record found for this domain")
 
-        mock_gethostbyname.return_value = "1.2.3.4"
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
         response = self.client.post(
-            url, {"name": "test3.com", "quota": 0, "default_mailbox_quota": 10}
+            url, {"name": "test4.com", "quota": 0, "default_mailbox_quota": 10}
         )
         self.assertEqual(response.status_code, 201)
 

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 """Domain related test cases."""
 
@@ -22,7 +22,7 @@ class DomainTestCase(ModoTestCase):
     """Test case for Domain."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(DomainTestCase, cls).setUpTestData()
         factories.populate_database()

--- a/modoboa/admin/tests/test_import_.py
+++ b/modoboa/admin/tests/test_import_.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
 
@@ -20,7 +20,7 @@ from ..models import Domain, Alias, DomainAlias
 class ImportTestCase(ModoTestCase):
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa: N802
         """Create test data."""
         super(ImportTestCase, cls).setUpTestData()
         cls.localconfig.parameters.set_value(

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -2,17 +2,22 @@
 
 from __future__ import unicode_literals
 
+import dns.resolver
 from mock import patch
+from testfixtures import LogCapture
 
 from django.core import mail
 from django.core import management
-from django.urls import reverse
 from django.test import override_settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
 
 from modoboa.core import factories as core_factories
 from modoboa.lib.tests import ModoTestCase
 
+from . import utils
 from .. import factories
+from ..lib import get_domain_mx_list
 from .. import models
 
 
@@ -25,25 +30,33 @@ class MXTestCase(ModoTestCase):
         super(MXTestCase, cls).setUpTestData()
         cls.domain = factories.DomainFactory(name="modoboa.org")
         # should not exist
-        cls.bad_domain = factories.DomainFactory(name="pouet.com")
+        cls.bad_domain = factories.DomainFactory(name="does-not-exist.example.com")
         # Add domain admin with mailbox
         mb = factories.MailboxFactory(
             address="admin", domain=cls.bad_domain,
-            user__username="admin@pouet.com",
+            user__username="admin@does-not-exist.example.com",
             user__groups=("DomainAdmins", )
         )
         cls.bad_domain.add_admin(mb.user)
         # Add domain admin with no mailbox
         admin = core_factories.UserFactory(
-            username="admin2@pouet.com", groups=("DomainAdmins", ))
+            username="admin2@does-not-exist.example.com", groups=("DomainAdmins", ))
         cls.bad_domain.add_admin(admin)
 
-        cls.localconfig.parameters.set_value("valid_mxs", "127.0.0.1")
+        cls.localconfig.parameters.set_value(
+            "valid_mxs", "192.0.2.1 2001:db8::1")
         cls.localconfig.save()
         models.MXRecord.objects.all().delete()
 
-    def test_management_command(self):
+    @patch("gevent.socket.gethostbyname")
+    @patch("socket.getaddrinfo")
+    @patch.object(dns.resolver.Resolver, "query")
+    def test_management_command(
+         self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check that command works fine."""
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "1.2.3.4"
         self.assertEqual(models.MXRecord.objects.count(), 0)
         management.call_command("modo", "check_mx", "--no-dnsbl", "--ttl=0")
         self.assertTrue(
@@ -63,8 +76,15 @@ class MXTestCase(ModoTestCase):
         qs = models.MXRecord.objects.filter(domain=self.domain)
         self.assertEqual(id, qs[0].id)
 
-    def test_single_domain_update(self):
+    @patch("gevent.socket.gethostbyname")
+    @patch("socket.getaddrinfo")
+    @patch.object(dns.resolver.Resolver, "query")
+    def test_single_domain_update(
+         self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Update only one domain."""
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "1.2.3.4"
         management.call_command(
             "modo", "check_mx", "--domain", self.domain.name)
         self.assertTrue(
@@ -81,6 +101,36 @@ class MXTestCase(ModoTestCase):
         management.call_command(
             "modo", "check_mx", "--domain", "toto.com")
 
+    @patch("socket.getaddrinfo")
+    @patch.object(dns.resolver.Resolver, "query")
+    def test_get_domain_mx_list_logging(self, mock_query, mock_getaddrinfo):
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        with LogCapture("modoboa.admin") as log:
+            get_domain_mx_list("does-not-exist.example.com")
+            get_domain_mx_list("no-mx.example.com")
+            get_domain_mx_list("no-ns-servers.example.com")
+            get_domain_mx_list("timeout.example.com")
+            get_domain_mx_list("no-lookup.example.com")
+            get_domain_mx_list("bad-response.example.com")
+        log.check(
+            ("modoboa.admin", "ERROR",
+                _("No DNS records found for %s")
+                % "does-not-exist.example.com"),
+            ("modoboa.admin", "ERROR",
+                _("No MX record for %s") % "no-mx.example.com"),
+            ("modoboa.admin", "ERROR", _("No working name servers found")),
+            ("modoboa.admin", "WARNING",
+                _("DNS resolution timeout, unable to query %s at the moment")
+                % "timeout.example.com"),
+            ("modoboa.admin", "WARNING",
+                _("Unable to lookup ip addresses for %s; %s")
+                % ("does-not-exist.example.com", "")),
+            ("modoboa.admin", "WARNING",
+                _("Invalid IP address format for %s; %s")
+                % ("bad-response.example.com", "BAD")),
+            )
+
 
 @override_settings(DNSBL_PROVIDERS=["zen.spamhaus.org"])
 class DNSBLTestCase(ModoTestCase):
@@ -91,15 +141,22 @@ class DNSBLTestCase(ModoTestCase):
         """Create some data."""
         super(DNSBLTestCase, cls).setUpTestData()
         cls.domain = factories.DomainFactory(name="modoboa.org")
-        factories.DomainFactory(name="pouet.com")  # should not exist
+        factories.DomainFactory(name="does-not-exist.example.com")
         cls.domain2 = factories.DomainFactory(
             name="test.localhost")  # Should not be checked
         cls.domain3 = factories.DomainFactory(
             name="modoboa.com", enable_dns_checks=False)
         models.DNSBLResult.objects.all().delete()
 
-    def test_management_command(self):
+    @patch("gevent.socket.gethostbyname")
+    @patch("socket.getaddrinfo")
+    @patch.object(dns.resolver.Resolver, "query")
+    def test_management_command(
+         self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check that command works fine."""
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "1.2.3.4"
         self.assertEqual(models.DNSBLResult.objects.count(), 0)
         management.call_command("modo", "check_mx")
         self.assertTrue(
@@ -113,15 +170,30 @@ class DNSBLTestCase(ModoTestCase):
         self.assertTrue(self.domain2.uses_a_reserved_tld)
 
     @patch("gevent.socket.gethostbyname")
-    def test_notifications(self, mock_gethostbyname):
+    @patch("socket.getaddrinfo")
+    @patch.object(dns.resolver.Resolver, "query")
+    def test_notifications(
+         self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check notifications."""
-        mock_gethostbyname.return_value = "1.2.3.4"
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "1.2.3.4"
         management.call_command(
             "modo", "check_mx", "--email", "user@example.test")
+        if len(mail.outbox) != 2:
+            for message in mail.outbox:
+                print(message.subject)
         self.assertEqual(len(mail.outbox), 2)
 
-    def test_management_command_no_dnsbl(self):
+    @patch("gevent.socket.gethostbyname")
+    @patch("socket.getaddrinfo")
+    @patch.object(dns.resolver.Resolver, "query")
+    def test_management_command_no_dnsbl(
+         self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check that command works fine without dnsbl."""
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "1.2.3.4"
         self.assertEqual(models.DNSBLResult.objects.count(), 0)
         management.call_command("modo", "check_mx", "--no-dnsbl")
         self.assertFalse(

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """DNSBL related tests."""
 
 from __future__ import unicode_literals
@@ -25,7 +27,7 @@ class MXTestCase(ModoTestCase):
     """TestCase for DNSBL related features."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa:N802
         """Create some data."""
         super(MXTestCase, cls).setUpTestData()
         cls.domain = factories.DomainFactory(name="modoboa.org")
@@ -64,17 +66,17 @@ class MXTestCase(ModoTestCase):
 
         # we passed a ttl to 0. this will reset the cache this time
         qs = models.MXRecord.objects.filter(domain=self.domain)
-        id = qs[0].id
+        id_ = qs[0].id
         management.call_command("modo", "check_mx", "--no-dnsbl", "--ttl=7200")
         qs = models.MXRecord.objects.filter(domain=self.domain)
-        self.assertNotEqual(id, qs[0].id)
-        id = qs[0].id
+        self.assertNotEqual(id_, qs[0].id)
+        id_ = qs[0].id
 
         # assume that mxrecords ids are the same. means that we taking care of
         # ttl
         management.call_command("modo", "check_mx", "--no-dnsbl")
         qs = models.MXRecord.objects.filter(domain=self.domain)
-        self.assertEqual(id, qs[0].id)
+        self.assertEqual(id_, qs[0].id)
 
     @patch("gevent.socket.gethostbyname")
     @patch("socket.getaddrinfo")
@@ -137,7 +139,7 @@ class DNSBLTestCase(ModoTestCase):
     """TestCase for DNSBL related features."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa:N802
         """Create some data."""
         super(DNSBLTestCase, cls).setUpTestData()
         cls.domain = factories.DomainFactory(name="modoboa.org")

--- a/modoboa/admin/tests/utils.py
+++ b/modoboa/admin/tests/utils.py
@@ -1,8 +1,62 @@
+# -*- coding: utf-8 -*-
+
 """Test utilities."""
 
+from __future__ import unicode_literals
 
-class FakeDNSAnswer(object):
-    """Fake answer."""
+import socket
 
-    def __init__(self, exchange):
-        self.exchange = exchange
+from dns.name import Name
+from dns.rdtypes.ANY.MX import MX
+from dns.resolver import NoAnswer, NoNameservers, NXDOMAIN, Timeout
+
+_MX_RECORD_1 = MX("IN", "MX", 10, Name("mx.example.com".split(".")))
+_MX_RECORD_2 = MX("IN", "MX", 10, Name("mx2.example.com".split(".")))
+_BAD_MX_RECORD = MX("IN", "MX", 10, Name("bad-response.example.com".split(".")))
+_DNE_MX_RECORD = MX("IN", "MX", 10, Name("does-not-exist.example.com".split(".")))
+_MX_RECORDS = [_MX_RECORD_1]
+
+_IPV4_RECORD_1 = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.1", 25))
+_IPV4_RECORD_2 = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.2", 25))
+_IPV6_RECORD = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 25))
+_BAD_IP_RECORD = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("BAD", 25))
+_IP_RECORDS = [_IPV4_RECORD_1, _IPV6_RECORD]
+
+_POSSIBLE_DNS_RESULTS = {
+    "test3.com": [_MX_RECORD_2],
+    "no-mx.example.com": NoAnswer(),
+    "does-not-exist.example.com": NXDOMAIN(),
+    "timeout.example.com": Timeout(),
+    "no-ns-servers.example.com": NoNameservers(),
+    "bad-response.example.com": [_BAD_MX_RECORD],
+    "no-lookup.example.com": [_DNE_MX_RECORD],
+}
+
+_POSSIBLE_IP_RESULTS = {
+    "test3.com": [_IPV4_RECORD_2],
+    "mx2.example.com": [_IPV4_RECORD_2],
+    "bad-response.example.com": [_BAD_IP_RECORD],
+    "does-not-exist.example.com": socket.gaierror(),
+    "192.0.2.254": socket.gaierror(),
+    "2001:db8:254": socket.gaierror(),
+}
+
+
+def mock_dns_query_result(qname, *args, **kwargs):
+    if qname in _POSSIBLE_DNS_RESULTS:
+        if isinstance(_POSSIBLE_DNS_RESULTS[qname], Exception):
+            raise _POSSIBLE_DNS_RESULTS[qname]
+        else:
+            return _POSSIBLE_DNS_RESULTS[qname]
+
+    return _MX_RECORDS
+
+
+def mock_ip_query_result(host, port, *args, **kwargs):
+    if host in _POSSIBLE_IP_RESULTS:
+        if isinstance(_POSSIBLE_IP_RESULTS[host], Exception):
+            raise _POSSIBLE_IP_RESULTS[host]
+        else:
+            return _POSSIBLE_IP_RESULTS[host]
+
+    return _IP_RECORDS

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -237,6 +237,7 @@ CKEDITOR_CONFIGS = {
 
 LOGGING = {
     'version': 1,
+    'disable_existing_loggers': False,
     'formatters': {
         'syslog': {
             'format': '%(name)s: %(levelname)s %(message)s'


### PR DESCRIPTION
- add support for looking up IPv6 addresses (socket.getaddrinfo)
- add support for International Domain Names in case the DNS reponse contains one
- when looking up an ip address, don't stop on the first failure check all addresses
- add logging for potential configuration errors:
    - DNS configuration errors (i.e. no MX records)
    - server name resolution errors (i.e. resolv.conf doesn't contain a working name server)
    - invalid values in MX records
- update mock results for tests