### PR TITLE
postgresql_psycopg2 is now an alias for postgresql

### DIFF
--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -135,7 +135,7 @@ class DeployCommand(Command):
             info["NAME"] = "%s.db" % name
             return info
         if info["ENGINE"] == "postgres":
-            info["ENGINE"] = "django.db.backends.postgresql_psycopg2"
+            info["ENGINE"] = "django.db.backends.postgresql"
             default_port = 5432
         else:
             info["ENGINE"] = "django.db.backends.mysql"

--- a/modoboa/core/management/commands/generate_postfix_maps.py
+++ b/modoboa/core/management/commands/generate_postfix_maps.py
@@ -99,7 +99,7 @@ query = {{ query|safe }}
             if dburl else settings.DATABASES["default"])
         if "sqlite" in db_settings["ENGINE"]:
             dbtype = "sqlite"
-        elif "psycopg2" in db_settings["ENGINE"]:
+        elif "postgresql" in db_settings["ENGINE"]:
             dbtype = "postgres"
         else:
             dbtype = "mysql"


### PR DESCRIPTION
Won't be removed until Django 3 but might as well fix it as it's been an alias since Django 1.9.