### PR TITLE
Accept rrdtool version in Debian Buster

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -55,9 +55,14 @@ following system packages according to your distribution:
 .. note::
 
    Alternatively, you could rely on your distribution packages for the Modoboa
-   dependencies which require compilation - e.g. ``psycopg2`` - if the version
+   dependencies which require compilation - e.g. ``rrdtool`` - if the version
    is compatible. In this case, you have to create your virtual environment
-   with the ``--system-site-packages`` option.
+   with the ``--system-site-packages`` option, and the required system
+   packages will be:
+
+    +---------------------------------------+
+    | python3-wheel python3-rrdtool rrdtool |
+    +---------------------------------------+
 
 Then, install Modoboa by running:
 
@@ -183,7 +188,7 @@ you just have to run the following command:
    A database url should meet the following syntax
    ``<mysql|postgres>://[user:pass@][host:port]/dbname`` **OR**
    ``sqlite:////full/path/to/your/database/file.sqlite``.
-   
+
    Fox example, if you were using postgres, you could setup your command like this:
    ``modoboa-admin.py deploy instance_name --collectstatic --domain example.com --dburl default:postgres://user:pass@[localhost]/modoboa``
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ chardet
 ovh
 oath
 redis
-rrdtool>=0.1.11
+rrdtool>=0.1.10
 qrcode
 
 aiosmtplib


### PR DESCRIPTION
The Debian package `python-rrdtool` in Buster uses the Python binding provided by `rrdtool`. Even if the current version is 0.1.10, `rrdtool` version is 1.7.1 which should already include required features - e.g. export functions regarding the [changelog](https://github.com/oetiker/rrdtool-1.x/blob/master/CHANGES). Finally, regarding the ["changelog"](https://github.com/commx/python-rrdtool/releases) of the separated `rrdtool` package which is in PyPi, it does not include relevant features or fixes.