### PR TITLE
Update tox.ini and tests to be run locally

### DIFF
--- a/modoboa/core/management/commands/generate_postfix_maps.py
+++ b/modoboa/core/management/commands/generate_postfix_maps.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
         """Return map file template."""
         tplcontent = MAP_FILE_TEMPLATE
         if dbtype == "sqlite":
-            tplcontent += """dbpath = {{ dbname }}
+            tplcontent += """dbpath = {{ dbname|safe }}
 query = {{ query|safe }}
 """
         else:

--- a/modoboa/ldapsync/tests.py
+++ b/modoboa/ldapsync/tests.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 
 from unittest import skipIf
 
-import ldap
-
 from django.utils import six
 from django.utils.encoding import force_bytes, force_str
 
@@ -13,7 +11,9 @@ from modoboa.core import factories as core_factories
 from modoboa.lib.tests import NO_LDAP, ModoTestCase
 from modoboa.parameters import tools as param_tools
 
-from . import lib
+if not NO_LDAP:
+    import ldap
+    from . import lib
 
 
 @skipIf(NO_LDAP, "No ldap module installed")

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -70,9 +70,15 @@ MODOBOA_APPS = (
     "modoboa.limits",
     "modoboa.parameters",
     "modoboa.dnstools",
-    "modoboa.ldapsync",
     # Modoboa extensions here.
 )
+
+try:
+    import ldap  # noqa: F401
+except ImportError:
+    pass
+else:
+    MODOBOA_APPS += ("modoboa.ldapsync",)
 
 INSTALLED_APPS += MODOBOA_APPS
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27,py34
+envlist = py{27,35,36,37}
 
 [testenv]
-changedir=test_project
+changedir = test_project
 commands =
     python ../tests.py
     coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
@@ -19,7 +19,7 @@ setenv =
     DB=SQLITE
 
 [testenv:serve]
-changedir=test_project
+changedir = test_project
 whitelist_externals =
     rm
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py{27,35,36,37}
 changedir = test_project
 commands =
     python ../tests.py
-    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.relaydomains
+    coverage run --source modoboa manage.py test modoboa.core modoboa.lib modoboa.admin modoboa.limits modoboa.transport modoboa.relaydomains modoboa.dnstools modoboa.ldapsync
 
     coverage report --show-missing
 deps =


### PR DESCRIPTION
This fixes some cases where we want that tox passes all tests locally and updates Python versions to check.