### PR TITLE
Maintenance: Add missing log parse parts plus hint

### DIFF
--- a/doc/manual_installation/modoboa.rst
+++ b/doc/manual_installation/modoboa.rst
@@ -235,10 +235,22 @@ following content inside:
    0     0  *  *  *  modoboa  $PYTHON $INSTANCE/manage.py clearsessions
    # Logs table cleanup
    0     0  *  *  *  modoboa  $PYTHON $INSTANCE/manage.py cleanlogs
+   # Logs parsing
+   */15  *  *  *  *  root     $PYTHON $INSTANCE/manage.py logparser &> /dev/null
+   0     *  *  *  *  modoboa  $PYTHON $INSTANCE/manage.py update_statistics
    # DNSBL checks
    */30  *  *  *  *  modoboa  $PYTHON $INSTANCE/manage.py modo check_mx
    # Public API communication
    0     *  *  *  *  modoboa  $PYTHON $INSTANCE/manage.py communicate_with_public_api
+
+.. hint:: **🥵 potential high load configuration**
+
+   Please note that above crontab might not be ideal on high load systems.
+   If you receive a fairly high amount of emails per day, you may want to
+   run modoboas logparser tasks *once per night*.
+   
+   This has the down side that the statistic graph and message log within
+   the UI are updated once per day only.
 
 .. _policy_daemon:
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Our environment sends over 50,000 emails per day. Even with dividing dovecots and postfix log and daily rotate, you'll still end up in 80MB log files easily. This causes huge CPU spikes the bigger the log file gets. Eventually this will cause all of your system cores to be under extremely high load causing the whole system to be slow.

This is also shown in this discussion:
https://github.com/modoboa/modoboa/discussions/2031

and this isuse:
https://github.com/modoboa/modoboa/issues/1187

For context, here's the systems load over 30 days - you can clearly see when we switched to once per day which is why I believe the hint I've added is very useful for others.

![image](https://user-images.githubusercontent.com/6549061/177537704-4fcd3c75-53df-4339-9c9b-0519545a7a3d.png)


Current behavior before PR:
Logparsing was entirely missing from the crontab. No hint of possible performance issues.

Desired behavior after PR is merged:
Modoboa also offers log parsing which was not yet reflected in the cron job sample of the manual installation part.
As log parsing can be fairly CPU intensive there's also a hint for that.