### PR TITLE
Adding setting to disable RSS requests.

### DIFF
--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -297,6 +297,8 @@ SILENCED_SYSTEM_CHECKS = [
     "security.W019",  # modoboa uses iframes to display e-mails
 ]
 
+DISABLE_RSS = False
+
 # Load settings from extensions
 {% for extension in extra_settings %}
 try:

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -297,7 +297,7 @@ SILENCED_SYSTEM_CHECKS = [
     "security.W019",  # modoboa uses iframes to display e-mails
 ]
 
-DISABLE_RSS = False
+DISABLE_DASHBOARD_EXTERNAL_QUERIES = False
 
 # Load settings from extensions
 {% for extension in extra_settings %}

--- a/modoboa/core/tests/test_views.py
+++ b/modoboa/core/tests/test_views.py
@@ -160,16 +160,16 @@ class DashboardTestCase(ModoTestCase):
         response = self.client.get(url)
         self.assertNotContains(response, "Features looking for sponsoring")
 
-    @override_settings(DISABLE_RSS=False)
-    def test_enable_rss(self):
-        """Load dashboard with DISABLE_RSS = False"""
+    @override_settings(DISABLE_DASHBOARD_EXTERNAL_QUERIES=False)
+    def test_enable_dashboard_external_queries(self):
+        """Load dashboard with DISABLE_DASHBOARD_EXTERNAL_QUERIES = False"""
         url = reverse("core:dashboard")
         response = self.client.get(url)
         self.assertContains(response, 'href="https://modoboa.org/en/weblog/')
 
-    @override_settings(DISABLE_RSS=True)
-    def test_disable_rss(self):
-        """Load dashboard with DISABLE_RSS = True"""
+    @override_settings(DISABLE_DASHBOARD_EXTERNAL_QUERIES=True)
+    def test_disable_dashboard_external_queries(self):
+        """Load dashboard with DISABLE_DASHBOARD_EXTERNAL_QUERIES = True"""
         url = reverse("core:dashboard")
         response = self.client.get(url)
         self.assertNotContains(response, 'https://modoboa.org/en/weblog/')

--- a/modoboa/core/tests/test_views.py
+++ b/modoboa/core/tests/test_views.py
@@ -4,6 +4,7 @@ from testfixtures import compare
 
 from django import forms
 from django.urls import reverse
+from django.test import override_settings
 
 from modoboa.lib.tests import ModoTestCase
 from modoboa.parameters import forms as param_forms, tools as param_tools
@@ -158,6 +159,20 @@ class DashboardTestCase(ModoTestCase):
         self.set_global_parameter("hide_features_widget", True)
         response = self.client.get(url)
         self.assertNotContains(response, "Features looking for sponsoring")
+
+    @override_settings(DISABLE_RSS=False)
+    def test_enable_rss(self):
+        """Load dashboard with DISABLE_RSS = False"""
+        url = reverse("core:dashboard")
+        response = self.client.get(url)
+        self.assertContains(response, 'href="https://modoboa.org/en/weblog/')
+
+    @override_settings(DISABLE_RSS=True)
+    def test_disable_rss(self):
+        """Load dashboard with DISABLE_RSS = True"""
+        url = reverse("core:dashboard")
+        response = self.client.get(url)
+        self.assertNotContains(response, 'https://modoboa.org/en/weblog/')
 
     def test_root_dispatch(self):
         """Check root dispatching."""

--- a/modoboa/core/views/dashboard.py
+++ b/modoboa/core/views/dashboard.py
@@ -45,10 +45,9 @@ class DashboardView(auth_mixins.AccessMixin, generic.TemplateView):
                 self.request.localconfig.parameters.get_value("rss_feed_url"))
             if custom_feed_url:
                 feed_url = custom_feed_url
-        if not settings.DISABLE_RSS:
-            posts = feedparser.parse(feed_url)
         entries = []
-        if not settings.DISABLE_RSS:
+        if not settings.DISABLE_DASHBOARD_EXTERNAL_QUERIES:
+            posts = feedparser.parse(feed_url)
             for entry in posts["entries"][:5]:
                 entry["published"] = parser.parse(entry["published"])
                 entries.append(entry)
@@ -61,7 +60,7 @@ class DashboardView(auth_mixins.AccessMixin, generic.TemplateView):
             url = "{}{}/api/projects/?featured=true".format(
                 MODOBOA_WEBSITE_URL, lang)
             features = []
-            if not settings.DISABLE_RSS:
+            if not settings.DISABLE_DASHBOARD_EXTERNAL_QUERIES:
                 try:
                     response = requests.get(url)
                 except RequestException:

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -292,4 +292,5 @@ SILENCED_SYSTEM_CHECKS = [
     "security.W019",  # modoboa uses iframes to display e-mails
 ]
 
+DISABLE_RSS = False
 # Load settings from extensions

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -292,5 +292,5 @@ SILENCED_SYSTEM_CHECKS = [
     "security.W019",  # modoboa uses iframes to display e-mails
 ]
 
-DISABLE_RSS = False
+DISABLE_DASHBOARD_EXTERNAL_QUERIES = False
 # Load settings from extensions


### PR DESCRIPTION
Resolves #1797 

Current behavior before PR:
Modoboa server is behind proxy, so no internet direct access
Acces dashboard via admin account

-> 504 Gateway Time-out

Desired behavior after PR is merged:
It is possible to disable RSS requests in settings.py file being behind a proxy to avoid the dashboard time-out.
