### PR TITLE
Make dependency on argon2 optional

### DIFF
--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -6,15 +6,20 @@ from __future__ import unicode_literals
 
 import os
 import smtplib
-from unittest import skipIf
+from unittest import skipIf, skipUnless
 
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
-import argon2
+try:
+    import argon2
+except ImportError:
+    argon2 = None
 
-from modoboa.core.password_hashers import get_password_hasher, get_dovecot_schemes
+from modoboa.core.password_hashers import (
+    get_password_hasher, get_dovecot_schemes
+)
 from modoboa.lib.tests import NO_SMTP, ModoTestCase
 from .. import factories, models
 
@@ -93,11 +98,12 @@ class AuthenticationTestCase(ModoTestCase):
         user.refresh_from_db()
         self.assertTrue(user.password.startswith("{SHA256}"))
 
-        self.client.logout()
-        self.set_global_parameter("password_scheme", "argon2id")
-        self.client.post(reverse("core:login"), data)
-        user.refresh_from_db()
-        self.assertTrue(user.password.startswith("{ARGON2ID}"))
+        if argon2 is not None:
+            self.client.logout()
+            self.set_global_parameter("password_scheme", "argon2id")
+            self.client.post(reverse("core:login"), data)
+            user.refresh_from_db()
+            self.assertTrue(user.password.startswith("{ARGON2ID}"))
 
         self.client.logout()
         self.set_global_parameter("password_scheme", "fallback_scheme")
@@ -112,8 +118,9 @@ class AuthenticationTestCase(ModoTestCase):
         user.refresh_from_db()
         self.assertTrue(user.password.startswith(pw_hash.scheme))
 
-    def test_password_parameter_change(self):
-        """Validate hash parameter update on login works"""
+    @skipUnless(argon2, "argon2-cffi not installed")
+    def test_password_argon2_parameter_change(self):
+        """Validate hash parameter update on login works with argon2."""
         username = "user@test.com"
         password = "toto"
         data = {"username": username, "password": password}
@@ -124,11 +131,14 @@ class AuthenticationTestCase(ModoTestCase):
         with self.settings(
             MODOBOA_ARGON2_TIME_COST=4,
             MODOBOA_ARGON2_MEMORY_COST=10000,
-            MODOBOA_ARGON2_PARALLELISM=4):
+            MODOBOA_ARGON2_PARALLELISM=4,
+        ):
             self.client.post(reverse("core:login"), data)
         user.refresh_from_db()
         self.assertTrue(user.password.startswith("{ARGON2ID}"))
-        parameters = argon2.extract_parameters(user.password.lstrip("{ARGON2ID}"))
+        parameters = argon2.extract_parameters(
+            user.password.lstrip("{ARGON2ID}")
+        )
         self.assertEqual(parameters.time_cost, 4)
         self.assertEqual(parameters.memory_cost, 10000)
         self.assertEqual(parameters.parallelism, 4)
@@ -137,7 +147,8 @@ class AuthenticationTestCase(ModoTestCase):
         with self.settings(
             MODOBOA_ARGON2_TIME_COST=3,
             MODOBOA_ARGON2_MEMORY_COST=1000,
-            MODOBOA_ARGON2_PARALLELISM=2):
+            MODOBOA_ARGON2_PARALLELISM=2,
+        ):
             self.client.post(reverse("core:login"), data)
         user.refresh_from_db()
         self.assertTrue(user.password.startswith("{ARGON2ID}"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,3 @@ rfc6266
 lxml
 backports.csv; python_version < '3'
 chardet
-argon2_cffi

--- a/setup.py
+++ b/setup.py
@@ -81,5 +81,6 @@ if __name__ == "__main__":
             "ldap": LDAP_REQUIRES,
             "mysql": MYSQL_REQUIRES,
             "postgresql": POSTGRESQL_REQUIRES,
+            "argon2": ["argon2-cffi >= 16.1.0"],
         },
     )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+argon2-cffi>=16.1.0
 factory-boy>=2.4
 mock==2.0.0; python_version < '3.3'
 httmock==1.2.5


### PR DESCRIPTION
## Description of the issue this PR addresses
Thanks to #1690, Argon2 is now supported as password hasher. However, it is not optional and Argon2 requires a third-party library - that's why Django do not use it as default (see the [related documentation](https://docs.djangoproject.com/en/2.1/topics/auth/passwords/#using-argon2-with-django)). This PR try to make this password hasher optional.

## Current behavior before PR
* argon2 is in the requirements
* argon2 is imported in modoboa/core/password_hashers/advanced.py
* ARGON2IDHasher is defined and inherits from PasswordHasher
* tests depend on argon2

## Desired behavior after PR is merged
* argon2 is not in requirements but in extras
* argon2 is imported in modoboa/core/password_hashers/advanced.py with a `try...except` catch
* ARGON2IDHasher is defined but only inherits from PasswordHasher if argon2 is installed
* tests related to argon2 are skipped if it is not installed