### PR TITLE
add missing optional dependency used by ckeditor for attaching images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ gevent==1.2.2
 ipaddress; python_version < '3.3'
 jsonfield==2.0.2
 passlib==1.7.1
+Pillow  # Optional dependency for django-ckeditor
 progressbar33==2.4
 py-dateutil==2.2
 cryptography


### PR DESCRIPTION
Attaching an image to an e-mail in webmail causes an `Internal Server Error` because Pillow an optional dependency for ckeditor is missing.

As django-ckeditor is in modoboas `requirements.txt` I've included it here and not in modoboa-webmail.