### PR TITLE
Extra dkim management signal

### DIFF
--- a/modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py
+++ b/modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py
@@ -66,3 +66,4 @@ class ManageDKIMKeys(BaseCommand):
             self.create_new_dkim_key(domain)
         if qset.exists():
             signals.new_dkim_keys.send(sender=self.__class__, domains=qset)
+        signals.extra_dkim_management.send(sender=self.__class__)

--- a/modoboa/admin/signals.py
+++ b/modoboa/admin/signals.py
@@ -29,4 +29,5 @@ get_domain_form_instances = django.dispatch.Signal(
 import_object = django.dispatch.Signal(providing_args=["objtype"])
 use_external_recipients = django.dispatch.Signal(providing_args=["recipients"])
 new_dkim_keys = django.dispatch.Signal(providing_args=["domains"])
+extra_dkim_management = django.dispatch.Signal()
 extra_account_identities_actions = django.dispatch.Signal(providing_args=["account"])


### PR DESCRIPTION
~Added a signal on selector changed on a domain.~

Added a signal for extra actions to perform at the end of the dkim management command.

Main use will be for modoboa-rspamd to update selector map.

