### PR TITLE
docs: Fix a few typos

### DIFF
--- a/modoboa/bower_components/c3/c3.js
+++ b/modoboa/bower_components/c3/c3.js
@@ -598,7 +598,7 @@
         // bars
         $$.updateBar(durationForExit);
 
-        // lines, areas and cricles
+        // lines, areas and circles
         $$.updateLine(durationForExit);
         $$.updateArea(durationForExit);
         $$.updateCircle();

--- a/modoboa/bower_components/jquery-ui/jquery-ui.js
+++ b/modoboa/bower_components/jquery-ui/jquery-ui.js
@@ -4581,7 +4581,7 @@ $.extend(Datepicker.prototype, {
 			inst.input.focus();
 		}
 
-		// deffered render of the years select (to avoid flashes on Firefox)
+		// deferred render of the years select (to avoid flashes on Firefox)
 		if( inst.yearshtml ){
 			origyearshtml = inst.yearshtml;
 			setTimeout(function(){

--- a/modoboa/bower_components/jquery-ui/ui/datepicker.js
+++ b/modoboa/bower_components/jquery-ui/ui/datepicker.js
@@ -827,7 +827,7 @@ $.extend(Datepicker.prototype, {
 			inst.input.focus();
 		}
 
-		// deffered render of the years select (to avoid flashes on Firefox)
+		// deferred render of the years select (to avoid flashes on Firefox)
 		if( inst.yearshtml ){
 			origyearshtml = inst.yearshtml;
 			setTimeout(function(){


### PR DESCRIPTION
There are small typos in:
- modoboa/bower_components/c3/c3.js
- modoboa/bower_components/jquery-ui/jquery-ui.js
- modoboa/bower_components/jquery-ui/ui/datepicker.js

Fixes:
- Should read `deferred` rather than `deffered`.
- Should read `circles` rather than `cricles`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md