### PR TITLE
 Fix test database setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
 sudo: false
 
 addons:
+  postgresql: "9.3"
+  mysql: "5.5"
   apt:
     packages:
       - ldap-utils
@@ -29,8 +31,6 @@ services:
 
 before_install:
   - pip install codecov
-  - if [[ $DB = "POSTGRESQL" ]]; then pip install -q psycopg2; fi
-  - if [[ $DB = "MYSQL" ]]; then pip install -q mysqlclient; fi
 
 install:
   - pip install -q -r requirements.txt
@@ -39,10 +39,6 @@ install:
   - python setup.py -q develop
 
 before_script:
-  - if [[ $DB = "POSTGRESQL" ]]; then psql -c "CREATE DATABASE modoboa_test;" -U postgres; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE DATABASE IF NOT EXISTS modoboa_test;" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE USER 'modoboa'@'localhost' IDENTIFIED BY 'modoboa'" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'modoboa'@'localhost';" -uroot; fi
   - mkdir /tmp/slapd
   - slapd -f test_data/slapd.conf -h ldap://localhost:3389 &
   - sleep 3

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,17 +2,11 @@ comment:
   layout: header, changes, diff
 coverage:
   ignore:
-  - modoboa/core/migrations/*
-  - modoboa/core/tests.py
+  - **/migrations/*
+  - **/tests/*
+  - **/tests.py
   - modoboa/core/dev_settings.py
-  - modoboa/lib/migrations/*
-  - modoboa/lib/tests.py
-  - modoboa/admin/migrations/*
-  - modoboa/admin/tests/*
-  - modoboa/limits/migrations/*
-  - modoboa/limits/tests.py
-  - modoboa/relaydomains/migrations/*
-  - modoboa/relaydomains/tests.py
+  - modoboa/test_settings.py
   status:
     patch:
       default:

--- a/modoboa/test_settings.py
+++ b/modoboa/test_settings.py
@@ -5,49 +5,48 @@ from __future__ import unicode_literals
 import os
 
 # Database
-# https://docs.djangoproject.com/en/1.6/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
-DB = os.environ.get('DB', 'POSTGRES')
+DB = os.environ.get('DB', 'POSTGRESQL')
 
 if DB == 'MYSQL':
     DATABASES = {
-
         'default': {
             'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'modoboa_test',
-            'USER': 'modoboa',
-            'PASSWORD': 'modoboa',
+            'NAME': 'modoboa',
+            'USER': 'root',
+            'PASSWORD': '',
             'HOST': 'localhost',
             'PORT': '',
             'ATOMIC_REQUESTS': True,
-
+            # MySQL's Strict Mode fixes many data integrity problems in MySQL,
+            # such as data truncation upon insertion, by escalating warnings
+            # into errors. It is strongly recommended you activate it.
+            # MySQL >= 5.7 set STRICT_TRANS_TABLES by default
+            # See: https://docs.djangoproject.com/en/1.11/ref/databases/#mysql-sql-mode
+            'OPTIONS': {
+                'init_command': 'SET sql_mode=\'STRICT_TRANS_TABLES\'',
+            },
         },
-
     }
 elif DB == 'SQLITE':
     DATABASES = {
-
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'modoboa_test.db',
+            'NAME': 'modoboa.db',
             'PORT': '',
             'ATOMIC_REQUESTS': True,
-
         },
-
     }
 else:
     DATABASES = {
-
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'modoboa_test',
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'modoboa',
             'USER': 'postgres',
             'PASSWORD': '',
             'HOST': 'localhost',
             'PORT': '',
             'ATOMIC_REQUESTS': True,
-
         },
-
     }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,5 @@ mock==2.0.0
 httmock==1.2.5
 testfixtures==4.7.0
 tox
+psycopg2>=2.5.4
+mysqlclient>=1.3.3


### PR DESCRIPTION
Django automatically renames test databases to 'test_%s' % settings.DATABASES[*]["NAME"], so modoboa_test became test_modoboa_test. There's no point creating the database in `before script` as the test suite creates it.

https://docs.djangoproject.com/en/1.11/topics/testing/advanced/#django.db.connection.creation.create_test_db

- target oldest currently supported database servers, travis currently defaults to PostgreSQL 9.2 which isn't supported anymore.

- move database dependencies out of travis.yml into test_requirements.txt and pin to minimum versions recommended by django.
  See https://docs.djangoproject.com/en/1.11/ref/databases/

- use MySQL root user for tests, we already use the root user (postgres) for PostgreSQL.

- fix typo in modoboa/test_settings for DB variable, default should be POSTGRESQL not POSTGRES

- enable MySQL strict mode (on by default on MySQL >= 5.7)
  See https://docs.djangoproject.com/en/1.11/ref/databases/#mysql-sql-mode