### PR TITLE
Fixed core parameters unable to save on v2

### DIFF
--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -94,6 +94,7 @@ class AdminParametersForm(param_forms.AdminParametersForm):
     custom_dns_server = GenericIPAddressField(
         label=ugettext_lazy("Custom DNS server"),
         required=False,
+        initial="",
         help_text=ugettext_lazy(
             "Use a custom DNS server instead of local server configuration"
         )

--- a/modoboa/core/api/v2/serializers.py
+++ b/modoboa/core/api/v2/serializers.py
@@ -107,7 +107,8 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     )
 
     # Dashboard settings
-    rss_feed_url = serializers.URLField(allow_blank=True, required=False, allow_null=True)
+    rss_feed_url = serializers.URLField(
+        allow_blank=True, required=False, allow_null=True)
     hide_features_widget = serializers.BooleanField(default=False)
 
     # Notification settings
@@ -135,7 +136,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
         for field, definition in sms_backend_fields.items():
             self.fields[field] = definition["type"](
                 **definition["attrs"])
-        #Choices serializer for default_top_redirection field
+        # Choices serializer for default_top_redirection field
         self.fields["default_top_redirection"].choices = app_settings.enabled_applications()
 
     def validate_ldap_user_dn_template(self, value):

--- a/modoboa/core/api/v2/serializers.py
+++ b/modoboa/core/api/v2/serializers.py
@@ -127,7 +127,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     log_maximum_age = serializers.IntegerField(default=365)
     items_per_page = serializers.IntegerField(default=30)
     default_top_redirection = serializers.ChoiceField(
-        default="user", choices=app_settings.enabled_applications(), required=False)
+        default="user", choices=[("user", _("User profile"))], required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -135,6 +135,8 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
         for field, definition in sms_backend_fields.items():
             self.fields[field] = definition["type"](
                 **definition["attrs"])
+        #Choices serializer for default_top_redirection field
+        self.fields["default_top_redirection"].choices = app_settings.enabled_applications()
 
     def validate_ldap_user_dn_template(self, value):
         try:

--- a/modoboa/core/api/v2/serializers.py
+++ b/modoboa/core/api/v2/serializers.py
@@ -13,6 +13,7 @@ from modoboa.lib import fields as lib_fields
 from ... import constants
 from ... import models
 from ... import sms_backends
+from ... import app_settings
 
 
 class CoreGlobalParametersSerializer(serializers.Serializer):
@@ -106,7 +107,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     )
 
     # Dashboard settings
-    rss_feed_url = serializers.URLField(allow_blank=True)
+    rss_feed_url = serializers.URLField(allow_blank=True, required=False)
     hide_features_widget = serializers.BooleanField(default=False)
 
     # Notification settings
@@ -126,7 +127,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     log_maximum_age = serializers.IntegerField(default=365)
     items_per_page = serializers.IntegerField(default=30)
     default_top_redirection = serializers.ChoiceField(
-        default="user", choices=[""])
+        default="user", choices=app_settings.enabled_applications())
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/modoboa/core/api/v2/serializers.py
+++ b/modoboa/core/api/v2/serializers.py
@@ -45,7 +45,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
         required=False, allow_blank=True)
     sms_password_recovery = serializers.BooleanField(default=False)
     sms_provider = serializers.ChoiceField(
-        choices=constants.SMS_BACKENDS, required=False)
+        choices=constants.SMS_BACKENDS, required=False, allow_null=True)
 
     # LDAP settings
     ldap_server_address = serializers.CharField(default="localhost")
@@ -107,7 +107,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     )
 
     # Dashboard settings
-    rss_feed_url = serializers.URLField(allow_blank=True, required=False)
+    rss_feed_url = serializers.URLField(allow_blank=True, required=False, allow_null=True)
     hide_features_widget = serializers.BooleanField(default=False)
 
     # Notification settings
@@ -127,7 +127,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     log_maximum_age = serializers.IntegerField(default=365)
     items_per_page = serializers.IntegerField(default=30)
     default_top_redirection = serializers.ChoiceField(
-        default="user", choices=app_settings.enabled_applications())
+        default="user", choices=app_settings.enabled_applications(), required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/modoboa/core/api/v2/tests.py
+++ b/modoboa/core/api/v2/tests.py
@@ -58,7 +58,7 @@ CORE_SETTINGS = {
     "top_notifications_check_interval": 30,
     "log_maximum_age": 365,
     "items_per_page": 30,
-    "default_top_redirection": ""
+    "default_top_redirection": "user"
 }
 
 

--- a/modoboa/core/sms_backends/ovh.py
+++ b/modoboa/core/sms_backends/ovh.py
@@ -76,21 +76,24 @@ class OVHBackend(SMSBackend):
             "type": serializers.CharField,
             "attrs": {
                 "required": False,
-                "allow_blank": True
+                "allow_blank": True,
+                "allow_null": True,
             }
         },
         "sms_ovh_application_secret": {
             "type": serializers.CharField,
             "attrs": {
                 "required": False,
-                "allow_blank": True
+                "allow_blank": True,
+                "allow_null": True,
             }
         },
         "sms_ovh_consumer_key": {
             "type": serializers.CharField,
             "attrs": {
                 "required": False,
-                "allow_blank": True
+                "allow_blank": True,
+                "allow_null": True,
             }
         }
     }

--- a/modoboa/core/sms_backends/ovh.py
+++ b/modoboa/core/sms_backends/ovh.py
@@ -75,19 +75,22 @@ class OVHBackend(SMSBackend):
         "sms_ovh_application_key": {
             "type": serializers.CharField,
             "attrs": {
-                "required": False
+                "required": False,
+                "allow_blank": True
             }
         },
         "sms_ovh_application_secret": {
             "type": serializers.CharField,
             "attrs": {
-                "required": False
+                "required": False,
+                "allow_blank": True
             }
         },
         "sms_ovh_consumer_key": {
             "type": serializers.CharField,
             "attrs": {
-                "required": False
+                "required": False,
+                "allow_blank": True
             }
         }
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
fixes #2559 
User can now save core parameters on new-admin.
