### PR TITLE
updated docs to new api

### DIFF
--- a/doc/rest_api.rst
+++ b/doc/rest_api.rst
@@ -6,14 +6,18 @@ To ease the integration with external sources (software or other),
 Modoboa provides a REST API.
 
 Every installed instance comes with a ready-to-use API and a
-documentation. You will find them using the following url patterns:
+documentation. 
+
+**You will find them using the following url patterns:**
 
 * New API+Docs: *https://<hostname>/api/schema-v2/swagger/*
 * Old API: *http://<hostname>/api/v1/
 * (Old) Documentation: *http://<hostname>/docs/api/*
 
-`new example <https://demo.modoboa.org/api/schema-v2/swagger/>`_
-An `old example <https://demo.modoboa.org/docs/api/>`_ 
+**Examples:**
+
+* `new example <https://demo.modoboa.org/api/schema-v2/swagger/>`_
+* `old example <https://demo.modoboa.org/docs/api/>`_ 
 documentation is available on the official demo.
 
 Using this API requires an authentication and for now, only a token

--- a/doc/rest_api.rst
+++ b/doc/rest_api.rst
@@ -8,11 +8,12 @@ Modoboa provides a REST API.
 Every installed instance comes with a ready-to-use API and a
 documentation. You will find them using the following url patterns:
 
-* API: *http://<hostname>/api/v1/*
-* Documentation: *http://<hostname>/docs/api/*
-* New Docs: *https://<hostname>/api/schema-v2/swagger/*
+* New API+Docs: *https://<hostname>/api/schema-v2/swagger/*
+* Old API: *http://<hostname>/api/v1/
+* (Old) Documentation: *http://<hostname>/docs/api/*
 
-An `old example <https://demo.modoboa.org/docs/api/>`_ of this and here: `new example <https://demo.modoboa.org/api/schema-v2/swagger/>`_
+`new example <https://demo.modoboa.org/api/schema-v2/swagger/>`_
+An `old example <https://demo.modoboa.org/docs/api/>`_ 
 documentation is available on the official demo.
 
 Using this API requires an authentication and for now, only a token

--- a/doc/rest_api.rst
+++ b/doc/rest_api.rst
@@ -10,8 +10,9 @@ documentation. You will find them using the following url patterns:
 
 * API: *http://<hostname>/api/v1/*
 * Documentation: *http://<hostname>/docs/api/*
+* New Docs: *https://<hostname>/api/schema-v2/swagger/*
 
-An `example <https://demo.modoboa.org/docs/api/>`_ of this
+An `old example <https://demo.modoboa.org/docs/api/>`_ of this and here: `new example <https://demo.modoboa.org/api/schema-v2/swagger/>`_
 documentation is available on the official demo.
 
 Using this API requires an authentication and for now, only a token


### PR DESCRIPTION
Description of the issue/feature this PR addresses: new API route v2-swagger

Current behavior before PR: showing page does not exist in demo page

Desired behavior after PR is merged: points to new url 
