### PR TITLE
Fix depreciation from python 3.10

### DIFF
--- a/modoboa/policyd/management/commands/policy_daemon.py
+++ b/modoboa/policyd/management/commands/policy_daemon.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         """Entry point."""
         loop = asyncio.get_event_loop()
         coro = asyncio.start_server(
-            core.new_connection, options["host"], options["port"], loop=loop
+            core.new_connection, options["host"], options["port"]
         )
         server = loop.run_until_complete(coro)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
see issue #2562 and #2561. 
From python 3.10, start_server() doesn't take[ ``loop`` as an argument ](https://docs.python.org/3.10/library/asyncio-stream.html#asyncio.start_server). As a result, it is tedious to use it on Ubuntu 22.04. 

Current behavior before PR:
Policy deamon keep crashing due to a TypeError making it impossible to receive/send mails.

Desired behavior after PR is merged:
Have it compatible with python 3.10. 
!!!!! I've just deleted a line, and I'm not sure if this was the right thing to do, however, I can now send mails !
