### PR TITLE
Fixed some warnings reported by drf-speculator

### DIFF
--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -183,6 +183,7 @@ class IdentityViewSet(viewsets.ViewSet):
     """Viewset for identities."""
 
     permission_classes = (permissions.IsAuthenticated, )
+    serializer_class = None
 
     def list(self, request, **kwargs):
         """Return all identities."""

--- a/modoboa/core/api/v1/viewsets.py
+++ b/modoboa/core/api/v1/viewsets.py
@@ -19,6 +19,7 @@ class AccountViewSet(viewsets.ViewSet):
     """
 
     permission_classes = (permissions.IsAuthenticated, )
+    serializer_class = None
 
     @action(methods=["post"], detail=False, url_path="tfa/setup")
     def tfa_setup(self, request):

--- a/modoboa/core/drf_authentication.py
+++ b/modoboa/core/drf_authentication.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from django_otp.models import Device
+from drf_spectacular.contrib.rest_framework_simplejwt import SimpleJWTScheme
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework_simplejwt.authentication import JWTAuthentication
@@ -44,3 +45,8 @@ class JWTAuthenticationWith2FA(JWTAuthentication):
         if user.tfa_enabled:
             self.verify_user(request, user)
         return user, token
+
+
+class SimpleJWTWith2FAScheme(SimpleJWTScheme):
+    target_class = 'modoboa.core.drf_authentication.JWTAuthenticationWith2FA'
+    name = 'jwt2FAAuth'

--- a/modoboa/parameters/api/v2/viewsets.py
+++ b/modoboa/parameters/api/v2/viewsets.py
@@ -12,6 +12,7 @@ class ParametersViewSet(viewsets.ViewSet):
     """Parameter viewset."""
 
     lookup_value_regex = r"\w+"
+    serializer_class = None
 
     @extend_schema(responses=serializers.ApplicationSerializer(many=True))
     @action(methods=["get"], detail=False)


### PR DESCRIPTION
This fixes the following error and warnings reported by drf-speculator:

```
Error #0: AccountViewSet: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Ignoring view for now.
Warning #1: AccountViewSet: could not resolve authenticator <class 'modoboa.core.drf_authentication.JWTAuthenticationWith2FA'>. There was no OpenApiAuthenticationExtension registered for that class. Try creating one by subclassing it. Ignoring for now.
```