### PR TITLE
Argon2 support

### DIFF
--- a/modoboa/core/password_hashers/__init__.py
+++ b/modoboa/core/password_hashers/__init__.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 from django.utils.encoding import smart_text
 
 from modoboa.core.password_hashers.advanced import (  # NOQA:F401
-    BLFCRYPTHasher, MD5CRYPTHasher, SHA256CRYPTHasher, SHA512CRYPTHasher, ARGON2IDHasher
+    BLFCRYPTHasher, MD5CRYPTHasher, SHA256CRYPTHasher, SHA512CRYPTHasher,
+    ARGON2IDHasher
 )
 from modoboa.core.password_hashers.base import (  # NOQA:F401
     CRYPTHasher, MD5Hasher, PLAINHasher, SHA256Hasher

--- a/modoboa/core/password_hashers/__init__.py
+++ b/modoboa/core/password_hashers/__init__.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 from django.utils.encoding import smart_text
 
 from modoboa.core.password_hashers.advanced import (  # NOQA:F401
-    BLFCRYPTHasher, MD5CRYPTHasher, SHA256CRYPTHasher, SHA512CRYPTHasher
+    BLFCRYPTHasher, MD5CRYPTHasher, SHA256CRYPTHasher, SHA512CRYPTHasher, ARGON2IDHasher
 )
 from modoboa.core.password_hashers.base import (  # NOQA:F401
     CRYPTHasher, MD5Hasher, PLAINHasher, SHA256Hasher

--- a/modoboa/core/password_hashers/base.py
+++ b/modoboa/core/password_hashers/base.py
@@ -86,6 +86,16 @@ class PasswordHasher(with_metaclass(MetaHasher, object)):
             hashed_value
         )
 
+    def needs_rehash(self, hashed_value):
+        """Check if the provided hash needs rehasing accoring to the current
+        parameters
+
+        :param str hashed_value: hased password
+        :rtype bool
+        :return: True if the password needs rehash, false otherwise
+        """
+        return False
+
     @classmethod
     def get_password_hashers(cls):
         """Return all the PasswordHasher supported by Modoboa"""

--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -92,6 +92,12 @@ class AuthenticationTestCase(ModoTestCase):
         self.assertTrue(user.password.startswith("{SHA256}"))
 
         self.client.logout()
+        self.set_global_parameter("password_scheme", "argon2id")
+        self.client.post(reverse("core:login"), data)
+        user.refresh_from_db()
+        self.assertTrue(user.password.startswith("{ARGON2ID}"))
+
+        self.client.logout()
         self.set_global_parameter("password_scheme", "fallback_scheme")
         self.client.post(reverse("core:login"), data)
         user.refresh_from_db()

--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -122,12 +122,11 @@ class AuthenticationTestCase(ModoTestCase):
 
         self.client.logout()
         with self.settings(
-                MODOBOA_ARGON2_TIME_COST=4,
-                MODOBOA_ARGON2_MEMORY_COST=10000,
-                MODOBOA_ARGON2_PARALLELISM=4):
+            MODOBOA_ARGON2_TIME_COST=4,
+            MODOBOA_ARGON2_MEMORY_COST=10000,
+            MODOBOA_ARGON2_PARALLELISM=4):
             self.client.post(reverse("core:login"), data)
         user.refresh_from_db()
-        print(user.password)
         self.assertTrue(user.password.startswith("{ARGON2ID}"))
         parameters = argon2.extract_parameters(user.password.lstrip("{ARGON2ID}"))
         self.assertEqual(parameters.time_cost, 4)
@@ -136,13 +135,14 @@ class AuthenticationTestCase(ModoTestCase):
 
         self.client.logout()
         with self.settings(
-                MODOBOA_ARGON2_TIME_COST=3,
-                MODOBOA_ARGON2_MEMORY_COST=1000,
-                MODOBOA_ARGON2_PARALLELISM=2):
+            MODOBOA_ARGON2_TIME_COST=3,
+            MODOBOA_ARGON2_MEMORY_COST=1000,
+            MODOBOA_ARGON2_PARALLELISM=2):
             self.client.post(reverse("core:login"), data)
         user.refresh_from_db()
         self.assertTrue(user.password.startswith("{ARGON2ID}"))
-        parameters = argon2.extract_parameters(user.password.lstrip("{ARGON2ID}"))
+        parameters = argon2.extract_parameters(
+            user.password.lstrip("{ARGON2ID}"))
         self.assertEqual(parameters.time_cost, 3)
         self.assertEqual(parameters.memory_cost, 1000)
         self.assertEqual(parameters.parallelism, 2)

--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -12,6 +12,8 @@ from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
+import argon2
+
 from modoboa.core.password_hashers import get_password_hasher, get_dovecot_schemes
 from modoboa.lib.tests import NO_SMTP, ModoTestCase
 from .. import factories, models
@@ -109,6 +111,41 @@ class AuthenticationTestCase(ModoTestCase):
         self.client.post(reverse("core:login"), data)
         user.refresh_from_db()
         self.assertTrue(user.password.startswith(pw_hash.scheme))
+
+    def test_password_parameter_change(self):
+        """Validate hash parameter update on login works"""
+        username = "user@test.com"
+        password = "toto"
+        data = {"username": username, "password": password}
+        user = models.User.objects.get(username=username)
+        self.set_global_parameter("password_scheme", "argon2id")
+
+        self.client.logout()
+        with self.settings(
+                MODOBOA_ARGON2_TIME_COST=4,
+                MODOBOA_ARGON2_MEMORY_COST=10000,
+                MODOBOA_ARGON2_PARALLELISM=4):
+            self.client.post(reverse("core:login"), data)
+        user.refresh_from_db()
+        print(user.password)
+        self.assertTrue(user.password.startswith("{ARGON2ID}"))
+        parameters = argon2.extract_parameters(user.password.lstrip("{ARGON2ID}"))
+        self.assertEqual(parameters.time_cost, 4)
+        self.assertEqual(parameters.memory_cost, 10000)
+        self.assertEqual(parameters.parallelism, 4)
+
+        self.client.logout()
+        with self.settings(
+                MODOBOA_ARGON2_TIME_COST=3,
+                MODOBOA_ARGON2_MEMORY_COST=1000,
+                MODOBOA_ARGON2_PARALLELISM=2):
+            self.client.post(reverse("core:login"), data)
+        user.refresh_from_db()
+        self.assertTrue(user.password.startswith("{ARGON2ID}"))
+        parameters = argon2.extract_parameters(user.password.lstrip("{ARGON2ID}"))
+        self.assertEqual(parameters.time_cost, 3)
+        self.assertEqual(parameters.memory_cost, 1000)
+        self.assertEqual(parameters.parallelism, 2)
 
     def test_supported_schemes(self):
         """Validate dovecot supported schemes."""

--- a/modoboa/core/views/auth.py
+++ b/modoboa/core/views/auth.py
@@ -52,6 +52,14 @@ def dologin(request):
                         )
                         user.set_password(form.cleaned_data["password"])
                         user.save()
+                    if pwhash.needs_rehash(user.password):
+                        logging.info(
+                            _("Password hash parameter missmatch. "
+                              "Updating %s password"),
+                            user.username
+                        )
+                        user.set_password(form.cleaned_data["password"])
+                        user.save()
 
                 login(request, user)
                 if not form.cleaned_data["rememberme"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ rfc6266
 lxml
 backports.csv; python_version < '3'
 chardet
+argon2_cffi


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR implements support for the argon2 password hash and adds the ability to rehash passwords not only for schema changes but also for parameter changes. Right now the later is only implemented for argon2 hashes, but could also be interesting for sha{256,512}crypt hashes.

Current behavior before PR:
no argon2 support

Desired behavior after PR is merged:
working argon2 support with the ability to rehash password for parameter update on login


I have not (yet) written any documentation about the argon2 functionality. Because I'm unsure where it would fit best, any ideas?

#1673 