### PR TITLE
New functionality: account can send email from a domain with any address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ modoboa_test
 .coverage
 build/
 dist/
+/.project
+/.pydevproject

--- a/modoboa/admin/postfix_maps.py
+++ b/modoboa/admin/postfix_maps.py
@@ -124,7 +124,12 @@ class SenderLoginMap(object):
         "WHERE al.enabled=1 AND ("
         "  al.address='%s' OR ("
         "    adoma.name='%d' AND al.address=concat('%u', '@', adom.name)"
-        ")))"
+        "))) "
+        "UNION "
+        "(SELECT concat(mb.address, '@', dom.name) FROM admin_mailbox mb "
+        "INNER JOIN admin_senderaddress sad ON sad.mailbox_id=mb.id "
+        "INNER JOIN admin_domain dom ON dom.id=mb.domain_id "
+        "WHERE sad.address=concat('@','%d')) "
     )
     postgres = (
         "(SELECT email FROM core_user WHERE email='%s' AND is_active) "
@@ -143,7 +148,12 @@ class SenderLoginMap(object):
         "WHERE al.enabled AND ("
         "  al.address='%s' OR ("
         "    adoma.name='%d' AND al.address='%u'||'@'||adom.name"
-        ")))"
+        "))) "
+        "UNION "
+        "(SELECT mb.address || '@' || dom.name FROM admin_mailbox mb "
+        "INNER JOIN admin_senderaddress sad ON sad.mailbox_id=mb.id "
+        "INNER JOIN admin_domain dom ON dom.id=mb.domain_id "
+        "WHERE sad.address='@'||'%d') "
     )
     sqlite = (
         "SELECT email FROM core_user WHERE email='%s' AND is_active=1 "
@@ -162,5 +172,10 @@ class SenderLoginMap(object):
         "WHERE al.enabled=1 AND ("
         "  al.address='%s' OR ("
         "    adoma.name='%d' AND al.address='%u'||'@'||adom.name"
-        "))"
+        ")) "
+        "UNION "
+        "(SELECT mb.address || '@' || dom.name FROM admin_mailbox mb "
+        "INNER JOIN admin_senderaddress sad ON sad.mailbox_id=mb.id "
+        "INNER JOIN admin_domain dom ON dom.id=mb.domain_id "
+        "WHERE sad.address='@'||'%d') "
     )


### PR DESCRIPTION
New functionality: account can send email from a domain with any address

Originally during the sending of email there is a check to not send out
email from an unaothorized address. There you can set only exact email
addresses.
With this modification you are able to send out any address within a
specified domain. This is the reverse methodology to the catchall
function, you can use this to catch everything and send everything in a
domain, usable for a project management/ERP software.

To enable this you need to set "@domain.com" as sender address alias
just like you set up a cacthall functionality.