### PR TITLE
[Django 2.0]  Django instance namespace without app namespace is depreciated

### DIFF
--- a/modoboa/admin/urls.py
+++ b/modoboa/admin/urls.py
@@ -12,6 +12,8 @@ from .views import (
     identity as identity_views, import_ as import_views
 )
 
+app_name = "admin"
+
 urlpatterns = [
     url(r'^$', domain_views.index, name="index"),
     url(r'^domains/$', domain_views.domains, name="domain_list"),

--- a/modoboa/core/extensions.py
+++ b/modoboa/core/extensions.py
@@ -25,6 +25,8 @@ class ModoExtension(object):
     always_active = False
     url = None
     topredirection_url = None
+    # TODO: remove `url_namespace_required` when all extensions have been fixed.
+    url_namespace_required = True
 
     def get_url(self):
         """Return extension base url."""
@@ -113,8 +115,11 @@ class ExtensionsPool(object):
                 pattern = "{}.urls_api"
             else:
                 root = r"^{}/".format(ext.get_url())
-                options.update({"namespace": ext_name})
                 pattern = "{}.urls"
+                # TODO remove `url_namespace_required` when all extensions have
+                # been fixed.
+                if ext.url_namespace_required:
+                    options["namespace"] = ext_name
             try:
                 result.append(
                     url(root, include(pattern.format(ext_name), **options))

--- a/modoboa/core/tests/stupid_extension_2/modo_extension.py
+++ b/modoboa/core/tests/stupid_extension_2/modo_extension.py
@@ -14,6 +14,7 @@ class StupidExtension2(extensions.ModoExtension):
     label = "Stupid extension"
     version = "1.0.0"
     description = "A stupid extension"
+    url_namespace_required = False
 
 
 extensions.exts_pool.register_extension(StupidExtension2, show=False)

--- a/modoboa/core/tests/stupid_extension_2/urls.py
+++ b/modoboa/core/tests/stupid_extension_2/urls.py
@@ -8,6 +8,8 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = "stupid_extension_2"
+
 urlpatterns = [
     url("^$", views.test_view, name="index")
 ]

--- a/modoboa/core/urls.py
+++ b/modoboa/core/urls.py
@@ -8,6 +8,8 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = "core"
+
 urlpatterns = [
     url(r'^$', views.RootDispatchView.as_view(), name="root"),
     url(r'^dashboard/$', views.DashboardView.as_view(), name="dashboard"),

--- a/modoboa/urls.py
+++ b/modoboa/urls.py
@@ -26,9 +26,9 @@ urlpatterns = [
         name="ckeditor_upload"),
     url(r'^ckeditor/browse/', login_required(cku_views.browse),
         name="ckeditor_browse"),
-    url("", include("modoboa.core.urls", namespace="core")),
+    url("", include("modoboa.core.urls")),
     url("^user/forward/", forward, name="user_forward"),
-    url("admin/", include("modoboa.admin.urls", namespace="admin")),
+    url("admin/", include("modoboa.admin.urls")),
     # No namespace
     url(r'^accounts/password_reset/$', core_views.password_reset,
         name="password_reset"),
@@ -53,7 +53,7 @@ if extra_routes:
 # API urls
 urlpatterns += [
     url("^docs/api/", include_docs_urls(title=API_TITLE, public=False)),
-    url("^api/v1/", include("modoboa.urls_api", namespace="api")),
+    url("^api/v1/", include("modoboa.urls_api")),
 ]
 
 if settings.DEBUG:

--- a/modoboa/urls_api.py
+++ b/modoboa/urls_api.py
@@ -8,6 +8,8 @@ from django.conf.urls import include, url
 
 from modoboa.core.extensions import exts_pool
 
+app_name = "api"
+
 urlpatterns = [
     url("", include("modoboa.admin.urls_api")),
     url("", include("modoboa.limits.urls_api")),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ dj-database-url
 
 coreapi==2.3.3
 coreapi-cli==1.0.6
-djangorestframework==3.7.3
+djangorestframework==3.7.7
 
 # bcrypt requires libffi-dev
 bcrypt==3.1.4


### PR DESCRIPTION
Fix the last `RemovedInDjango20Warning`.

`url_namespace_required ` in `ModoExtension` provides compatibility until all the extensions have been fixed then the `url_namespace_required ` code can be removed.

See https://docs.djangoproject.com/en/1.11/ref/urls/#include