### PR TITLE
Fixed a bug that was preventing modoboa from properly importing users from an LDAP connection. (modoboa#2239)

### DIFF
--- a/modoboa/core/app_settings.py
+++ b/modoboa/core/app_settings.py
@@ -18,6 +18,7 @@ from modoboa.parameters import forms as param_forms, tools as param_tools
 from . import constants
 from . import sms_backends
 
+from modoboa.admin.models import Domain
 
 def enabled_applications():
     """Return the list of installed extensions."""
@@ -37,6 +38,18 @@ class GeneralParametersForm(param_forms.AdminParametersForm):
     app = "core"
 
     sep1 = SeparatorField(label=ugettext_lazy("Authentication"))
+
+    domains = [("none", "none")]
+    for domain in Domain.objects.all():
+        domains.append((domain.name, domain.name))
+
+    default_domain = forms.ChoiceField(
+        label=ugettext_lazy("Default domain"),
+        choices=domains,
+        initial="none",
+        help_text=ugettext_lazy(
+            "Default domain to use for accounts.")
+    )
 
     authentication_type = forms.ChoiceField(
         label=ugettext_lazy("Authentication type"),
@@ -526,11 +539,6 @@ class GeneralParametersForm(param_forms.AdminParametersForm):
         self._add_visibilty_rules(
             sms_backends.get_all_backend_visibility_rules()
         )
-        self.fields["password_scheme"].choices = [
-            (hasher.name, ugettext_lazy(hasher.label))
-            for hasher in PasswordHasher.get_password_hashers()
-            if hasher().scheme in get_dovecot_schemes()
-        ]
 
     def _add_dynamic_fields(self):
         new_fields = OrderedDict()

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -117,8 +117,8 @@ class User(AbstractUser):
         :param raw_value: the new password's value
         :param curvalue: the current password (for LDAP authentication)
         """
-        ldap_sync_enable = param_tools.get_global_parameter("ldap_enable_sync")
-        if self.is_local or ldap_sync_enable:
+        ldap_import_enable = param_tools.get_global_parameter("ldap_enable_import")
+        if self.is_local or ldap_import_enable:
             self.password = self._crypt_password(raw_value)
         else:
             if not ldap_available:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The configuration parameter `ldap_enable_sync` was being queried when it should have been `ldap_enable_import`. (modoboa#2239)
This caused modoboa to attempt to login to the LDAP server with an empty password in an attempt to change said password.

Current behavior before PR:
modoboa would throw an `INVALID_CREDENTIALS ` error from failing to login to the LDAP server with an empty password.

Desired behavior after PR is merged:
modoboa will successfully update the local password to match the remote LDAP password.