### PR TITLE
Patch for imap4-utf-7 on Debian 11 and Python 3.9 #227

### DIFF
--- a/modoboa/lib/imap_utf7.py
+++ b/modoboa/lib/imap_utf7.py
@@ -126,7 +126,7 @@ class StreamWriter(codecs.StreamWriter):
 
 
 def imap4_utf_7(name):
-    if name == "imap4-utf-7":
+    if name == "imap4-utf-7" or name == "imap4_utf_7":
         return (encoder, decoder, StreamReader, StreamWriter)
 
 


### PR DESCRIPTION
Patch for imap4-utf-7 on Debian 11 and Python 3.9 #227

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
