### PR TITLE
dnstools: ignore extra spaces in records.

### DIFF
--- a/modoboa/dnstools/lib.py
+++ b/modoboa/dnstools/lib.py
@@ -165,6 +165,8 @@ def check_spf_syntax(record):
     modifiers = []
     mechanisms = []
     for part in parts:
+        if part == "":
+            continue
         qualifier = None
         if part[0] in ["+", "-", "~", "?"]:
             qualifier = part[0]
@@ -200,6 +202,8 @@ def check_dkim_syntax(record):
     key = None
     for tag in record.split(";")[1:]:
         tag = tag.strip(" ")
+        if tag == "":
+            continue
         parts = tag.split("=", 1)
         if len(parts) != 2:
             raise DNSSyntaxError(_("Invalid tag {}").format(tag))
@@ -250,6 +254,8 @@ def check_dmarc_syntax(record):
         raise DNSSyntaxError(_("Not a valid DMARC record"))
     tags = {}
     for tag in record.split(";")[1:]:
+        if tag == "":
+            continue
         tag = tag.strip(" ")
         parts = tag.split("=")
         if len(parts) != 2:

--- a/modoboa/dnstools/tests.py
+++ b/modoboa/dnstools/tests.py
@@ -44,7 +44,7 @@ GOOD_SPF_RECORDS = [
     "v=spf1 ptr -all",
     "v=spf1 ptr:otherdomain.com -all",
     "v=spf1 exists:example.com -all",
-    "v=spf1 include:example.com -all",
+    "v=spf1 include:example.com  -all",
     "v=spf1 ?include:example.com -all",
     "v=spf1 redirect=example.com",
     "v=spf1 exp=example.com",

--- a/modoboa/dnstools/tests.py
+++ b/modoboa/dnstools/tests.py
@@ -65,7 +65,7 @@ BAD_DMARC_RECORDS = [
 ]
 
 GOOD_DMARC_RECORDS = [
-    "v=DMARC1; p=reject; pct=100",
+    "v=DMARC1; p=reject;; pct=100",
     "v=DMARC1; p=quarantine; sp=none; adkim=s; aspf=s; "
     "rua=mailto:dmarc-aggrep@ngyn.org; ruf=mailto:toto@test.com!24m; "
     "rf=afrf; pct=100; ri=86400"
@@ -74,7 +74,7 @@ GOOD_DMARC_RECORDS = [
 BAD_DKIM_RECORDS = [
     ("", "Not a valid DKIM record"),
     ("v=DKIM1; toto;p=XXX", "Invalid tag toto"),
-    ("v=DKIM1;k=rsa", "No key found in record"),
+    ("v=DKIM1;;k=rsa", "No key found in record"),
 ]
 
 

--- a/mysql-requirements.txt
+++ b/mysql-requirements.txt
@@ -1,1 +1,1 @@
-mysqlclient>=1.3.11
+mysqlclient<=1.3.99


### PR DESCRIPTION
fix #1657 