### PR TITLE
fix regression that caused the rounds parameter to be ignored

### DIFF
--- a/modoboa/core/password_hashers/advanced.py
+++ b/modoboa/core/password_hashers/advanced.py
@@ -36,8 +36,7 @@ class BLFCRYPTHasher(PasswordHasher):
         # rounds = parameters.get_global_parameter("rounds_number")
         # To get around this, I use the default of 12.
         rounds = 12
-        bcrypt.using(rounds=rounds)
-        return bcrypt.hash(clearvalue)
+        return bcrypt.hash(clearvalue, rounds=rounds)
 
     def verify(self, clearvalue, hashed_value):
         return bcrypt.verify(clearvalue, hashed_value)
@@ -82,8 +81,7 @@ class SHA256CRYPTHasher(PasswordHasher):
 
     def _encrypt(self, clearvalue, salt=None):
         rounds = param_tools.get_global_parameter("rounds_number")
-        sha256_crypt.using(rounds=rounds)
-        return sha256_crypt.hash(clearvalue)
+        return sha256_crypt.hash(clearvalue, rounds=rounds)
 
     def verify(self, clearvalue, hashed_value):
         return sha256_crypt.verify(clearvalue, hashed_value)
@@ -106,8 +104,7 @@ class SHA512CRYPTHasher(PasswordHasher):
 
     def _encrypt(self, clearvalue, salt=None):
         rounds = param_tools.get_global_parameter("rounds_number")
-        sha512_crypt.using(rounds=rounds)
-        return sha512_crypt.hash(clearvalue)
+        return sha512_crypt.hash(clearvalue, rounds=rounds)
 
     def verify(self, clearvalue, hashed_value):
         return sha512_crypt.verify(clearvalue, hashed_value)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A regression introduces about year ago caused the rounds parameter to be ignored

Current behavior before PR:
The rounds parameter is ignore, passlib always uses the default which for sha512_crypt is 656000.

Desired behavior after PR is merged:
The rounds parameter is honored.
You can verify this by setting it to != 656000 and the password hash to sha{256,512}_crypt.
Then update the pw and verify the result in the `password` field of the `core_user` table
