### PR TITLE
Remove Reference to System Package

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -96,12 +96,6 @@ Install the corresponding Python binding:
 
    (env)$ pip install psycopg2
 
-.. note::
-
-   Alternatively, you can install the ``python3-psycopg2`` package instead on
-   Debian-based distributions if your virtual environment was created with
-   ``--system-site-packages`` option.
-
 Then, create a user and a database. For example, to create the ``modoboa``
 database owned by a ``modoboa`` user, run the following commands on your
 PostgreSQL server:


### PR DESCRIPTION
This will help people not be confused by the fact python3 is the new default.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
