### PR TITLE
Fix account removal from domain admins

### DIFF
--- a/modoboa/admin/forms/account.py
+++ b/modoboa/admin/forms/account.py
@@ -494,8 +494,7 @@ class AccountPermissionsForm(forms.Form, DynamicForm):
                 domain.add_admin(self.account)
 
         for domain in models.Domain.objects.get_for_admin(self.account):
-            if not filter(lambda name: self.cleaned_data[name] == domain.name,
-                          self.cleaned_data.keys()):
+            if domain.name not in self.cleaned_data.values():
                 domain.remove_admin(self.account)
 
 


### PR DESCRIPTION
#### Current behavior before PR

In the account edition modal for a user with *DomainAdmins* role, removing a domain from its permissions is not considered when the form is submitted. The user is still an admin for the domain.