### PR TITLE
Bugfix: DKIM checks fail

### DIFF
--- a/modoboa/dnstools/lib.py
+++ b/modoboa/dnstools/lib.py
@@ -200,7 +200,7 @@ def check_dkim_syntax(record):
     key = None
     for tag in record.split(";")[1:]:
         tag = tag.strip(" ")
-        parts = tag.split("=",1)
+        parts = tag.split("=", 1)
         if len(parts) != 2:
             raise DNSSyntaxError(_("Invalid tag {}").format(tag))
         name = parts[0].strip(" ")

--- a/modoboa/dnstools/lib.py
+++ b/modoboa/dnstools/lib.py
@@ -200,7 +200,7 @@ def check_dkim_syntax(record):
     key = None
     for tag in record.split(";")[1:]:
         tag = tag.strip(" ")
-        parts = tag.split("=")
+        parts = tag.split("=",1)
         if len(parts) != 2:
             raise DNSSyntaxError(_("Invalid tag {}").format(tag))
         name = parts[0].strip(" ")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The DKIM key is base64 encoded, meaning it can end with "=" signs
Split on "=" and check if you have 2 'parts' (key and value) will fail in these cases.
By using split("=",1) we make sure we only slit on the first occurence of the "=" sign
(solves modoboa#1647 and partially modoboa#1640 and modoboa#1642)

Current behavior before PR:
DKIM checks fail

Desired behavior after PR is merged:
DKIM checks work