### PR TITLE
IPv6 and rDNS checks, updated DKIMKeyViewer on vue admin

### DIFF
--- a/frontend/src/components/domains/DKIMKeyViewer.vue
+++ b/frontend/src/components/domains/DKIMKeyViewer.vue
@@ -9,20 +9,6 @@ export default {
     domain: Object
   },
   methods: {
-    splitKey (value) {
-      let key = value
-      const result = []
-      while (key.length > 0) {
-        if (key.length > 74) {
-          result.push(`  "${key.substring(0, 74)}"`)
-          key = key.substring(74)
-        } else {
-          result.push(`  "${key}"`)
-          break
-        }
-      }
-      return result.join('\n')
-    },
     copyDNSToClipboard () {
       const text = document.getElementById('dkimdns').textContent
       navigator.clipboard.writeText(text)

--- a/frontend/src/components/domains/DKIMKeyViewer.vue
+++ b/frontend/src/components/domains/DKIMKeyViewer.vue
@@ -1,5 +1,5 @@
 <template>
-<button @click="copySelToClipboard()"><pre>
+<button @click="copyToClipboard()"><pre>
 {{ domain.dkim_key_selector }}._domain_key.{{ domain.name }}. IN TXT (
   {{ splitKey(`v=DKIM1;k=rsa;p=${domain.dkim_public_key}`) }})</pre></button>
 </template>
@@ -11,7 +11,7 @@ export default {
   },
   methods: {
     copyToClipboard () {
-      const text = domain.dkim_key_selector + "_domain_key."+ domain.name + " . IN TXT " + "\"v=DKIM1;k=rsa;p=" + domain.dkim_public_key + "\""
+      const text = domain.dkim_key_selector + '_domain_key.' + domain.name + ' . IN TXT ' + '"v=DKIM1;k=rsa;p=' + domain.dkim_public_key + '"'
       navigator.clipboard.writeText(text)
     },
     splitKey (value) {

--- a/frontend/src/components/domains/DKIMKeyViewer.vue
+++ b/frontend/src/components/domains/DKIMKeyViewer.vue
@@ -1,7 +1,7 @@
 <template>
-<pre>
+<button @click="copySelToClipboard()"><pre>
 {{ domain.dkim_key_selector }}._domain_key.{{ domain.name }}. IN TXT (
-  {{ splitKey(`v=DKIM1;k=rsa;p=${domain.dkim_public_key}`) }})</pre>
+  {{ splitKey(`v=DKIM1;k=rsa;p=${domain.dkim_public_key}`) }})</pre></button>
 </template>
 
 <script>
@@ -10,6 +10,10 @@ export default {
     domain: Object
   },
   methods: {
+    copyToClipboard () {
+      const text = domain.dkim_key_selector + "_domain_key."+ domain.name + " . IN TXT " + "\"v=DKIM1;k=rsa;p=" + domain.dkim_public_key + "\""
+      navigator.clipboard.writeText(text)
+    },
     splitKey (value) {
       let key = value
       const result = []

--- a/frontend/src/components/domains/DKIMKeyViewer.vue
+++ b/frontend/src/components/domains/DKIMKeyViewer.vue
@@ -1,6 +1,6 @@
 <template>
 <button @click="copyDNSToClipboard()" class='dkimbutton'><p id='dkimdns' class='dkim'>
-{{ domain.dkim_key_selector }}._domain_key.{{ domain.name }}. IN TXT "v=DKIM1;k=rsa;p={{ domain.dkim_public_key }}"</p></button>
+{{ domain.dkim_key_selector }}._domain_key.{{ domain.name }}. IN TXT ({{ splitKey(`v=DKIM1;k=rsa;p=${domain.dkim_public_key}`) }})</p></button>
 </template>
 
 <script>
@@ -9,6 +9,20 @@ export default {
     domain: Object
   },
   methods: {
+    splitKey (value) {
+      let key = value
+      const result = []
+      while (key.length > 0) {
+        if (key.length > 74) {
+          result.push(`  "${key.substring(0, 74)}"`)
+          key = key.substring(74)
+        } else {
+          result.push(`  "${key}"`)
+          break
+        }
+      }
+      return result.join('\n')
+    },
     copyDNSToClipboard () {
       const text = document.getElementById('dkimdns').textContent
       navigator.clipboard.writeText(text)

--- a/frontend/src/components/domains/DKIMKeyViewer.vue
+++ b/frontend/src/components/domains/DKIMKeyViewer.vue
@@ -1,7 +1,6 @@
 <template>
-<button @click="copyToClipboard()"><pre>
-{{ domain.dkim_key_selector }}._domain_key.{{ domain.name }}. IN TXT (
-  {{ splitKey(`v=DKIM1;k=rsa;p=${domain.dkim_public_key}`) }})</pre></button>
+<button @click="copyDNSToClipboard()" class='dkimbutton'><p id='dkimdns' class='dkim'>
+{{ domain.dkim_key_selector }}._domain_key.{{ domain.name }}. IN TXT "v=DKIM1;k=rsa;p={{ domain.dkim_public_key }}"</p></button>
 </template>
 
 <script>
@@ -10,10 +9,6 @@ export default {
     domain: Object
   },
   methods: {
-    copyToClipboard () {
-      const text = domain.dkim_key_selector + '_domain_key.' + domain.name + ' . IN TXT ' + '"v=DKIM1;k=rsa;p=' + domain.dkim_public_key + '"'
-      navigator.clipboard.writeText(text)
-    },
     splitKey (value) {
       let key = value
       const result = []
@@ -27,6 +22,10 @@ export default {
         }
       }
       return result.join('\n')
+    },
+    copyDNSToClipboard () {
+      const text = document.getElementById('dkimdns').textContent
+      navigator.clipboard.writeText(text)
     }
   }
 }

--- a/frontend/src/components/domains/DNSDetail.vue
+++ b/frontend/src/components/domains/DNSDetail.vue
@@ -60,6 +60,20 @@
     <v-row>
       <v-col>
         <v-chip
+          v-if="detail.ipv6_record"
+          color="success"
+          >
+          <translate>IPV6 record found</translate>
+        </v-chip>
+        <v-chip
+          v-else
+          color="error"
+          >
+          <translate>IPV6 record not found</translate>
+        </v-chip>
+      </v-col>
+      <v-col>
+        <v-chip
           v-if="detail.spf_record"
           color="success"
           >
@@ -98,6 +112,20 @@
           color="error"
           >
           <translate>DMARC record not found</translate>
+        </v-chip>
+      </v-col>
+      <v-col>
+        <v-chip
+          v-if="detail.rdns_record"
+          color="success"
+          >
+          <translate>rDNS record found</translate>
+        </v-chip>
+        <v-chip
+          v-else
+          color="error"
+          >
+          <translate>rDNS record not found</translate>
         </v-chip>
       </v-col>
     </v-row>

--- a/frontend/src/components/domains/DNSDetail.vue
+++ b/frontend/src/components/domains/DNSDetail.vue
@@ -116,7 +116,7 @@
       </v-col>
       <v-col>
         <v-chip
-          v-if="detail.rdns_record"
+          v-if="(detail.rdns4_record && !domain.enable_ipv6) || (domain.enable_ipv6 && detail.rnds4_record && detail.rdns6_record)"
           color="success"
           >
           <translate>rDNS record found</translate>

--- a/frontend/src/components/domains/DomainDKIMKey.vue
+++ b/frontend/src/components/domains/DomainDKIMKey.vue
@@ -1,7 +1,4 @@
 <style>
-.v-alert {
-  word-break: break-all;
-}
 .dkimbutton {
   border-radius: 10px;
 }
@@ -15,7 +12,6 @@
 }
 .dkim {
   word-break: break-all;
-  overflow-wrap: anywhere;
 }
 </style>
 

--- a/frontend/src/components/domains/DomainDKIMKey.vue
+++ b/frontend/src/components/domains/DomainDKIMKey.vue
@@ -1,3 +1,24 @@
+<style>
+.v-alert {
+  word-break: break-all;
+}
+.dkimbutton {
+  border-radius: 10px;
+}
+.dkimbutton:hover {
+    background-color: rgba(131, 131, 250, 0.283);
+    transition: all 0.8s
+}
+.dkimbutton:active {
+    background-color: rgba(60, 255, 60, 0.136);
+    transition: all 0.2s
+}
+.dkim {
+  word-break: break-all;
+  overflow-wrap: anywhere;
+}
+</style>
+
 <template>
 <v-card>
   <v-card-title>
@@ -6,7 +27,7 @@
     </span>
   </v-card-title>
   <v-card-text>
-    <p><translate>Raw format</translate></p>
+    <p><translate>Raw format. Click to copy</translate></p>
     <v-alert
       border="left"
       colored-border
@@ -14,11 +35,11 @@
       elevation="2"
       dense
       >
-      {{ domain.dkim_public_key }}
+      <button @click="copyPubKeyToClipboard()" class='dkimbutton'><p id='dkimpub' class='dkim'>{{ domain.dkim_public_key }}</p></button>
     </v-alert>
   </v-card-text>
   <v-card-text>
-    <p><translate>Bind/named format</translate></p>
+    <p><translate>Bind/named format. Click to copy</translate></p>
     <v-alert
       border="left"
       colored-border
@@ -51,6 +72,10 @@ export default {
   methods: {
     close () {
       this.$emit('close')
+    },
+    copyPubKeyToClipboard () {
+      const text = document.getElementById('dkimpub').textContent
+      navigator.clipboard.writeText(text)
     }
   }
 }

--- a/frontend/src/components/domains/DomainDNSConfig.vue
+++ b/frontend/src/components/domains/DomainDNSConfig.vue
@@ -32,6 +32,18 @@ mail.{{ domain.name }}. IN A <strong>[<translate>IP address of your Modoboa serv
     </v-alert>
 
     <v-alert
+      border="left"
+      colored-border
+      color="primary lighten-3"
+      elevation="2"
+      dense
+      >
+      <div class="title">IPV6</div>
+      <pre>
+mail.{{ domain.name }}. IN AAAA <strong>[<translate>IPv6 address of your Modoboa server</translate>]</strong></pre>
+    </v-alert>
+
+    <v-alert
       v-if="domain.enable_dkim && domain.dkim_public_key"
       border="left"
       colored-border
@@ -65,6 +77,19 @@ _dmarc.{{ domain.name }}. IN TXT "v=DMARC1; p=quarantine; pct=100;"</pre>
 autoconfig.{{ domain.name }}. IN CNAME <strong>[<translate>hostname of your automx server</translate>]</strong>
 autodiscover.{{ domain.name }}. IN CNAME <strong>[<translate>hostname of your automx server</translate>]</strong></pre>
     </v-alert>
+
+    <v-alert
+      border="left"
+      colored-border
+      color="primary lighten-3"
+      elevation="2"
+      dense
+      >
+      <div class="title">rDNS</div>
+      <pre>
+<strong>[<translate>Contact your VPS provider, or check your admin console</translate>]</strong></pre>
+    </v-alert>
+
   </v-card-text>
   <v-card-actions>
     <v-spacer></v-spacer>

--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -91,6 +91,23 @@ class AdminParametersForm(param_forms.AdminParametersForm):
         )
     )
 
+    enable_ipv6_checks = YesNoField(
+        label=ugettext_lazy("Enable IPV6 checks"),
+        initial=True,
+        help_text=ugettext_lazy(
+            "Check if every domain has a valid AAAA record for IPV6"
+        )
+    )
+
+    enable_rdns_checks = YesNoField(
+        label=ugettext_lazy("Enable rDNS checks"),
+        initial=True,
+        help_text=ugettext_lazy(
+            "Check if every domain has a valid PTR record"
+        )
+    )
+
+
     custom_dns_server = GenericIPAddressField(
         label=ugettext_lazy("Custom DNS server"),
         required=False,

--- a/modoboa/admin/management/commands/subcommands/_mx.py
+++ b/modoboa/admin/management/commands/subcommands/_mx.py
@@ -221,6 +221,15 @@ class CheckMXRecords(BaseCommand):
         if param_tools.get_global_parameter("enable_spf_checks"):
             dns_models.DNSRecord.objects.get_or_create_for_domain(
                 domain, "spf", ttl)
+        if param_tools.get_global_parameter("enable_ipv6_checks"):
+            dns_models.DNSRecord.objects.get_or_create_for_domain(
+                domain, "ipv6", ttl)
+        if param_tools.get_global_parameter("enable_rdns_checks"):
+            dns_models.DNSRecord.objects.get_or_create_for_domain(
+                domain, "rdns4", ttl)
+            if param_tools.get_global_parameter("enable_ipv6_checks"):
+                dns_models.DNSRecord.objects.get_or_create_for_domain(
+                    domain, "rdns6", ttl)
         condition = (
             param_tools.get_global_parameter("enable_dkim_checks") and
             domain.dkim_public_key

--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -179,6 +179,15 @@ class Domain(mixins.MessageLimitMixin, AdminObject):
                 errors.append("autoconfig")
             if self.autodiscover_record is None:
                 errors.append("autodiscover")
+        if config["enable_ipv6_checks"]:
+            if self.ipv6_record is None:
+                errors.append("ipv6")
+        if config["enable_rdns_checks"]:
+            if self.rdns4_record is None:
+                errors.append("rdns")
+            if config["enable_ipv6_checks"]:
+                if self.rdns6_record is None:
+                    errors.append("rdns")
         if len(errors) == 0:
             return "ok"
         return "critical"
@@ -212,6 +221,21 @@ class Domain(mixins.MessageLimitMixin, AdminObject):
     def autoconfig_record(self):
         """Return autoconfig record."""
         return self.dnsrecord_set.filter(type="autoconfig").first()
+
+    @property
+    def ipv6_record(self):
+        """Return IPV6 record"""
+        return self.dnsrecord_set.filter(type="ipv6").first()
+
+    @property
+    def rdns4_record(self):
+        """Return rDNS record for ipv4"""
+        return self.dnsrecord_set.filter(type="rdns4").first()
+
+    @property
+    def rdns6_record(self):
+        """Return rDNS record for ipv6"""
+        return self.dnsrecord_set.filter(type="rdns6").first()
 
     @property
     def autodiscover_record(self):

--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -289,16 +289,16 @@ class Domain(mixins.MessageLimitMixin, AdminObject):
         # TXT records longer than 255 characters need split into chunks
         # split record into 74 character chunks (+2 for indent, +2 for quotes(")
         # == 78 characters) to make more readable in text editors.
-        split_record = []
+        split_record = ""
         while record:
             if len(record) > 74:
-                split_record.append("  \"%s\"" % record[:74])
+                split_record += (" \"%s\"" % record[:74])
                 record = record[74:]
             else:
-                split_record.append("  \"%s\"" % record)
+                split_record += (" \"%s\"" % record)
                 break
-        record = "\n".join(split_record)
-        return "{}._domainkey.{}. IN TXT (\n{})".format(
+        record = split_record
+        return "{}._domainkey.{}. IN TXT ({})".format(
             self.dkim_key_selector, self.name, record)
 
     def add_admin(self, account):

--- a/modoboa/admin/static/admin/css/admin.css
+++ b/modoboa/admin/static/admin/css/admin.css
@@ -31,3 +31,18 @@ table tbody tr:hover {
     -webkit-border-radius:14px;-moz-border-radius:14px;border-radius:14px;
     padding-left: 14px;
 }
+
+.dkimbutton {
+    border-radius: 10px;
+}
+.dkimbutton:hover {
+    background-color: rgba(131, 131, 250, 0.283);
+    transition: all 0.8s
+}
+.dkimbutton:active {
+    background-color: rgba(60, 255, 60, 0.136);
+    transition: all 0.2s
+}
+.dkim {
+word-break: break-all;
+}

--- a/modoboa/admin/templates/admin/_domain_dkim_key.html
+++ b/modoboa/admin/templates/admin/_domain_dkim_key.html
@@ -8,12 +8,12 @@
     </div>
     <div class="modal-body">
       <div class="alert alert-info" style="overflow-wrap: break-word;">
-        <strong>{% trans "Raw format" %}</strong><br>
-        {{ domain.dkim_public_key }}
+        <strong>{% trans "Raw format. Click to copy" %}</strong><br>
+        <button onclick="copyRaw()" class="dkimbutton" id="copy_raw_dkim_key"><p class="dkim">{{ domain.dkim_public_key }}</p></button>
       </div>
       <div class="alert alert-info" style="overflow-wrap: break-word;">
-        <strong>{% trans "Bind/named format" %}</strong><br>
-        <span style="white-space: pre">{{ domain.bind_format_dkim_public_key }}</span>
+        <strong>{% trans "Bind/named format. Click to copy" %}</strong><br>
+        <button onclick="copyDns()" class="dkimbutton" id="copy_dns_dkim_key"><p class="dkim">{{ domain.bind_format_dkim_public_key }}</p></button>
       </div>
     </div>
     <div class="modal-footer">

--- a/modoboa/admin/templates/admin/_domain_dnschecks_status.html
+++ b/modoboa/admin/templates/admin/_domain_dnschecks_status.html
@@ -37,6 +37,37 @@
         <a href="{% url 'dnstools:dns_record_detail' domain.dmarc_record.pk %}" data-toggle="ajaxmodal">DMARC</a></span>
     {% endif %}
   {% endif %}
+  {% if enable_ipv6_checks %}
+    {% if not domain.ipv6_record %}
+      <span class="label label-mini label-danger" title="{% trans 'No record found' %}">IPV6</span>
+    {% else %}      
+      <span class="label label-mini label-{% if not domain.ipv6_record.is_valid %}warning{% else %}success{% endif %}">
+        <a href="{% url 'dnstools:dns_record_detail' domain.ipv6_record.pk %}" data-toggle="ajaxmodal">IPV6</a></span>
+    {% endif %}
+  {% endif %}
+  {% if enable_rdns_checks %}
+    {% if not domain.rdns4_record %}
+      <span class="label label-mini label-danger" title="{% trans 'No record found' %}">RDNS</span>
+    {% elif domain.rdns4_record and enable_rdns_checks and not domain.rdns6_record %}  
+    {% else %}
+      {% if domain.rdns4_record.is_valid %}
+        {% if enable_ipv6_check %}
+          {% if domain.rdns6_record.is_valid %} 
+            <span class="label label-mini label-success">
+          {% else %} 
+            <span class="label label-mini label-warning">  
+          {% endif %}
+          <a href="{% url 'dnstools:dns_record_detail' domain.rdns6_record.pk %}" data-toggle="ajaxmodal">RDNS</a></span>
+        {% else %} 
+        <span class="label label-mini label-success">
+          <a href="{% url 'dnstools:dns_record_detail' domain.rdns4_record.pk %}" data-toggle="ajaxmodal">RDNS</a></span>
+        {% endif %}
+      {% else %}
+        <span class="label label-mini label-warning">
+          <a href="{% url 'dnstools:dns_record_detail' domain.rdns4_record.pk %}" data-toggle="ajaxmodal">RDNS</a></span>
+      {% endif %}
+    {% endif %}
+  {% endif %}
   {% if enable_autoconfig_checks %}
     {% if not domain.autoconfig_record and not domain.autodiscover_record %}
       <span class="label label-mini label-danger" title="{% trans 'No record found' %}">autoconfig</span>

--- a/modoboa/admin/templates/admin/domain_detail.html
+++ b/modoboa/admin/templates/admin/domain_detail.html
@@ -187,5 +187,13 @@
           });
       });
   });
+  function copyRaw() {
+    const text = document.getElementById("copy_raw_dkim_key").textContent;
+    navigator.clipboard.writeText(text);
+  }
+  function copyDns() {
+    const text =document.getElementById("copy_dns_dkim_key").textContent;
+    navigator.clipboard.writeText(text);
+  }
   </script>
 {% endblock %}

--- a/modoboa/admin/views/domain.py
+++ b/modoboa/admin/views/domain.py
@@ -74,7 +74,9 @@ def _domains(request):
         "enable_dmarc_checks": parameters.get_value("enable_dmarc_checks"),
         "enable_autoconfig_checks": (
             parameters.get_value("enable_autoconfig_checks")),
-        "enable_dnsbl_checks": parameters.get_value("enable_dnsbl_checks")
+        "enable_dnsbl_checks": parameters.get_value("enable_dnsbl_checks"),
+        "enable_ipv6_checks": parameters.get_value("enable_ipv6_checks"),
+        "enable_rdns_checks": parameters.get_value("enable_rdns_checks")
     }
     context["headers"] = render_to_string(
         "admin/domain_headers.html", dns_checks, request
@@ -109,7 +111,9 @@ def domains(request, tplname="admin/domains.html"):
         "enable_dmarc_checks": parameters.get_value("enable_dmarc_checks"),
         "enable_autoconfig_checks": (
             parameters.get_value("enable_autoconfig_checks")),
-        "enable_dnsbl_checks": parameters.get_value("enable_dnsbl_checks")
+        "enable_dnsbl_checks": parameters.get_value("enable_dnsbl_checks"),
+        "enable_ipv6_checks": parameters.get_value("enable_ipv6_checks"),
+        "enable_rdns_checks": parameters.get_value("enable_rdns_checks")
     })
 
 
@@ -277,6 +281,8 @@ class DomainDetailView(
             "enable_autoconfig_checks": (
                 parameters.get_value("enable_autoconfig_checks")),
             "enable_dnsbl_checks": parameters.get_value("enable_dnsbl_checks"),
+            "enable_ipv6_checks": parameters.get_value("enable_ipv6_checks"),
+            "enable_rdns_checks": parameters.get_value("enable_rdns_checks")
         })
         for _receiver, widgets in result:
             for widget in widgets:

--- a/modoboa/dnstools/api/v2/serializers.py
+++ b/modoboa/dnstools/api/v2/serializers.py
@@ -42,10 +42,14 @@ class DNSDetailSerializer(serializers.ModelSerializer):
     dkim_record = DNSRecordSerializer()
     dmarc_record = DNSRecordSerializer()
     dnsbl_results = DNSBLResultSerializer(many=True, source="dnsblresult_set")
+    rdns4_record = DNSRecordSerializer()
+    rdns6_record = DNSRecordSerializer()
+    ipv6_record = DNSRecordSerializer()
 
     class Meta:
         model = admin_models.Domain
         fields = (
             "mx_records", "dnsbl_results", "autoconfig_record",
-            "autodiscover_record", "spf_record", "dkim_record", "dmarc_record"
+            "autodiscover_record", "spf_record", "dkim_record", "dmarc_record",
+            "ipv6_record", "rdns4_record", "rdns6_record"
         )

--- a/modoboa/dnstools/constants.py
+++ b/modoboa/dnstools/constants.py
@@ -9,6 +9,9 @@ DNS_RECORD_TYPES = [
     ("dmarc", "DMARC"),
     ("autoconfig", "Autoconfig"),
     ("autodiscover", "Autodiscover"),
+    ("ipv6", "IPV6"),
+    ("rdns4", "rDNS4"),
+    ("rdns6", "rDNS6")
 ]
 
 SPF_MECHANISMS = ["ip4", "ip6", "a", "mx", "ptr", "exists", "include"]

--- a/modoboa/dnstools/lib.py
+++ b/modoboa/dnstools/lib.py
@@ -99,11 +99,11 @@ def get_ipv6_record(domain):
 
 def get_rdns4_record(domain):
     """Return rdns record for ipv4"""
-    return _get_ptr_record("mail.{}".format(domain), "A", domain)
+    return _get_ptr_record("mail.{}".format(domain), "A")
 
 def get_rdns6_record(domain):
     """Return rdns reocrd for ipv6"""
-    return _get_ptr_record("mail.{}".format(domain), "AAAA", domain)
+    return _get_ptr_record("mail.{}".format(domain), "AAAA")
 
 
 
@@ -305,7 +305,7 @@ def check_dmarc_syntax(record):
 def check_ipv6_syntax(record):
     """Check if record has valid ipv6 syntax"""
     try: 
-        ipaddress.ip_address(record)
+        ipaddress.ip_network(record, False)
     except ValueError:
         raise DNSSyntaxError(_("IPv6 syntax is not good"))
 

--- a/modoboa/dnstools/templates/dnstools/domain_dns_configuration.html
+++ b/modoboa/dnstools/templates/dnstools/domain_dns_configuration.html
@@ -14,6 +14,9 @@
   <pre>
 mail.{{ domain.name }}. IN A <strong>[{% trans "IP address of your Modoboa server" %}]</strong>
 @ IN MX 10 mail.{{ domain.name }}.</pre>
+  IPV6
+  <pre>
+mail.{{ domain.name }}. IN AAAA  <strong>[{% trans "IP address of your Modoboa server" %}]</strong></pre>
   SPF
   <pre>
 @ IN TXT "v=spf1 mx ~all"</pre>
@@ -29,5 +32,7 @@ _dmarc.{{ domain.name }}. IN TXT "v=DMARC1; p=quarantine; pct=100;"</pre>
   <pre>
 autoconfig.{{ domain.name }}. IN CNAME <strong>[{% trans "hostname of your automx server" %}]</strong>
 autodiscover.{{ domain.name }}. IN CNAME <strong>[{% trans "hostname of your automx server" %}]</strong></pre>
-
+  rDNS
+<pre>
+<strong>Please contact your VPS provider, or check your admin console</strong></pre>
 {% endblock %}


### PR DESCRIPTION
This PR add checks for IPv6 set (pointed to mail.example.com.). As well as rDNS checks (for IPv4 and IPv6 if IPv6 checking is enabled).
I also refactored a bit the DKIMKeyViewer to prevent overflow of the v-alert, and added the ability to one-click copy it to clipboard.

Note: there are several migrations needed, it seems.
