### PR TITLE
Fixed statistics empty on GUIv2

### DIFF
--- a/frontend/src/components/tools/TimeSerieChart.vue
+++ b/frontend/src/components/tools/TimeSerieChart.vue
@@ -79,7 +79,6 @@ export default {
       dateMenu: false,
       menu: false,
       options: {
-        colors: [],
         chart: {
           type: 'area',
           stacked: false,


### PR DESCRIPTION
Having an empty color made ApexCharts crash. 