### PR TITLE
Fix account alias on legacy interface

### DIFF
--- a/modoboa/admin/forms/account.py
+++ b/modoboa/admin/forms/account.py
@@ -420,9 +420,11 @@ class AccountFormMail(forms.Form, DynamicForm):
                     alias__address=alias).exists():
                 continue
             local_part, domname = split_mailbox(alias)
-            al = models.Alias(address=alias, enabled=account.is_active)
-            al.domain = models.Domain.objects.get(name=domname)
-            al.save()
+            al, _ = models.Alias.objects.get_or_create(
+                address=alias,
+                domain=models.Domain.objects.get(name=domname),
+                defaults={'enabled': account.is_active},
+            )
             al.set_recipients([self.mb.full_address])
             al.post_create(user)
 

--- a/modoboa/admin/forms/account.py
+++ b/modoboa/admin/forms/account.py
@@ -425,7 +425,7 @@ class AccountFormMail(forms.Form, DynamicForm):
                 domain=models.Domain.objects.get(name=domname),
                 defaults={'enabled': account.is_active},
             )
-            al.set_recipients([self.mb.full_address])
+            al.add_recipients([self.mb.full_address])
             al.post_create(user)
 
     def _update_sender_addresses(self):

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -137,8 +137,8 @@ class Alias(AdminObject):
             for admin in self.domain.admins:
                 grant_access_to_object(admin, self)
 
-    def set_recipients(self, address_list):
-        """Set recipients for this alias.
+    def add_recipients(self, address_list):
+        """Add recipients for this alias.
 
         Special recipients:
         * local mailbox + extension: r_mailbox will be set to local mailbox
@@ -186,6 +186,11 @@ class Alias(AdminObject):
                 else:
                     kwargs["r_mailbox"] = rcpt
             AliasRecipient(**kwargs).save()
+
+    def set_recipients(self, address_list):
+        """Set recipients for this alias."""
+
+        self.add_recipients(address_list)
 
         # Remove old recipients
         self.aliasrecipient_set.exclude(

--- a/modoboa/admin/tests/test_account.py
+++ b/modoboa/admin/tests/test_account.py
@@ -133,6 +133,7 @@ class AccountTestCase(ModoTestCase):
             "aliases": "alias@test.com",
         }
         self.ajax_post(reverse("admin:account_add"), values)
+        self.assertTrue(alias.aliasrecipient_set.count() == 2)
 
     def test_aliases_update_on_disable(self):
         """Check if aliases are updated when account is disabled."""

--- a/modoboa/admin/tests/test_account.py
+++ b/modoboa/admin/tests/test_account.py
@@ -119,6 +119,21 @@ class AccountTestCase(ModoTestCase):
         account = User.objects.get(username=values["username"])
         self.assertEqual(account.language, "fr")
 
+    def test_create_account_with_existing_alias(self):
+        alias = models.Alias.objects.get(address="alias@test.com")
+        alias.set_recipients(["user@external.com"])
+        values = {
+            "email": "tester@test.com",
+            "username": "tester@test.com",
+            "role": "SimpleUsers",
+            "random_password": "on",
+            "quota_act": True,
+            "is_active": True,
+            "stepid": "step2",
+            "aliases": "alias@test.com",
+        }
+        self.ajax_post(reverse("admin:account_add"), values)
+
     def test_aliases_update_on_disable(self):
         """Check if aliases are updated when account is disabled."""
         account = User.objects.get(username="user@test.com")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
#2399

Current behavior before PR:

- Exception and failure during account creation or update.

Desired behavior after PR is merged:

- No failure.
- Extension of the recipients of the Alias in order to record the account.

Fix #2399.