### PR TITLE
Fix asyncio.start_server call (unexpected keyword argument 'loop')

### DIFF
--- a/modoboa/policyd/management/commands/policy_daemon.py
+++ b/modoboa/policyd/management/commands/policy_daemon.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         """Entry point."""
         loop = asyncio.get_event_loop()
         coro = asyncio.start_server(
-            core.new_connection, options["host"], options["port"], loop=loop
+            core.new_connection, options["host"], options["port"]
         )
         server = loop.run_until_complete(coro)
 


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
The loop parameter was not necessary and was removed in Python 3.10. This was causing an error preventing the server from starting up at all in Python 3.10.

Current behavior before PR:

Desired behavior after PR is merged:
