### PR TITLE
Add delay for server search requests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@mdi/font": "^5.9.55",
     "apexcharts": "^3.25.0",
     "core-js": "^3.6.5",
+    "debounce": "^1.2.1",
     "js-cookie": "^2.2.1",
     "luxon": "^1.28.1",
     "vee-validate": "^3.4.5",

--- a/frontend/src/components/alarms/AlarmList.vue
+++ b/frontend/src/components/alarms/AlarmList.vue
@@ -63,7 +63,7 @@
 
 <script>
 import alarms from '@/api/alarms'
-
+import debounce from 'debounce'
 export default {
   data () {
     return {
@@ -103,6 +103,9 @@ export default {
   },
   mounted () {
     this.fetchAlarms()
+  },
+  created () {
+    this.fetchAlarms = debounce(this.fetchAlarms, 500)
   },
   watch: {
     options: {

--- a/frontend/src/components/logs/AuditTrailList.vue
+++ b/frontend/src/components/logs/AuditTrailList.vue
@@ -31,7 +31,7 @@
 
 <script>
 import logs from '@/api/logs'
-
+import debounce from 'debounce'
 export default {
   data () {
     return {
@@ -79,6 +79,9 @@ export default {
         this.loading = false
       })
     }
+  },
+  created () {
+    this.fetchLogs = debounce(this.fetchLogs, 500)
   },
   watch: {
     options: {

--- a/frontend/src/components/logs/MessageList.vue
+++ b/frontend/src/components/logs/MessageList.vue
@@ -32,6 +32,7 @@
 
 <script>
 import logs from '@/api/logs'
+import debounce from 'debounce'
 
 export default {
   data () {
@@ -69,6 +70,9 @@ export default {
         this.loading = false
       })
     }
+  },
+  created () {
+    this.fetchMessages = debounce(this.fetchMessages, 500)
   },
   watch: {
     options: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3002,6 +3002,11 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

On the new admin interface, add delay when performing a search request to the server to avoid too many requests and risking being throttled.

Current behavior before PR:

Each new character in the field would fire a request to the server

Desired behavior after PR is merged:

A delay of 500ms is applied before firing a new request