### PR TITLE
Adding a restrictive robot.txt file

### DIFF
--- a/modoboa/core/templates/core/robots.txt
+++ b/modoboa/core/templates/core/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /

--- a/modoboa/core/urls.py
+++ b/modoboa/core/urls.py
@@ -1,6 +1,7 @@
 """Core urls."""
 
 from django.urls import path
+from django.views.generic.base import TemplateView
 
 from . import views
 
@@ -31,4 +32,5 @@ urlpatterns = [
     path('user/profile/', views.profile, name="user_profile"),
     path('user/api/', views.api_access, name="user_api_access"),
     path('user/security/', views.security, name="user_security"),
+    path('robots.txt', TemplateView.as_view(template_name="core/robots.txt", content_type="text/plain")),
 ]


### PR DESCRIPTION
Hi !

This PR addresses the issue #1612 by adding a robots.txt file that denies access to Modoboa's web interface. 

Currently search engines are allowed to index every crawlable modoboa file. This new robots.txt file would prevent any page from being indexed, which is probably a good thing as pointed out by the original issue. 

Please let me know if you think of ways to improve this PR. 
