### PR TITLE
fix <modoboa dir> to APP NAME

### DIFF
--- a/doc/manual_installation/webserver.rst
+++ b/doc/manual_installation/webserver.rst
@@ -97,7 +97,7 @@ gunicorn configuration (create a new file named
 To start gunicorn, execute the following commands::
 
   $ cd <modoboa dir>
-  $ gunicorn -c gunicorn.conf.py <modoboa dir>.wsgi:application
+  $ gunicorn -c gunicorn.conf.py <APP/INSTANCE Name>.wsgi:application
 
 Now the nginx part. Just create a new virtual host and use the
 following configuration::


### PR DESCRIPTION
Description of the issue:
<modoboa dir> is not only wrong, it was also misleading, fixed doc

Current behavior before PR: 
<modoboa dir> in gunicorn installation was misleading

Desired behavior after PR is merged:
no misleading, since the correct way is giving the instance/app name which is used during deployment!