### PR TITLE
doc: fix ldapsync parameters table.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -470,7 +470,7 @@ and enable it from the admin panel.
    Make sure to install additional :ref:`requirements <ldap_auth>`
    otherwise it won't work.
 
-The following parameters are available and must be filled::
+The following parameters are available and must be filled:
 
 +--------------------+---------------------------------+--------------------+
 |Name                |Description                      |Default value       |


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixes ldapsync parameters table in docs/configuration.
