### PR TITLE
WIP: Review requirements to prefer Debian packages

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -55,9 +55,15 @@ following system packages according to your distribution:
 .. note::
 
    Alternatively, you could rely on your distribution packages for the Modoboa
-   dependencies which require compilation - e.g. ``psycopg2`` - if the version
+   dependencies which require compilation - e.g. ``rrdtool`` - if the version
    is compatible. In this case, you have to create your virtual environment
-   with the ``--system-site-packages`` option.
+   with the ``--system-site-packages`` option, and the required system
+   packages will be:
+
+    +--------------------------------+
+    | python3-greenlet python3-wheel |
+    | python3-rrdtool rrdtool        |
+    +--------------------------------+
 
 Then, install Modoboa by running:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ bcrypt  # Requires libffi-dev and python-dev
 
 dnspython==1.16.0
 feedparser==6.0.2
-greenlet==0.4.17
+greenlet>=0.4.15,<1.0
 gevent==20.9.0
 jsonfield==3.1.0
 Pillow  # Optional dependency for django-ckeditor

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ chardet
 ovh
 oath
 redis
-rrdtool>=0.1.11
+rrdtool>=0.1.10
 qrcode
 
 aiosmtplib


### PR DESCRIPTION
The goal of this PR is to prefer Debian packages instead of Python ones as soon as some compilation is needed. In addition to rely on the great work which is done by the distribution developers to have working stable versions of those libraries, this will prevent useless compilation on the server and all the dependencies that it needs.