### PR TITLE
Wrap ModelViewSet requests to a revision block

### DIFF
--- a/modoboa/admin/api.py
+++ b/modoboa/admin/api.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 
 from modoboa.core import models as core_models
 from modoboa.core import sms_backends
+from modoboa.lib.viewsets import RevisionModelMixin
 
 from . import lib, models, serializers
 
@@ -31,7 +32,7 @@ from . import lib, models, serializers
         summary="Create a new domain"
     )
 )
-class DomainViewSet(viewsets.ModelViewSet):
+class DomainViewSet(RevisionModelMixin, viewsets.ModelViewSet):
     """Domain viewset."""
 
     permission_classes = [IsAuthenticated, DjangoModelPermissions, ]
@@ -46,7 +47,7 @@ class DomainViewSet(viewsets.ModelViewSet):
         instance.delete(self.request.user)
 
 
-class DomainAliasViewSet(viewsets.ModelViewSet):
+class DomainAliasViewSet(RevisionModelMixin, viewsets.ModelViewSet):
     """ViewSet for DomainAlias."""
 
     permission_classes = [IsAuthenticated, DjangoModelPermissions, ]
@@ -62,7 +63,7 @@ class DomainAliasViewSet(viewsets.ModelViewSet):
         return queryset
 
 
-class AccountViewSet(viewsets.ModelViewSet):
+class AccountViewSet(RevisionModelMixin, viewsets.ModelViewSet):
     """ViewSet for User/Mailbox."""
 
     filter_backends = [filters.SearchFilter]
@@ -157,7 +158,7 @@ class AccountViewSet(viewsets.ModelViewSet):
         return Response(body)
 
 
-class AliasViewSet(viewsets.ModelViewSet):
+class AliasViewSet(RevisionModelMixin, viewsets.ModelViewSet):
     """
     create:
     Create a new alias instance.
@@ -182,7 +183,7 @@ class AliasViewSet(viewsets.ModelViewSet):
         return queryset
 
 
-class SenderAddressViewSet(viewsets.ModelViewSet):
+class SenderAddressViewSet(RevisionModelMixin, viewsets.ModelViewSet):
     """View set for SenderAddress model."""
 
     permission_classes = [IsAuthenticated, DjangoModelPermissions, ]

--- a/modoboa/admin/tests/test_api.py
+++ b/modoboa/admin/tests/test_api.py
@@ -10,6 +10,7 @@ from django.test import override_settings
 from django.urls import reverse
 
 from rest_framework.authtoken.models import Token
+from reversion.models import Version
 
 from modoboa.admin import models as admin_models
 from modoboa.core import factories as core_factories, models as core_models
@@ -51,8 +52,9 @@ class DomainAPITestCase(ModoAPITestCase):
             url, {"name": "test3.com", "quota": 0, "default_mailbox_quota": 10}
         )
         self.assertEqual(response.status_code, 201)
-        self.assertTrue(
-            models.Domain.objects.filter(name="test3.com").exists())
+        domain = models.Domain.objects.get(name="test3.com")
+        self.assertEqual(Version.objects.get_for_object(domain).count(), 1)
+
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
         self.assertIn("name", response.data)

--- a/modoboa/lib/viewsets.py
+++ b/modoboa/lib/viewsets.py
@@ -1,0 +1,11 @@
+"""ViewSet related mixins and tools."""
+
+from reversion.views import RevisionMixin
+
+
+class RevisionModelMixin(RevisionMixin):
+    """
+    A mixin to wrap every request in a revision block.
+    """
+
+    pass

--- a/modoboa/relaydomains/viewsets.py
+++ b/modoboa/relaydomains/viewsets.py
@@ -4,10 +4,11 @@ from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 
 from modoboa.admin import models as admin_models
+from modoboa.lib.viewsets import RevisionModelMixin
 from . import serializers
 
 
-class RelayDomainViewSet(viewsets.ModelViewSet):
+class RelayDomainViewSet(RevisionModelMixin, viewsets.ModelViewSet):
     """RelayDomain viewset."""
 
     permission_classes = [IsAuthenticated, DjangoModelPermissions, ]


### PR DESCRIPTION
## Description of the issue this PR addresses

Creation, update and deletion of an object is currently not logged when it is done through the API.

## Current behavior before PR

The `create()`, `update()` and `delete()` methods of `rest_framework.viewsets.ModelViewSet` do not create a revision, which do not produce the corresponding log message creation - see `modoboa.core.handlers.post_revision_commit`.

## Desired behavior after PR is merged

This simply adds a new `modoboa.libs.viewsets.RevisionModelMixin` mixin - sorry, it will produce a conflict with the refacto/vuejs_interface branch - which inherits from [`reversion.views.RevisionMixin`](https://django-reversion.readthedocs.io/en/stable/views.html#reversion-views-revisionmixin). This will decorate the `dispatch()` method to wrap every request in a revision block.

The following can be discussed:

- Is it a good idea to rely on `reversion.views.RevisionMixin` or should Modoboa implements its own mixin?
- Is it okay to decorate all methods - e.g. not just `create()`, `update()` and `delete()`?