### PR TITLE
Change middlwares order and set cookies cookies instead of using depr…

### DIFF
--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -393,20 +393,20 @@ packages to ``INSTALLED_APPS``:
        'django_otp.plugins.otp_static',
    )
 
-Add new middlewares to ``MIDDLEWARE``:
+Add new middlewares to ``MIDDLEWARE``. It has to be after the SessionMiddleware and before the CommonMiddleware:
 
 .. sourcecode:: python
 
    MIDDLEWARE = (
        'x_forwarded_for.middleware.XForwardedForMiddleware',
        'django.contrib.sessions.middleware.SessionMiddleware',
+       'django.middleware.locale.LocaleMiddleware',
        'django.middleware.common.CommonMiddleware',
        'django.middleware.csrf.CsrfViewMiddleware',
        'django.contrib.auth.middleware.AuthenticationMiddleware',
        'django_otp.middleware.OTPMiddleware',
        'modoboa.core.middleware.TwoFAMiddleware',
        'django.contrib.messages.middleware.MessageMiddleware',
-       'django.middleware.locale.LocaleMiddleware',
        'django.middleware.clickjacking.XFrameOptionsMiddleware',
        'modoboa.core.middleware.LocalConfigMiddleware',
        'modoboa.lib.middleware.AjaxLoginRedirect',

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -97,15 +97,15 @@ INSTALLED_APPS += MODOBOA_APPS
 AUTH_USER_MODEL = 'core.User'
 
 MIDDLEWARE = (
-    'x_forwarded_for.middleware.XForwardedForMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'x_forwarded_for.middleware.XForwardedForMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django_otp.middleware.OTPMiddleware',
     'modoboa.core.middleware.TwoFAMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'modoboa.core.middleware.LocalConfigMiddleware',
     'modoboa.lib.middleware.AjaxLoginRedirect',

--- a/modoboa/core/views/auth.py
+++ b/modoboa/core/views/auth.py
@@ -4,6 +4,7 @@ import logging
 
 import oath
 
+from django.conf import settings
 from django.http import (
     HttpResponse, HttpResponseRedirect, Http404, JsonResponse)
 from django.template.loader import render_to_string
@@ -83,8 +84,6 @@ def dologin(request):
                     request.session.set_expiry(0)
 
                 translation.activate(request.user.language)
-                request.session[translation.LANGUAGE_SESSION_KEY] = (
-                    request.user.language)
 
                 logger.info(
                     _("User '%s' successfully logged in") % user.username
@@ -93,7 +92,10 @@ def dologin(request):
                     sender="dologin",
                     username=form.cleaned_data["username"],
                     password=form.cleaned_data["password"])
-                return HttpResponseRedirect(find_nextlocation(request, user))
+                response = HttpResponseRedirect(find_nextlocation(request, user))
+                response.set_cookie(settings.LANGUAGE_COOKIE_NAME, request.user.language)
+                return response
+
             error = _(
                 "Your username and password didn't match. Please try again.")
             logger.warning(

--- a/modoboa/core/views/user.py
+++ b/modoboa/core/views/user.py
@@ -5,6 +5,7 @@ import io
 import qrcode
 import qrcode.image.svg
 
+from django.conf import settings
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils import translation
@@ -55,11 +56,10 @@ def profile(request, tplname="core/user_profile.html"):
                     form.cleaned_data["confirmation"]
                 ))
             translation.activate(request.user.language)
-            request.session[translation.LANGUAGE_SESSION_KEY] = (
-                request.user.language)
-            return render_to_json_response(_("Profile updated"))
-        return render_to_json_response(
-            {"form_errors": form.errors}, status=400)
+            response = render_to_json_response(_("Profile updated"))
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, request.user.language)
+            return response
+        render_to_json_response({"form_errors": form.errors}, status=400)
 
     form = ProfileForm(update_password, instance=request.user)
     return render_to_json_response({

--- a/modoboa/core/views/user.py
+++ b/modoboa/core/views/user.py
@@ -59,7 +59,7 @@ def profile(request, tplname="core/user_profile.html"):
             response = render_to_json_response(_("Profile updated"))
             response.set_cookie(settings.LANGUAGE_COOKIE_NAME, request.user.language)
             return response
-        render_to_json_response({"form_errors": form.errors}, status=400)
+        return render_to_json_response({"form_errors": form.errors}, status=400)
 
     form = ProfileForm(update_password, instance=request.user)
     return render_to_json_response({

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -104,15 +104,15 @@ INSTALLED_APPS += MODOBOA_APPS
 AUTH_USER_MODEL = 'core.User'
 
 MIDDLEWARE = (
-    'x_forwarded_for.middleware.XForwardedForMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'x_forwarded_for.middleware.XForwardedForMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django_otp.middleware.OTPMiddleware',
     'modoboa.core.middleware.TwoFAMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'modoboa.core.middleware.LocalConfigMiddleware',
     'modoboa.lib.middleware.AjaxLoginRedirect',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

https://github.com/modoboa/modoboa/issues/2719

Setting language in sessions is deprecated in Django since 3.0. Set a cookie instead. Also update the middlewares order to match the requirements.

https://docs.djangoproject.com/en/3.0/topics/i18n/translation/#explicitly-setting-the-active-language

Current behavior before PR:

Cannot switch from one language to another with the old interface.

Desired behavior after PR is merged:

It fixes it