### PR TITLE
Add gettext alpine package for compiling translations + force compili…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,12 @@ services:
       PYTHONPATH: ".."
       DB: "SQLITE"
       DEBUG: "True"
-    command: sh -c "cd test_project && python3 manage.py migrate && python3 manage.py load_initial_data && python3 manage.py runserver 0:8000"
+    command: >
+      sh -c "cd test_project
+             python3 manage.py migrate
+             python3 manage.py load_initial_data
+             django-admin compilemessages
+             python3 manage.py runserver 0:8000"
     volumes:
       - .:/code
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -7,7 +7,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 FROM base as build
 
 RUN apk add --update openssl librrd python3-dev libffi-dev gcc g++ musl-dev libxml2-dev libxslt-dev \
-    libressl-dev jpeg-dev rrdtool-dev file make \
+    libressl-dev jpeg-dev rrdtool-dev file make gettext \
     && rm -rf /var/cache/apk/*
 RUN python3 -m venv $VIRTUAL_ENV
 WORKDIR /tmp


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Add missing gettext alpine package in the api container + force re-compiling translations every time the server is starting up

Current behavior before PR:

Can't perform the command django-admin compilemessages because of missing msgfmt command.

Desired behavior after PR is merged:

django-admin compilemessages will now work and will be automatic
