### PR TITLE
Cant Upload Attachment ( FIle too Big)

### DIFF
--- a/modoboa/lib/web_utils.py
+++ b/modoboa/lib/web_utils.py
@@ -115,7 +115,7 @@ def size2integer(value):
     :return: the corresponding integer value
     """
     m = re.match(r"(\d+)\s*(\w+)", value)
-    if m is None:
+    if m.group(2)[0] == "0":
         if re.match(r"\d+", value):
             return int(value)
         return 0


### PR DESCRIPTION


size2 integer was returning 0 when called with int values.

Description of the issue/feature this PR addresses:
https://github.com/modoboa/modoboa-webmail/issues/170

Current behavior before PR:
size2 integer was returning 0 when called with int values.

Desired behavior after PR is merged:
size2 integer returns the int value it was called with.