### PR TITLE
prefer standard library version of mock over back port

### DIFF
--- a/modoboa/admin/tests/test_api.py
+++ b/modoboa/admin/tests/test_api.py
@@ -8,7 +8,6 @@ import copy
 import json
 
 import dns.resolver
-from mock import patch
 
 from django.test import override_settings
 from django.urls import reverse
@@ -20,6 +19,13 @@ from modoboa.core import factories as core_factories, models as core_models
 from modoboa.lib.tests import ModoAPITestCase
 from . import utils
 from .. import factories, models
+
+try:
+    # mock is part of the Python (>= 3.3) standard library
+    from unittest import mock
+except ImportError:
+    # fall back to the mock backport
+    import mock
 
 
 class DomainAPITestCase(ModoAPITestCase):
@@ -71,8 +77,8 @@ class DomainAPITestCase(ModoAPITestCase):
             url, {"name": "test4.com", "default_mailbox_quota": 10})
         self.assertEqual(response.status_code, 403)
 
-    @patch.object(dns.resolver.Resolver, "query")
-    @patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("socket.getaddrinfo")
     def test_create_domain_with_mx_check(self, mock_getaddrinfo, mock_query):
         """Check domain creation when MX check is activated."""
         self.set_global_parameter("enable_admin_limits", False, app="limits")

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -9,7 +9,6 @@ import shutil
 import tempfile
 
 import dns.resolver
-from mock import patch
 from testfixtures import compare
 
 from django.core.management import call_command
@@ -23,6 +22,13 @@ from modoboa.lib.tests import ModoTestCase
 from . import utils
 from .. import factories
 from ..models import Alias, Domain
+
+try:
+    # mock is part of the Python (>= 3.3) standard library
+    from unittest import mock
+except ImportError:
+    # fall back to the mock backport
+    import mock
 
 
 class DomainTestCase(ModoTestCase):
@@ -205,8 +211,8 @@ class DomainTestCase(ModoTestCase):
         self.assertContains(response, "value=\"500\"")
         self.assertContains(response, "value=\"50\"")
 
-    @patch.object(dns.resolver.Resolver, "query")
-    @patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("socket.getaddrinfo")
     def test_create_and_check_mx(self, mock_getaddrinfo, mock_query):
         """Check for authorized MX record."""
         reseller = core_factories.UserFactory(

--- a/modoboa/admin/tests/test_import_.py
+++ b/modoboa/admin/tests/test_import_.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import dns.resolver
-from mock import patch
 
 from django.core.files.base import ContentFile
 from django.urls import reverse
@@ -14,6 +13,13 @@ from modoboa.lib.tests import ModoTestCase
 from . import utils
 from .. import factories
 from ..models import Alias, Domain, DomainAlias
+
+try:
+    # mock is part of the Python (>= 3.3) standard library
+    from unittest import mock
+except ImportError:
+    # fall back to the mock backport
+    import mock
 
 
 class ImportTestCase(ModoTestCase):
@@ -78,8 +84,8 @@ domainalias; domalias1.com; domain1.com; True
             response,
             "Default mailbox quota cannot be greater than domain quota")
 
-    @patch.object(dns.resolver.Resolver, "query")
-    @patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("socket.getaddrinfo")
     def test_domain_import_with_mx_check(self, mock_getaddrinfo, mock_query):
         """Check domain import when MX check is enabled."""
         reseller = core_factories.UserFactory(

--- a/modoboa/admin/tests/test_mailbox_operations.py
+++ b/modoboa/admin/tests/test_mailbox_operations.py
@@ -8,14 +8,19 @@ import os
 import shutil
 import tempfile
 
-import mock
-
 from django.core.management import call_command
 from django.test import override_settings
 from django.urls import reverse
 
 from modoboa.lib.tests import ModoTestCase
 from .. import factories, models
+
+try:
+    # mock is part of the Python (>= 3.3) standard library
+    from unittest import mock
+except ImportError:
+    # fall back to the mock backport
+    import mock
 
 
 @override_settings(

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import dns.resolver
-from mock import patch
 from testfixtures import LogCapture
 
 from django.core import mail, management
@@ -18,6 +17,13 @@ from modoboa.lib.tests import ModoTestCase
 from . import utils
 from .. import factories, models
 from ..lib import get_domain_mx_list
+
+try:
+    # mock is part of the Python (>= 3.3) standard library
+    from unittest import mock
+except ImportError:
+    # fall back to the mock backport
+    import mock
 
 
 class MXTestCase(ModoTestCase):
@@ -49,9 +55,9 @@ class MXTestCase(ModoTestCase):
         cls.localconfig.save()
         models.MXRecord.objects.all().delete()
 
-    @patch("gevent.socket.gethostbyname")
-    @patch("socket.getaddrinfo")
-    @patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("gevent.socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
     def test_management_command(
             self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check that command works fine."""
@@ -77,9 +83,9 @@ class MXTestCase(ModoTestCase):
         qs = models.MXRecord.objects.filter(domain=self.domain)
         self.assertEqual(id_, qs[0].id)
 
-    @patch("gevent.socket.gethostbyname")
-    @patch("socket.getaddrinfo")
-    @patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("gevent.socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
     def test_single_domain_update(
             self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Update only one domain."""
@@ -102,8 +108,8 @@ class MXTestCase(ModoTestCase):
         management.call_command(
             "modo", "check_mx", "--domain", "toto.com")
 
-    @patch("socket.getaddrinfo")
-    @patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
     def test_get_domain_mx_list_logging(self, mock_query, mock_getaddrinfo):
         mock_query.side_effect = utils.mock_dns_query_result
         mock_getaddrinfo.side_effect = utils.mock_ip_query_result
@@ -149,9 +155,9 @@ class DNSBLTestCase(ModoTestCase):
             name="modoboa.com", enable_dns_checks=False)
         models.DNSBLResult.objects.all().delete()
 
-    @patch("gevent.socket.gethostbyname")
-    @patch("socket.getaddrinfo")
-    @patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("gevent.socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
     def test_management_command(
             self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check that command works fine."""
@@ -170,9 +176,9 @@ class DNSBLTestCase(ModoTestCase):
         self.assertFalse(self.domain.uses_a_reserved_tld)
         self.assertTrue(self.domain2.uses_a_reserved_tld)
 
-    @patch("gevent.socket.gethostbyname")
-    @patch("socket.getaddrinfo")
-    @patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("gevent.socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
     def test_notifications(
             self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check notifications."""
@@ -186,9 +192,9 @@ class DNSBLTestCase(ModoTestCase):
                 print(message.subject)
         self.assertEqual(len(mail.outbox), 2)
 
-    @patch("gevent.socket.gethostbyname")
-    @patch("socket.getaddrinfo")
-    @patch.object(dns.resolver.Resolver, "query")
+    @mock.patch("gevent.socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "query")
     def test_management_command_no_dnsbl(
             self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
         """Check that command works fine without dnsbl."""

--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -7,14 +7,19 @@ from __future__ import unicode_literals
 import smtplib
 from unittest import skipIf
 
-from mock import patch
-
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
 from modoboa.lib.tests import NO_SMTP, ModoTestCase
 from .. import factories, models
+
+try:
+    # mock is part of the Python (>= 3.3) standard library
+    from unittest import mock
+except ImportError:
+    # fall back to the mock backport
+    import mock
 
 
 class AuthenticationTestCase(ModoTestCase):
@@ -123,24 +128,24 @@ class SMTPAuthenticationTestCase(ModoTestCase):
         self.assertTrue(
             models.User.objects.filter(username=username).exists())
 
-    @patch("smtplib.SMTP")
+    @mock.patch("smtplib.SMTP")
     def test_smtp_authentication(self, mock_smtp):
         """Check simple SMTP authentication."""
         self._test_smtp_authentication(mock_smtp)
 
-    @patch("smtplib.SMTP_SSL")
+    @mock.patch("smtplib.SMTP_SSL")
     @override_settings(AUTH_SMTP_SECURED_MODE="ssl")
     def test_smtp_authentication_over_ssl(self, mock_smtp):
         """Check SMTP authentication over SSL."""
         self._test_smtp_authentication(mock_smtp)
 
-    @patch("smtplib.SMTP")
+    @mock.patch("smtplib.SMTP")
     @override_settings(AUTH_SMTP_SECURED_MODE="starttls")
     def test_smtp_authentication_over_starttls(self, mock_smtp):
         """Check SMTP authentication over STARTTLS."""
         self._test_smtp_authentication(mock_smtp)
 
-    @patch("smtplib.SMTP")
+    @mock.patch("smtplib.SMTP")
     def test_smtp_authentication_failure(self, mock_smtp):
         """Check SMTP authentication failure."""
         instance = mock_smtp.return_value

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 factory-boy>=2.4
-mock==2.0.0
+mock==2.0.0; python_version < '3.3'
 httmock==1.2.5
 testfixtures==4.7.0
 tox


### PR DESCRIPTION
In python >=3.3 mock is included in the Python standard library (`unittest.mock`).