### PR TITLE
Replace py-dateutil with python-dateutil

### DIFF
--- a/.github/workflows/modoboa.yml
+++ b/.github/workflows/modoboa.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         database: ['postgres', 'mysql']
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
       fail-fast: false
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ gevent==22.10.1
 jsonfield==3.1.0
 Pillow  # Optional dependency for django-ckeditor
 progressbar33==2.4
-py-dateutil==2.2
+python-dateutil
 cryptography
 pytz
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}
+envlist = py{37,38,39,310}
 
 [testenv]
 changedir = test_project


### PR DESCRIPTION
`py-dateutil` is abandoned, it hasn't been touched since 2014. With Python 3.10, I receive errors like: `module 'collections' has no attribute 'Callable'`.

`python-dateutil` seems to be the maintained fork of `py-dateutil`, and a drop-in replacement. Test suite runs equally with or without the changed dependency.

```
Environment:


Request Method: GET
Request URL: https://modoboa.example.net/dashboard/

Django Version: 3.2.16
Python Version: 3.10.6
Installed Applications:
('django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.messages',
 'django.contrib.sites',
 'django.contrib.staticfiles',
 'reversion',
 'ckeditor',
 'ckeditor_uploader',
 'rest_framework',
 'rest_framework.authtoken',
 'drf_spectacular',
 'phonenumber_field',
 'django_otp',
 'django_otp.plugins.otp_totp',
 'django_otp.plugins.otp_static',
 'modoboa',
 'modoboa.core',
 'modoboa.lib',
 'modoboa.admin',
 'modoboa.transport',
 'modoboa.relaydomains',
 'modoboa.limits',
 'modoboa.parameters',
 'modoboa.dnstools',
 'modoboa.policyd',
 'modoboa.maillog')
Installed Middleware:
('x_forwarded_for.middleware.XForwardedForMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django_otp.middleware.OTPMiddleware',
 'modoboa.core.middleware.TwoFAMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.locale.LocaleMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'modoboa.core.middleware.LocalConfigMiddleware',
 'modoboa.lib.middleware.AjaxLoginRedirect',
 'modoboa.lib.middleware.CommonExceptionCatcher',
 'modoboa.lib.middleware.RequestCatcherMiddleware')



Traceback (most recent call last):
  File "/var/www/modoboa/env/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/modoboa/core/views/dashboard.py", line 27, in dispatch
    return super(DashboardView, self).dispatch(request, *args, **kwargs)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/django/views/generic/base.py", line 159, in get
    context = self.get_context_data(**kwargs)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/modoboa/core/views/dashboard.py", line 52, in get_context_data
    entry["published"] = parser.parse(entry["published"])
  File "/var/www/modoboa/env/lib/python3.10/site-packages/dateutil/parser.py", line 748, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/var/www/modoboa/env/lib/python3.10/site-packages/dateutil/parser.py", line 324, in parse
    if isinstance(tzinfos, collections.Callable) or tzinfos and res.tzname in tzinfos:

Exception Type: AttributeError at /dashboard/
Exception Value: module 'collections' has no attribute 'Callable'
```