### PR TITLE
disable client side form validation (#1370)

### DIFF
--- a/modoboa/core/templates/core/parameters.html
+++ b/modoboa/core/templates/core/parameters.html
@@ -1,6 +1,6 @@
 {% load i18n lib_tags %}
 <h2>{% trans "Parameters" %} <small>{% trans "Configure Modoboa" %}</small></h2><hr />
-<form id="parameters_form" method="POST" action="{% url 'core:parameters' %}" class="form-horizontal">{% csrf_token %}
+<form id="parameters_form" method="POST" action="{% url 'core:parameters' %}" class="form-horizontal" novalidate>{% csrf_token %}
   {% include "parameters/base_form.html" %}
   <hr>
   <button type="submit" class="btn btn-primary col-xs-offset-4 col-xs-4" name="update">{% trans 'Save' %}</button>


### PR DESCRIPTION
client side form validation currently fails if there's an error on a
tab that's not visible.

#1370
#1371
