### PR TITLE
Docs for manual installation: Added update_statistics call to cron.

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -193,6 +193,7 @@ following content inside::
 
   # Logs parsing
   */5     *       *       *       *       root    $PYTHON $INSTANCE/manage.py logparser &> /dev/null
+  0       *       *       *       *       root    $PYTHON $INSTANCE/manage.py update_statistics
 
   # DNSBL checks
   */30    *       *       *       *       root    $PYTHON $INSTANCE/manage.py modo check_mx


### PR DESCRIPTION
Docs for manual installation are missing the update_statistics call in crontab.

It has been added to the installer with [this commit](https://github.com/modoboa/modoboa-installer/commit/6c6945c11b8763851732041e3c2fbd4abda44107) so I guess it should be added here too.