### PR TITLE
FIX: relaydomain: next hop should matched with the domain's actual MX list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ modoboa_test
 .coverage
 build/
 dist/
+/.project
+/.pydevproject

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -155,6 +155,9 @@ class CheckMXRecords(BaseCommand):
         if not mxs:
             alerts.append(_("Domain {} has no MX record").format(domain))
         elif valid_mxs:
+            for mx, addr in mxs:
+                mx.managed = False
+                mx.save()
             for subnet in valid_mxs:
                 for mx, addr in mxs:
                     if addr in subnet:

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -203,7 +203,10 @@ class CheckMXRecords(BaseCommand):
                 mx.save()
             for subnet in valid_mxs:
                 for mx, addr in mxs:
-                    if addr in subnet:
+                    if domain.type == 'relaydomain' and mx.name == self._get_nexthop(domain):
+                        mx.managed = check = True
+                        mx.save()
+                    elif addr in subnet:
                         mx.managed = check = True
                         mx.save()
             if check is False:


### PR DESCRIPTION
FIX: relaydomain: next hop should matched with the domain's actual MX list

If you create a relaydomain, than the DKIM and SPF checks are useful,
because they check that in the domain's data you really have good
config. But the MX check is not useful, because it tries to match with
your valid MX list (setted globally in the config panel), what is a good
behavior for a handled domain, but for a relay domain it is not.

This modification modifies the MX record checking methodology that it
checks if your relay hop is setted as a MX receiver for that domain, so
with the MX red/green tag on your dashboard you can check that you
forward your emails into the good target server or not.