### PR TITLE
dnstools dkim TXT record evaluation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ modoboa_test
 .coverage
 build/
 dist/
+/.project
+/.pydevproject

--- a/modoboa/dnstools/lib.py
+++ b/modoboa/dnstools/lib.py
@@ -30,7 +30,7 @@ def get_dkim_record(domain, selector):
     if records is None:
         return None
     for record in records:
-        value = str(record).strip('"')
+        value = str(record).strip('"').replace('" "', '')
         if value.startswith("v=DKIM1"):
             return value
     return None


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The DKIM button was red, but my TXT record setted well. So i looked about the issue, and i founded the evaluation of the TXT record is not good. According to DNS standard, a TXT record what is longer than 256 character need to split to several strings: https://help.directadmin.com/item.php?id=552

Current behavior before PR:
I just merge the splitted parts together.

Desired behavior after PR is merged:
The DKIM button is now green as it should be.