### PR TITLE
fix: use dbport settings in generate_postfix_map

### DIFF
--- a/modoboa/core/management/commands/generate_postfix_maps.py
+++ b/modoboa/core/management/commands/generate_postfix_maps.py
@@ -99,6 +99,11 @@ query = {{ query|safe }}
             dbtype = "postgres"
         else:
             dbtype = "mysql"
+        dbhost = db_settings.get("HOST", "127.0.0.1")
+        dbport = db_settings.get("PORT", "")
+        if len(dbport):
+            dbhost += ':' + dbport
+
         commandline = "{} {}".format(
             os.path.basename(sys.argv[0]), " ".join(sys.argv[1:]))
         context = {
@@ -108,7 +113,7 @@ query = {{ query|safe }}
             "dbuser": db_settings["USER"],
             "dbpass": db_settings["PASSWORD"],
             "dbname": db_settings["NAME"],
-            "dbhost": db_settings.get("HOST", "127.0.0.1"),
+            "dbhost": dbhost
         }
         return context
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: #2608 

Current behavior before PR:

port is not appended to host (see [mysql_table](http://www.postfix.org/mysql_table.5.html) and [pgsql_table](https://www.postfix.org/pgsql_table.5.html))

```
# This file was generated on Sept. 22, 2022, 12:38 p.m. by running:
# manage.py generate_postfix_maps --settings itsufficient.settings_local --force-overwrite --destdir /etc/postfix
# DO NOT EDIT!
user = v-kubernet-mail_mod-x
password = y
dbname = modoboa
hosts = pgbouncer.db
query = SELECT service || ':' || next_hop FROM transport_transport WHERE pattern='%s'
```

Desired behavior after PR is merged:

```
# This file was generated on Sept. 22, 2022, 12:38 p.m. by running:
# manage.py generate_postfix_maps --settings itsufficient.settings_local --force-overwrite --destdir /etc/postfix
# DO NOT EDIT!
user = v-kubernet-mail_mod-x
password = y
dbname = modoboa
hosts = pgbouncer.db:6432
query = SELECT service || ':' || next_hop FROM transport_transport WHERE pattern='%s'
```