### PR TITLE
bump gevent to 1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ bcrypt  # Requires libffi-dev and python-dev
 
 dnspython==1.16.0
 feedparser==5.2.1
-gevent==1.4.0
+gevent==1.5.0
 jsonfield==2.0.2
 Pillow  # Optional dependency for django-ckeditor
 progressbar33==2.4


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
fixes #1875

Current behavior before PR:
failed when running mx check on python 3.8

Desired behavior after PR is merged:
mx check works again