### PR TITLE
Allow login with username instead of email for LDAP.

### DIFF
--- a/modoboa/core/tests/test_ldap.py
+++ b/modoboa/core/tests/test_ldap.py
@@ -107,11 +107,9 @@ class LDAPAuthenticationTestCase(LDAPTestCaseMixin, ModoTestCase):
         self.client.logout()
         self.directbind_mode()
 
-        # 1: must fail because usernames of simple users must be email
-        # addresses
         username = "testuser"
-        with self.assertRaises(TypeError):
-            self.client.login(username=username, password="test")
+        self.client.login(username=username, password="test")
+        self.check_created_user(username + "@example.com")
 
         # 1: must work because usernames of domain admins are not
         # always email addresses

--- a/modoboa/lib/authbackends.py
+++ b/modoboa/lib/authbackends.py
@@ -87,7 +87,15 @@ try:
             if group == "SimpleUsers":
                 lpart, domain = split_mailbox(username)
                 if domain is None:
-                    return None
+                    # Try to find associated email
+                    email = None
+                    for attr in ['mail', 'userPrincipalName']:
+                        if attr in ldap_user.attrs:
+                            email = ldap_user.attrs[attr][0]
+                            break
+                    if email is None:
+                        return None
+                    username = email
             user, created = User.objects.get_or_create(
                 username__iexact=username,
                 defaults={


### PR DESCRIPTION
see #1798 
