### PR TITLE
Provide Python 3 requirement hints on documentation

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -9,6 +9,13 @@ You will need a Server to perform well with at least:
 * CPU: 2
 * RAM: 2GB
 * Disk: 10GB
+* Python 3
+
+.. note:: **👀 Heads up for modoboa versions 1.15 and later**
+   
+   Python 2 support has been dropped with modoboa version 1.15. 
+   If you still have Python 2 installed on your system either uninstall it 
+   or force modoboa user to run with Python 3.
 
 Recommended way
 ===============


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As discussed on https://github.com/modoboa/modoboa/issues/1992#issuecomment-673392601 new administrators that only look at the documentation page for the modoboa installer will not notice the fixed Python 3 requirement.

Current behavior before PR:

The documentation does not provide Python 3 as modoboa requirement.

Desired behavior after PR is merged:

The documentation provides Python 3 as fixed modoboa requirement and also nots about when the change did come.