### PR TITLE
Proxify API requests in Vue's development server

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,3 +1,3 @@
 {
-    "API_BASE_URL": "http://localhost:8000/api/v2"
+    "API_BASE_URL": "/api/v2/"
 }

--- a/frontend/src/api/repository.js
+++ b/frontend/src/api/repository.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import axios from 'axios'
 import Cookies from 'js-cookie'
 
@@ -10,7 +9,6 @@ const _axios = axios.create()
 _axios.interceptors.request.use(
   function (config) {
     // Do something before request is sent
-    config.baseURL = Vue.prototype.$config.API_BASE_URL
     if (store.state.auth.isAuthenticated) {
       config.headers['Accept-Language'] = store.state.auth.authUser.language
     }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,6 +8,7 @@ import router from './router'
 import store from './store'
 import vuetify from './plugins/vuetify'
 import sassStyles from './styles/global.scss' // eslint-disable-line no-unused-vars
+import repository from './api/repository'
 
 Vue.config.productionTip = false
 
@@ -15,7 +16,13 @@ export const bus = new Vue()
 
 fetch(process.env.BASE_URL + 'config.json').then(resp => {
   resp.json().then((config) => {
+    if (!config.API_BASE_URL) {
+      throw Error('API_BASE_URL is not defined in config.json')
+    }
+    repository.defaults.baseURL = config.API_BASE_URL
+
     Vue.prototype.$config = config
+
     new Vue({
       router,
       store,

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,4 +1,11 @@
 module.exports = {
+  devServer: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000/'
+      }
+    }
+  },
   transpileDependencies: [
     'vuetify'
   ]


### PR DESCRIPTION
Those changes allows one to run development servers for the API and the frontend without the need to configure CORS headers. They are otherwise required since the frontend and the API are not server on the same base URL since the ports are not the same.

By the way, the `baseUrl` option for axios is also defined when the configuration is fetched and an error is raised if `API_BASE_URL` is missing.