### PR TITLE
Update frontend doc and fix new admin default url

### DIFF
--- a/doc/rest_api.rst
+++ b/doc/rest_api.rst
@@ -11,13 +11,14 @@ documentation.
 **You will find them using the following url patterns:**
 
 * New API+Docs: *https://<hostname>/api/schema-v2/swagger/*
-* Old API: *http://<hostname>/api/v1/
+* Old API: *http://<hostname>/api/v1/*
 * (Old) Documentation: *http://<hostname>/docs/api/*
 
 **Examples:**
 
 * `new example <https://demo.modoboa.org/api/schema-v2/swagger/>`_
 * `old example <https://demo.modoboa.org/docs/api/>`_ 
+
 documentation is available on the official demo.
 
 Using this API requires an authentication and for now, only a token

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -54,17 +54,19 @@ New-admin interface
 ===================
 
 .. note::
-   You don't need to perform these actions if you installed modoboa after 2.0.5.
+   You don't need to perform these actions if you use the installer to upgrade your instance.
 
-New admin interface won't update by itself. To fix this, run the following commands (you need to perform this only one time):
+New admin interface won't update by itself. Run the following commands to update it:
 
 .. sourcecode:: bash
 
    > sudo -u <modoboa_user> -i bash
    > cd <modoboa_instance_dir>
+   > cp frontend/config.json ./
    > rm -rf frontend
-   > ln -s <virtuenv_path>/lib/pythonX.X/site-packages/modoboa/frontend_dist/ frontend/
-
+   > cp -R <virtuenv_path>/lib/pythonX.X/site-packages/modoboa/frontend_dist/ frontend/
+   > cp ./config.json frontend/config.json
+ 
 Extensions
 **********
 

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -50,6 +50,18 @@ Make sure to use root privileges and run the following command:
 
 Then, reload postfix.
 
+New-admin interface
+===================
+
+New admin interface won't update by itself. To do so, run the following commands:
+
+.. sourcecode:: bash
+
+   > sudo -u <modoboa_user> -i bash
+   > cd <modoboa_instance_dir>
+   > rm -rf frontend
+   > cp -R <virtuenv_path>/lib/pythonX.X/site-packages/modoboa/frontend_dist/ frontend/
+
 Extensions
 **********
 

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -53,14 +53,17 @@ Then, reload postfix.
 New-admin interface
 ===================
 
-New admin interface won't update by itself. To do so, run the following commands:
+.. note::
+   You don't need to perform these actions if you installed modoboa after 2.0.5.
+
+New admin interface won't update by itself. To fix this, run the following commands (you need to perform this only one time):
 
 .. sourcecode:: bash
 
    > sudo -u <modoboa_user> -i bash
    > cd <modoboa_instance_dir>
    > rm -rf frontend
-   > cp -R <virtuenv_path>/lib/pythonX.X/site-packages/modoboa/frontend_dist/ frontend/
+   > ln -s <virtuenv_path>/lib/pythonX.X/site-packages/modoboa/frontend_dist/ frontend/
 
 Extensions
 **********
@@ -136,13 +139,13 @@ The following modifications must be applied to the :file:`settings.py` file:
    ]
 
 
-* Add the following variable::
+* Add the following variable:
 
 .. sourcecode:: python
 
    PID_FILE_STORAGE_PATH = '/var/run'
 
-* Update ``LOGGING`` variable to define an address for ``syslog-auth`` handler::
+* Update ``LOGGING`` variable to define an address for ``syslog-auth`` handler:
 
 .. sourcecode:: python
 
@@ -154,9 +157,8 @@ The following modifications must be applied to the :file:`settings.py` file:
    },
 
 
-* You now have the possibility to customize the url of the new-admin
-interface.  To do so please head up to :ref:`the custom configuration
-chapter <customization>` (advanced user).
+* You now have the possibility to customize the url of the new-admin interface.  
+   To do so please head up to :ref:`the custom configuration chapter <customization>` (advanced user).
 
 * Add ``DEFAULT_THROTTLE_RATES`` to ``REST_FRAMEWORK``:
 

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -273,7 +273,7 @@ class DeployCommand(Command):
         if not os.path.exists(base_frontend_dir):
             return
         frontend_target_dir = "{}/frontend".format(parsed_args.name)
-        shutil.copytree(base_frontend_dir, frontend_target_dir)
+        os.symlink(base_frontend_dir, frontend_target_dir, True)
 
         with open("{}/config.json".format(frontend_target_dir), "w") as fp:
             fp.write("""{

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -273,7 +273,7 @@ class DeployCommand(Command):
         if not os.path.exists(base_frontend_dir):
             return
         frontend_target_dir = "{}/frontend".format(parsed_args.name)
-        os.symlink(base_frontend_dir, frontend_target_dir, True)
+        shutil.copytree(base_frontend_dir, frontend_target_dir)
 
         with open("{}/config.json".format(frontend_target_dir), "w") as fp:
             fp.write("""{

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -213,7 +213,7 @@ REST_FRAMEWORK = {
 }
 
 # Uncomment if you need a custom sub url for new_admin interface
-# NEW_ADMIN_URL = 'new_admin'
+# NEW_ADMIN_URL = 'new-admin'
 
 SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX': r'/api/v[0-9]',

--- a/modoboa/core/context_processors.py
+++ b/modoboa/core/context_processors.py
@@ -25,5 +25,5 @@ def top_notifications(request):
 def new_admin_url(*args):
     """A context processor to include new admin url."""
     return {
-        "new_admin": getattr(settings, "NEW_ADMIN_URL", "new_admin")
+        "new_admin": getattr(settings, "NEW_ADMIN_URL", "new-admin")
     }

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -205,7 +205,7 @@ REST_FRAMEWORK = {
 }
 
 # Uncomment if you need a custom sub url for new_admin interface
-# NEW_ADMIN_URL = 'new_admin'
+# NEW_ADMIN_URL = 'new-admin'
 
 SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX': r'/api/v[0-9]',


### PR DESCRIPTION
* Added instructions to update the frontend manually.
* Fixed a few formatting errors across the documentation.
* Fixed the default new-admin url from `new_admin` to `new-admin` (true default).