### PR TITLE
Handle NameTooLong by logging an error

### DIFF
--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -198,6 +198,8 @@ def get_dns_records(name, typ, resolver=None):
         logger.warning(
             _("DNS resolution timeout, unable to query %s at the moment") %
             name, exc_info=e)
+    except dns.name.NameTooLong as e:
+        logger.error(_("DNS name is too long: %s" % name), exc_info=e)
     else:
         return dns_answers
     return None


### PR DESCRIPTION
get_dns_records() could be fed with a name that is too long for the DNS
protocol. In this case a NameTooLong error is thrown, which we can catch
and log an error for. This can happen for example if a DNS name that is
already at the limit is used in combination with "manage.py modo
check_mx", which appends an autodiscover to the domain, which then
exceeds the DNS name limit.

Description of the issue/feature this PR addresses:
`manage.py modo check_mx` crashes each time I run it, errors out with a NameTooLong error.

Current behavior before PR:
Crash

Desired behavior after PR is merged:
No crash, an error is logged instead.