### PR TITLE
MariaDB >= 10.2 requires mysqlclient >= 1.3.11

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -93,6 +93,10 @@ Install the corresponding Python binding:
 
   (env)> pip install mysqlclient
 
+.. note::
+
+   MariaDB 10.2 (and newer) require mysqlclient 1.3.11 (or newer).
+
 Then, create a user and a database:
 
 .. sourcecode:: bash


### PR DESCRIPTION
Documentation update to fix modoboa/modoboa-installer#136