### PR TITLE
#1417 psycopg2 binary package has been renamed to psycopg2-binary

### DIFF
--- a/postgresql-requirements.txt
+++ b/postgresql-requirements.txt
@@ -1,1 +1,1 @@
-psycopg2>=2.5.4
+psycopg2-binary>=2.7.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ mock==2.0.0
 httmock==1.2.5
 testfixtures==4.7.0
 tox
-psycopg2>=2.5.4
+psycopg2-binary>=2.7.4
 mysqlclient>=1.3.3


### PR DESCRIPTION
also bump the minimum version to 2.7.4 as this is when the psycopg2-binary became available.

See #1417 and http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/
