### PR TITLE
add python3-certbot-nginx to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ qrcode
 
 aiosmtplib
 aioredis==2.0.1
+python3-certbot-nginx # to fix issues like https://discord.com/channels/930814728928895078/936543858374873138/1019355699337236571


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
avoids error messages regarding certbot-nginx py plugin like:
- https://discord.com/channels/930814728928895078/936543858374873138/1019355699337236571 (Modoboa discord, Foghunter message)
- https://github.com/modoboa/modoboa/issues/2129 

**Current behavior before PR:**
Issues with missing python3-certbot-nginx

**Desired behavior after PR is merged:**
Error message should not pop up anymore, due to solving of the root cause. 

Note: idk if this is 100% correct, but theoretically it should be. 