### PR TITLE
improve e-mail address splitting functions

### DIFF
--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -271,7 +271,7 @@ def split_address(address):
         local_part = address
         domain = None
     else:
-        local_part, domain = address.split("@", 1)
+        local_part, domain = address.rsplit("@", 1)
     return (local_part, domain)
 
 

--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import email
 from email.header import Header
 from email.mime.text import MIMEText
-from email.utils import make_msgid, formatdate, parseaddr
+from email.utils import make_msgid, formataddr, formatdate, getaddresses
 import re
 import smtplib
 import time
@@ -341,22 +341,18 @@ def decode(string, encodings=None, charset=None):
 def prepare_addresses(addresses, usage="header"):
     """Prepare addresses before using them
 
-    FIXME: We need a real address parser here! If a name contains a
-    separator, it creates two wrong addresses.
-
     :param list addresses: a list of addresses
     :param string usage: how those addresses are going to be used
     :return: a string or a list depending on usage value
     """
     result = []
-    for address in re.split('[,;]', addresses):
+    for name, address in getaddresses(addresses):
         if not address:
             continue
-        name, addr = parseaddr(address)
         if name and usage == "header":
-            result.append("%s <%s>" % (Header(name, 'utf8'), addr))
+            result.append(formataddr((name, address)))
         else:
-            result.append(addr)
+            result.append(address)
     if usage == "header":
         return ",".join(result)
     return result

--- a/modoboa/lib/tests/test_email_utils.py
+++ b/modoboa/lib/tests/test_email_utils.py
@@ -9,7 +9,7 @@ import os
 from django.test import SimpleTestCase
 from django.utils.encoding import smart_bytes, smart_text
 
-from ..email_utils import Email
+from ..email_utils import Email, split_address, split_local_part
 
 SAMPLES_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), "sample_messages"))
@@ -106,3 +106,50 @@ class EmailTests(SimpleTestCase):
     def test_email_multipart_without_links(self):
         """display the text/html part of a multipart message with links removed"""
         self._test_email("multipart", dformat="html", links=False)
+
+
+class EmailAddressParserTests(SimpleTestCase):
+
+    """Tests for split_address() and split_local_part()."""
+
+    def test_split_address_with_domain(self):
+        """Split an e-mail address with domain."""
+        address = "User@sub.exAMPLE.COM"
+        expected_output = ("User", "sub.exAMPLE.COM")
+        output = split_address(address)
+        self.assertEqual(output, expected_output)
+
+    def test_split_address_without_domain(self):
+        """Split an e-mail address with domain."""
+        address = "User"
+        expected_output = ("User", None)
+        output = split_address(address)
+        self.assertEqual(output, expected_output)
+
+    def test_split_local_part_without_delimiter(self):
+        """Split a local part without delimiter."""
+        local_part = "User+Foo"
+        expected_output = ("User+Foo", None)
+        output = split_local_part(local_part)
+        self.assertEqual(output, expected_output)
+
+    def test_split_local_part_with_delimiter(self):
+        """Split a local part with delimiter."""
+        local_part = "User+Foo"
+        expected_output = ("User", "Foo")
+        output = split_local_part(local_part, "+")
+        self.assertEqual(output, expected_output)
+
+    def test_split_local_part_mailing_list_address(self):
+        """Check special case addresses used by mailing lists."""
+        local_part = "owner-modoboa"
+        expected_output = ("owner-modoboa", None)
+        output = split_local_part(local_part, "-")
+        self.assertEqual(output, expected_output)
+
+    def test_split_local_part_special_address(self):
+        """Check special case addresses."""
+        local_part = "mailer-daemon"
+        expected_output = ("mailer-daemon", None)
+        output = split_local_part(local_part, "-")
+        self.assertEqual(output, expected_output)

--- a/modoboa/lib/tests/test_email_utils.py
+++ b/modoboa/lib/tests/test_email_utils.py
@@ -9,7 +9,8 @@ import os
 from django.test import SimpleTestCase
 from django.utils.encoding import smart_bytes, smart_text
 
-from ..email_utils import Email, split_address, split_local_part
+from ..email_utils import (
+    Email, prepare_addresses, split_address, split_local_part)
 
 SAMPLES_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), "sample_messages"))
@@ -152,4 +153,34 @@ class EmailAddressParserTests(SimpleTestCase):
         local_part = "mailer-daemon"
         expected_output = ("mailer-daemon", None)
         output = split_local_part(local_part, "-")
+        self.assertEqual(output, expected_output)
+
+    def test_prepare_addresses(self):
+        """Check a list of e-mail addresses is sepearted correctly."""
+        # value is an array with one long string not 3 sepearte values.
+        value = [
+            "\"Doe, John\" <doe.john@sub.example.com>;"
+            "\"John Smith\" <john.smith@sub.example.com>,"
+            "admin@sub.example.com"
+        ]
+        expected_output = "\"Doe, John\" <doe.john@sub.example.com>,"\
+                          "John Smith <john.smith@sub.example.com>,"\
+                          "admin@sub.example.com"
+        output = prepare_addresses(value)
+        self.assertEqual(output, expected_output)
+
+    def test_prepare_addresses_usage_envelope(self):
+        """Check a list of e-mail addresses is sepearted correctly."""
+        # value is an array with one long string not 3 sepearte values.
+        value = [
+            "\"Doe, John\" <doe.john@sub.example.com>;"
+            "\"John Smith\" <john.smith@sub.example.com>,"
+            "admin@sub.example.com"
+        ]
+        expected_output = [
+            "doe.john@sub.example.com",
+            "john.smith@sub.example.com",
+            "admin@sub.example.com",
+        ]
+        output = prepare_addresses(value, usage="envelope")
         self.assertEqual(output, expected_output)


### PR DESCRIPTION
I've kept `split_address()` and `split_local_part()` for the modoboa-amavis code to work.

Needed for modoboa/modoboa-amavis#89
