### PR TITLE
 revert #1439 changes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 django-bower
 django-debug-toolbar
-packaging

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ from __future__ import unicode_literals
 import io
 from os import path
 
-from pip.req import parse_requirements
+try:
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10
+    from pip._internal.req import parse_requirements
+
 from setuptools import find_packages, setup
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,21 +13,21 @@ from __future__ import unicode_literals
 import io
 from os import path
 
-from packaging.requirements import Requirement
+from pip.req import parse_requirements
 from setuptools import find_packages, setup
 
 
 def get_requirements(requirements_file):
-    """Parse requirements file."""
+    """Use pip to parse requirements file."""
     requirements = []
     if path.isfile(requirements_file):
-        with io.open(requirements_file, encoding="utf-8") as fp:
-            for line in fp:
-                if line.startswith("#") or line.strip() == "":
-                    continue
-                req = Requirement(line)
-                if req.marker is None or req.marker.evaluate():
-                    requirements.append('%s%s' % (req.name, req.specifier))
+        for req in parse_requirements(requirements_file, session="hack"):
+            # check markers, such as
+            #
+            #     rope_py3k    ; python_version >= '3.0'
+            #
+            if req.match_markers():
+                requirements.append(str(req.req))
     return requirements
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ testfixtures==4.7.0
 tox
 psycopg2-binary>=2.7.4
 mysqlclient>=1.3.3
-packaging


### PR DESCRIPTION
Adding external dependencies to `setup.py` was a bad idea, for now continue to use pip internal functions until a better solution can be found.