### PR TITLE
Add adsp DNS config to avoid mails enter in spam in hotmail/outlook

### DIFF
--- a/frontend/src/components/domains/DomainDNSConfig.vue
+++ b/frontend/src/components/domains/DomainDNSConfig.vue
@@ -41,6 +41,9 @@ mail.{{ domain.name }}. IN A <strong>[<translate>IP address of your Modoboa serv
       >
       <div class="title">DKIM</div>
       <dkim-key-viewer :domain="domain" />
+      <div class="title">ADSP</div>
+      <pre>
+_adsp._domainkey.{{ domain.name }}. IN TXT "dkim=discardable;"</pre>
     </v-alert>
     <v-alert
       border="left"

--- a/modoboa/dnstools/templates/dnstools/domain_dns_configuration.html
+++ b/modoboa/dnstools/templates/dnstools/domain_dns_configuration.html
@@ -21,6 +21,9 @@ mail.{{ domain.name }}. IN A <strong>[{% trans "IP address of your Modoboa serve
     DKIM
     <pre>
 {{ domain.bind_format_dkim_public_key }}</pre>
+    ADSP
+    <pre>
+_adsp._domainkey.{{ domain.name }}. IN TXT "dkim=discardable;"</pre>
   {% endif %}
   DMARC
   <pre>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Add adsp DNS config to avoid mails enter in spam in hotmail/outlook

Current behavior before PR: Mails sent through modoboa enters to spam due DNS configuration

Desired behavior after PR is merged: Mails don't enter to spam in hotmail/outlook
