### PR TITLE
added convert2textfield function

### DIFF
--- a/modoboa/admin/templates/admin/_domain_dkim_key.html
+++ b/modoboa/admin/templates/admin/_domain_dkim_key.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n convert2textfield %}
 
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
@@ -13,7 +13,7 @@
       </div>
       <div class="alert alert-info" style="overflow-wrap: break-word;">
         <strong>{% trans "Bind/named format" %}</strong><br>
-        <span style="white-space: pre">{{ domain.bind_format_dkim_public_key }}</span>
+        <span style="white-space: pre">{{ domain.bind_format_dkim_public_key|convert2textfield }}</span>
       </div>
     </div>
     <div class="modal-footer">


### PR DESCRIPTION
dkim key convert into tetxtfield to be able to copy in a handy way

Description of the issue/feature this PR addresses: display dkim key in input text field to easier to copy line by line

Current behavior before PR: dkim key was displayed between quotes, copying was hard.

Desired behavior after PR is merged: easy text copy from input text box
