### PR TITLE
Mitigate spamhaus dns fail while querying for dnsbl

### DIFF
--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -82,7 +82,7 @@ class CheckMXRecords(BaseCommand):
                 #result from dnsbl is in ipv4 format
                 splited_result = result.split(".")
                 if int(splited_result[-1]) <= 15:
-                    #Typical dnsbl result : 127.255.255.[1-15] (depends on services)
+                    #Typical dnsbl result : 127.0.0.[1-15] (depends on services)
                     result = False
             except socket.gaierror:
                 result = False

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -79,6 +79,9 @@ class CheckMXRecords(BaseCommand):
             pattern = "{}.{}.".format(reverse, provider)
             try:
                 result = socket.gethostbyname(pattern)
+                #Mitigate Spamhaus status error (these codes don't mean ip is listed)
+                if result == "127.255.255.254" or result == "127.255.255.255":
+                    result = False
             except socket.gaierror:
                 result = False
             for mx in mxs:

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -79,8 +79,10 @@ class CheckMXRecords(BaseCommand):
             pattern = "{}.{}.".format(reverse, provider)
             try:
                 result = socket.gethostbyname(pattern)
-                #Mitigate Spamhaus status error (these codes don't mean ip is listed)
-                if result == "127.255.255.254" or result == "127.255.255.255":
+                #result from dnsbl is in ipv4 format
+                splited_result = result.split(".")
+                if int(splited_result[-1]) <= 15:
+                    #Typical dnsbl result : 127.255.255.[1-15] (depends on services)
                     result = False
             except socket.gaierror:
                 result = False

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -81,7 +81,7 @@ class CheckMXRecords(BaseCommand):
                 result = socket.gethostbyname(pattern)
                 #result from dnsbl is in ipv4 format
                 splited_result = result.split(".")
-                if int(splited_result[-1]) <= 15:
+                if int(splited_result[-1]) > 15:
                     #Typical dnsbl result : 127.0.0.[1-15] (depends on services)
                     result = False
             except socket.gaierror:

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -221,6 +221,19 @@ class DNSBLTestCase(ModoTestCase):
         management.call_command(
             "modo", "check_mx", "--email", "user@example.test")
         self.assertEqual(len(mail.outbox), 2)
+    
+    @mock.patch("gevent.socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "resolve")
+    def test_notifications_wrong_dnsbl_response(
+            self, mock_query, mock_getaddrinfo, mock_g_gethostbyname):
+        """Check notifications."""
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "127.255.255.254" #<--Spamhaus response when querying from an open resolver
+        management.call_command(
+            "modo", "check_mx", "--email", "user@example.test")
+        self.assertEqual(len(mail.outbox), 1)
 
     @mock.patch("gevent.socket.gethostbyname")
     @mock.patch("socket.getaddrinfo")

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -217,7 +217,7 @@ class DNSBLTestCase(ModoTestCase):
         """Check notifications."""
         mock_query.side_effect = utils.mock_dns_query_result
         mock_getaddrinfo.side_effect = utils.mock_ip_query_result
-        mock_g_gethostbyname.return_value = "1.2.3.4"
+        mock_g_gethostbyname.return_value = "127.0.0.4"
         management.call_command(
             "modo", "check_mx", "--email", "user@example.test")
         self.assertEqual(len(mail.outbox), 2)


### PR DESCRIPTION
Kind of same mitigation as modoboa/modoboa-installer#426 but for dnsbl check. 

I would be more in favor to simply drop spamhaus from dnsbl provider, but this could be a simple mitigation in case the user didn't set a dns resolver with rDNS.