### PR TITLE
Resynchronize the package index in tests

### DIFF
--- a/.github/workflows/modoboa.yml
+++ b/.github/workflows/modoboa.yml
@@ -66,7 +66,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install postfix librrd-dev rrdtool libldap2-dev libsasl2-dev libssl-dev
+          sudo apt-get update -y \
+          && sudo apt-get install -y \
+            postfix librrd-dev rrdtool libldap2-dev libsasl2-dev libssl-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r ldap-requirements.txt


### PR DESCRIPTION
The tests are currently broken since the image provided by Github is not up-to-date:
```
...
Err:4 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-dev amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1
  404  Not Found [IP: 52.147.219.192 80]
Fetched 2139 kB in 0s (10.1 MB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/cyrus-sasl2/libsasl2-dev_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

This ensure that the package index is synchronized before installing anything.