### PR TITLE
fix import command

### DIFF
--- a/modoboa/admin/management/commands/subcommands/_export.py
+++ b/modoboa/admin/management/commands/subcommands/_export.py
@@ -6,13 +6,17 @@ from __future__ import unicode_literals
 
 import sys
 
-from backports import csv
-
 from django.core.management.base import BaseCommand
+from django.utils import six
 
 from modoboa.core.extensions import exts_pool
 from modoboa.core.models import User
 from .... import models
+
+if six.PY2:
+    from backports import csv
+else:
+    import csv
 
 
 class ExportCommand(BaseCommand):

--- a/modoboa/admin/management/commands/subcommands/_import.py
+++ b/modoboa/admin/management/commands/subcommands/_import.py
@@ -8,7 +8,6 @@ import io
 import os
 
 import progressbar
-from backports import csv
 
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import six
@@ -17,6 +16,11 @@ from modoboa.core import models as core_models
 from modoboa.core.extensions import exts_pool
 from modoboa.lib.exceptions import Conflict
 from .... import signals
+
+if six.PY2:
+    from backports import csv
+else:
+    import csv
 
 
 class ImportCommand(BaseCommand):

--- a/modoboa/admin/tests/test_data/import_domains.csv
+++ b/modoboa/admin/tests/test_data/import_domains.csv
@@ -1,0 +1,2 @@
+domain;domain1.com;1000;100;True
+domain;dómain2.com;2000;200;True

--- a/modoboa/admin/tests/test_data/import_domains_duplicates.csv
+++ b/modoboa/admin/tests/test_data/import_domains_duplicates.csv
@@ -1,0 +1,3 @@
+domain;domain1.com;1000;100;True
+domain;dómain2.com;2000;200;True
+domain;dómain2.com;2000;200;True

--- a/modoboa/admin/views/export.py
+++ b/modoboa/admin/views/export.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-from backports import csv
 from rfc6266 import build_header
 
 from django.contrib.auth.decorators import (
@@ -18,6 +17,11 @@ from django.utils.translation import ugettext as _
 
 from ..forms import ExportDomainsForm, ExportIdentitiesForm
 from ..lib import get_domains, get_identities
+
+if six.PY2:
+    from backports import csv
+else:
+    import csv
 
 
 def _export(content, filename):

--- a/modoboa/admin/views/import_.py
+++ b/modoboa/admin/views/import_.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import io
 
-from backports import csv
 from reversion import revisions as reversion
 
 from django.contrib.auth.decorators import (
@@ -15,12 +14,18 @@ from django.contrib.auth.decorators import (
 from django.db import transaction
 from django.shortcuts import render
 from django.urls import reverse
+from django.utils import six
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 
 from modoboa.lib.exceptions import Conflict, ModoboaException
 from .. import signals
 from ..forms import ImportDataForm, ImportIdentitiesForm
+
+if six.PY2:
+    from backports import csv
+else:
+    import csv
 
 
 @reversion.create_revision()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ pytz
 requests
 rfc6266
 lxml
-backports.csv
+backports.csv; python_version < '3'
 chardet


### PR DESCRIPTION
I can't replicate the issue in #1430, but here's a couple of changes  that might fix it.

- ensure command line args are unicode(py2)/str(py3)

- use io.open to open file with utf8 encoding

- set newlines="" in open commands, csv module takes care of line endings

- add tests for import command
