### PR TITLE
Feature/deployment checks

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -73,5 +73,6 @@ Then, run the following commands:
    > cd <modoboa_instance_dir>
    > python manage.py migrate
    > python manage.py collectstatic
+   > python manage.py check --deploy
 
 Then, restart your web server.

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -31,6 +31,7 @@ Then, run the following commands:
    > cd <modoboa_instance_dir>
    > python manage.py migrate
    > python manage.py collectstatic
+   > python manage.py check --deploy
 
 Once done, check if the version you are installing requires
 :ref:`specific_upgrade_instructions`.
@@ -72,6 +73,7 @@ Then, run the following commands:
    > cd <modoboa_instance_dir>
    > python manage.py migrate
    > python manage.py collectstatic
+   > python manage.py check --deploy
 
 Finally, restart your web server.
 

--- a/modoboa/core/apps.py
+++ b/modoboa/core/apps.py
@@ -29,6 +29,8 @@ class CoreConfig(AppConfig):
     def ready(self):
         load_core_settings()
 
+        # Import these to force registration of checks and signals
+        from . import checks  # noqa:F401
         from . import handlers
 
         signals.post_migrate.connect(handlers.create_local_config, sender=self)

--- a/modoboa/core/checks/__init__.py
+++ b/modoboa/core/checks/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# Import these to force registration of checks
+from . import settings_checks  # noqa:F401

--- a/modoboa/core/checks/settings_checks.py
+++ b/modoboa/core/checks/settings_checks.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.core.checks import Warning, register
+from django.utils.translation import ugettext as _
+
+
+W001 = Warning(
+    _("You have USE_TZ set to False, this may result in issues during "
+      "transitions between summer/winter time (ie the same local time occuring "
+      "twice due to clock change)."),
+    hint=_("Set `USE_TZ = True` in settings.py"),
+    id="modoboa.W001",
+)
+
+
+@register(deploy=True)
+def check_use_tz_enabled(app_configs, **kwargs):
+    """Ensure USE_TZ is enabled in settings.py
+
+    When USE_TZ is enabled all date/times are stored in UTC.
+    Fixes #1086 - https://github.com/modoboa/modoboa/issues/1086
+    """
+    errors = []
+    if not settings.USE_TZ:
+        errors.append(W001)
+    return errors

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -295,6 +295,10 @@ LOGGING = {
     }
 }
 
+SILENCED_SYSTEM_CHECKS = [
+    "security.W019",  # modoboa uses iframes to display e-mails
+]
+
 # Load settings from extensions
 {% for extension in extra_settings %}
 try:

--- a/modoboa/core/tests/test_checks.py
+++ b/modoboa/core/tests/test_checks.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from ..checks import settings_checks
+
+
+class CheckSessionCookieSecureTest(SimpleTestCase):
+    @override_settings(USE_TZ=False)
+    def test_use_tz_false(self):
+        """If USE_TZ is off provide one warning."""
+        self.assertEqual(
+            settings_checks.check_use_tz_enabled(None),
+            [settings_checks.W001]
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_use_tz_true(self):
+        """If USE_TZ is on, there's no warning about it."""
+        self.assertEqual(settings_checks.check_use_tz_enabled(None), [])


### PR DESCRIPTION
Add a system check to ensue USE_TZ is enabled,  if its not enabled errors can occur during summer/winter time transitions due to the local time occurring twice. When USE_TZ is enabled all times are stored in UTC to avoid this issue.

Fixes #1086