### PR TITLE
Convert options[sepchar] into string. Fixes #1483

### DIFF
--- a/modoboa/admin/management/commands/subcommands/_export.py
+++ b/modoboa/admin/management/commands/subcommands/_export.py
@@ -60,5 +60,5 @@ class ExportCommand(BaseCommand):
 
     def handle(self, *args, **options):
         exts_pool.load_all()
-        self.csvwriter = csv.writer(sys.stdout, delimiter=options["sepchar"])
+        self.csvwriter = csv.writer(sys.stdout, delimiter=unicode(options["sepchar"]))
         getattr(self, "export_{}".format(options["objtype"]))()


### PR DESCRIPTION
Signed-off-by: Gui Iribarren <guido@codigosur.org>

Fixes 'TypeError: "delimiter" must be string, not bytes'