### PR TITLE
removed html dump to file

### DIFF
--- a/modoboa/lib/email_utils.py
+++ b/modoboa/lib/email_utils.py
@@ -253,8 +253,6 @@ class Email(object):
         )
         mail_text = lxml.html.tostring(
             cleaner.clean_html(html), encoding="unicode")
-        with open("/tmp/output.txt", "w") as fp:
-            fp.write(mail_text)
         return smart_text(mail_text)
 
     def _map_cid(self, url):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
see #2572 

HTML emails would be dumped into ``/tmp/output.txt``. I didn't find any call for this file. Considering it useless.

