### PR TITLE
Better UX on failling to save parameters

### DIFF
--- a/frontend/locale/br/LC_MESSAGES/app.po
+++ b/frontend/locale/br/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:17+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr "Kont hizivaet"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Oberioù"
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Chomlec'h"
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Aliasoù"
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Domanioù meret"
@@ -397,6 +398,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -438,6 +444,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -477,12 +485,12 @@ msgstr "Kota arloet d'ar boestoù-postel. Gellout a ra bezañ ezpleget e Ko, Mo 
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -494,8 +502,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Deskrivadur"
@@ -687,10 +695,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -763,8 +771,8 @@ msgstr "Enaouiñ ar gwiriañ DNS"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Enaouet"
 
@@ -803,8 +811,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Diamzeriet da"
 
@@ -826,8 +834,8 @@ msgstr "C'hwitet"
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -897,13 +905,13 @@ msgstr "Linennet penn-da-benn"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Hollek"
 
@@ -1069,8 +1077,8 @@ msgstr "Deiziad aozañ diwezhañ"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1109,7 +1117,7 @@ msgid "Logger"
 msgstr "Enroller"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Digevreañ"
 
@@ -1131,10 +1139,17 @@ msgstr "Boest-posteloù"
 msgid "Mailboxes"
 msgstr "Boest-posteloù"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Implij"
 
@@ -1145,8 +1160,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1196,15 +1211,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Anv"
 
@@ -1263,12 +1278,12 @@ msgstr "Da-heul"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1336,8 +1351,8 @@ msgstr ""
 msgid "Options"
 msgstr "Dibarzhioù"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1361,9 +1376,9 @@ msgstr "Ger-tremen"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1407,8 +1422,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1476,10 +1491,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr "Kota"
 
@@ -1509,8 +1526,8 @@ msgstr "Chomlec'h dre-zegouezh"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Ger-tremen dre-zegouezh"
 
@@ -1601,8 +1618,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1638,8 +1655,8 @@ msgstr "Eil chomlec'h postel"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1698,7 +1715,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Arventennoù"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1740,8 +1757,8 @@ msgstr "Statud"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Statud"
 
@@ -1805,8 +1822,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1913,9 +1930,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Anv implier"
 
@@ -1942,12 +1959,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1980,12 +1997,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -2009,6 +2026,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2017,7 +2038,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2039,8 +2060,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/cs/LC_MESSAGES/app.po
+++ b/frontend/locale/cs/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -395,6 +396,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -436,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -475,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -492,8 +500,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -685,10 +693,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -760,8 +768,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -800,8 +808,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -823,8 +831,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -892,13 +900,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1063,8 +1071,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1103,7 +1111,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1125,10 +1133,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1139,8 +1154,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1188,15 +1203,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1255,12 +1270,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1327,8 +1342,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1352,9 +1367,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1398,8 +1413,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1465,10 +1480,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1498,8 +1515,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1590,8 +1607,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1627,8 +1644,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1728,8 +1745,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1793,8 +1810,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1900,9 +1917,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1929,12 +1946,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1967,12 +1984,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1996,6 +2013,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2004,7 +2025,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2026,8 +2047,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/de/LC_MESSAGES/app.po
+++ b/frontend/locale/de/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:17+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -81,11 +81,11 @@ msgstr "Konto aktualisiert"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -112,11 +112,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Adresse"
 
@@ -170,8 +170,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -210,10 +211,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Aliase"
 
@@ -249,9 +250,9 @@ msgstr "Antworten"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Administrierte Domains"
@@ -398,6 +399,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -439,6 +445,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -478,12 +486,12 @@ msgstr "Auf Postfächer angewendete Quota. Kann in KB, MB (Voreinstellung) oder 
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -495,8 +503,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Beschreibung"
@@ -688,10 +696,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -764,8 +772,8 @@ msgstr "Aktiviere DNS Prüfungen"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -804,8 +812,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Läuft ab am"
 
@@ -827,8 +835,8 @@ msgstr "Fehlgeschlagen"
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -898,13 +906,13 @@ msgstr "Voll zugeordnet"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Allgemein"
 
@@ -1070,8 +1078,8 @@ msgstr "Datum der letzten Änderung"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1110,7 +1118,7 @@ msgid "Logger"
 msgstr "Logger"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Logout"
 
@@ -1132,10 +1140,17 @@ msgstr "Postfächer"
 msgid "Mailboxes"
 msgstr "Mailboxen"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Verwendung"
 
@@ -1146,8 +1161,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1197,15 +1212,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Name"
 
@@ -1265,12 +1280,12 @@ msgstr "Weiter"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1338,8 +1353,8 @@ msgstr ""
 msgid "Options"
 msgstr "Optionen"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1363,9 +1378,9 @@ msgstr "Passwort"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1409,8 +1424,8 @@ msgstr "Bitte die Primäre Email-Adresse eingeben"
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1478,10 +1493,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1511,8 +1528,8 @@ msgstr "Zufällige Adresse"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Zufälliges Passwort"
 
@@ -1603,8 +1620,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1640,8 +1657,8 @@ msgstr "Zweite E-Mail Adresse"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 #, fuzzy
 msgid "Secured"
 msgstr "Sicherheit"
@@ -1701,7 +1718,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1743,8 +1760,8 @@ msgstr "Statistiken"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Status"
 
@@ -1808,8 +1825,8 @@ msgstr "Bis"
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1918,9 +1935,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Benutzername"
 
@@ -1947,12 +1964,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1985,12 +2002,12 @@ msgstr "Jahr"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -2014,6 +2031,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2022,7 +2043,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2044,8 +2065,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/el/LC_MESSAGES/app.po
+++ b/frontend/locale/el/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -395,6 +396,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -436,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -475,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -492,8 +500,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -685,10 +693,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -760,8 +768,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -800,8 +808,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -823,8 +831,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -892,13 +900,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1063,8 +1071,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1103,7 +1111,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1125,10 +1133,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1139,8 +1154,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1188,15 +1203,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1255,12 +1270,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1327,8 +1342,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1352,9 +1367,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1398,8 +1413,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1465,10 +1480,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1498,8 +1515,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1590,8 +1607,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1627,8 +1644,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1728,8 +1745,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1793,8 +1810,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1900,9 +1917,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1929,12 +1946,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1967,12 +1984,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1996,6 +2013,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2004,7 +2025,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2026,8 +2047,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/en/LC_MESSAGES/app.po
+++ b/frontend/locale/en/LC_MESSAGES/app.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
@@ -75,11 +75,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -106,11 +106,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -164,8 +164,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -204,10 +205,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -243,9 +244,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -390,6 +391,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -431,6 +437,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -470,12 +478,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -487,8 +495,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -680,10 +688,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -755,8 +763,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -795,8 +803,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -818,8 +826,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -887,13 +895,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1058,8 +1066,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1098,7 +1106,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1120,10 +1128,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1134,8 +1149,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1183,15 +1198,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1250,12 +1265,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1322,8 +1337,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1347,9 +1362,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1393,8 +1408,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1460,10 +1475,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1493,8 +1510,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1585,8 +1602,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1622,8 +1639,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1682,7 +1699,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1723,8 +1740,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1788,8 +1805,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1895,9 +1912,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1924,12 +1941,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1962,12 +1979,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1991,6 +2008,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -1999,7 +2020,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2021,8 +2042,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/es/LC_MESSAGES/app.po
+++ b/frontend/locale/es/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -81,11 +81,11 @@ msgstr "Cuenta actualizada"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Acciones"
 
@@ -112,11 +112,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Dirección"
 
@@ -170,8 +170,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -210,10 +211,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Alias"
 
@@ -249,9 +250,9 @@ msgstr "Aplicar"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Dominios administrados"
@@ -397,6 +398,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -438,6 +444,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -477,12 +485,12 @@ msgstr "Cuota de mailbox predeterminda en MB. Un valor de 0 significa ningún li
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -494,8 +502,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Descripción"
@@ -687,10 +695,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -763,8 +771,8 @@ msgstr "Activar comprobación de DNS"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Activado"
 
@@ -803,8 +811,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Caduca en"
 
@@ -826,8 +834,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -897,13 +905,13 @@ msgstr "Nombre completo"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "General"
 
@@ -1069,8 +1077,8 @@ msgstr "Última fecha de modificación"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1109,7 +1117,7 @@ msgid "Logger"
 msgstr "Logger"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Salir"
 
@@ -1131,10 +1139,17 @@ msgstr "Mailboxes"
 msgid "Mailboxes"
 msgstr "Mailboxes"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Uso"
 
@@ -1145,8 +1160,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1196,15 +1211,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Nombre"
 
@@ -1263,12 +1278,12 @@ msgstr "Siguiente"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1336,8 +1351,8 @@ msgstr ""
 msgid "Options"
 msgstr "Opciones"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1361,9 +1376,9 @@ msgstr "Contraseña"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1407,8 +1422,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1476,10 +1491,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1509,8 +1526,8 @@ msgstr "Dirección aleatoria"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Dirección aleatoria"
 
@@ -1601,8 +1618,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1638,8 +1655,8 @@ msgstr "Email secundario"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1698,7 +1715,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1740,8 +1757,8 @@ msgstr "Estadísticas"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Estatus"
 
@@ -1805,8 +1822,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1913,9 +1930,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Nombre de usuario"
 
@@ -1942,12 +1959,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1980,12 +1997,12 @@ msgstr "Año"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -2009,6 +2026,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2017,7 +2038,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2039,8 +2060,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/fi/LC_MESSAGES/app.po
+++ b/frontend/locale/fi/LC_MESSAGES/app.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -79,11 +79,11 @@ msgstr "Tili päivitetty"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Toiminnot"
 
@@ -110,11 +110,11 @@ msgstr "Lisää lähettäjän osoite"
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Osoite"
 
@@ -170,8 +170,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr "Hälytykset"
 
@@ -211,10 +212,10 @@ msgstr "Tämän postilaatikon alias-nimet. Jos haluat luoda catchall-aliaksen, k
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Aliakset"
 
@@ -250,9 +251,9 @@ msgstr "Käytä"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Hallinnoidut verkkotunnukset"
@@ -401,6 +402,11 @@ msgstr "Kopioi leikepöydälle"
 msgid "Copy token to clipboard"
 msgstr "Kopioi turvatunnus leikepöydälle"
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -442,6 +448,8 @@ msgid "Daily message sending limit"
 msgstr "Päivittäinen viestien lähetysraja"
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr "Päivittäinen lähetysraja"
 
@@ -481,12 +489,12 @@ msgstr "Postilaatikoihin sovellettava oletuskiintiö. Voidaan ilmaista kilotavui
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr "Poista"
 
@@ -498,8 +506,8 @@ msgstr "Poista avain"
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Kuvaus"
@@ -692,10 +700,10 @@ msgstr "Älä käsittele päällekkäisiä objekteja virheinä"
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr "Muokkaa"
 
@@ -768,8 +776,8 @@ msgstr "Ota DNS-tarkistukset käyttöön"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Käytössä"
 
@@ -808,8 +816,8 @@ msgstr "Esim: 10 MB. Jätä tyhjäksi, jos et halua rajoitusta"
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Vanhenee"
 
@@ -831,8 +839,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr "Etunimi"
@@ -902,13 +910,13 @@ msgstr "Koko nimi"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Yleiset"
 
@@ -1081,8 +1089,8 @@ msgstr "Viimeisin muutospäivä"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr "Sukunimi"
@@ -1121,7 +1129,7 @@ msgid "Logger"
 msgstr "Lokikirja"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Kirjaudu ulos"
 
@@ -1143,10 +1151,17 @@ msgstr "Postilaatikko"
 msgid "Mailboxes"
 msgstr "Postilaatikot"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Viesti"
 
@@ -1157,8 +1172,8 @@ msgstr "Viestien historia"
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr "Viestien lähetysraja"
 
@@ -1208,15 +1223,15 @@ msgstr "MX-tietueet"
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Nimi"
 
@@ -1277,12 +1292,12 @@ msgstr "Seuraava"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr "Ei"
 
@@ -1351,8 +1366,8 @@ msgstr "Avatut hälytykset"
 msgid "Options"
 msgstr "Vaihtoehdot"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr "Parametrit päivitetty"
 
@@ -1376,9 +1391,9 @@ msgstr "Salasana"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr "Salasana kopioitu leikepöydälle"
 
@@ -1423,8 +1438,8 @@ msgstr "Täytä ensisijainen sähköpostiosoitteesi"
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1494,10 +1509,12 @@ msgstr "Jonon ID"
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr "Verkkotunnuksen oletuskiintiö"
 
@@ -1527,8 +1544,8 @@ msgstr "Satunnainen osoite"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Satunnainen salasana"
 
@@ -1620,8 +1637,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1657,8 +1674,8 @@ msgstr "Toissijainen sähköpostiosoite"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 #, fuzzy
 msgid "Secured"
 msgstr "Turvallisuus"
@@ -1718,7 +1735,7 @@ msgstr "Palvelu:"
 msgid "Settings"
 msgstr "Asetukset"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr "Asetukset: tämä etiketti"
 
@@ -1760,8 +1777,8 @@ msgstr "Tilastot"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Tila"
 
@@ -1833,8 +1850,8 @@ msgstr "Vastaanottaja"
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1942,9 +1959,9 @@ msgstr "Tuntematon"
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
@@ -1971,12 +1988,12 @@ msgstr "Tarkista koodi"
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr "Varoitus"
 
@@ -2009,12 +2026,12 @@ msgstr "Vuosi"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -2038,6 +2055,10 @@ msgstr "API-pääsytunnistetta ei ole vielä luotu."
 msgid "Your API token is:"
 msgstr "API-pääsytunnisteesi on:"
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr "kyllä"
@@ -2046,7 +2067,7 @@ msgstr "kyllä"
 msgid "no"
 msgstr "ei"
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr "Asetukset: "
 
@@ -2068,8 +2089,4 @@ msgstr "Virheellinen salasana"
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/fr/LC_MESSAGES/app.po
+++ b/frontend/locale/fr/LC_MESSAGES/app.po
@@ -1,20 +1,20 @@
-# 
+#
 # Translators:
 # Che Akycow, 2023
 # Antoine Nguyen <tonio@ngyn.org>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "Last-Translator: Antoine Nguyen <tonio@ngyn.org>, 2023\n"
 "Language-Team: French (https://app.transifex.com/tonio/teams/13749/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: easygettext\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #: src/components/domains/DomainList.vue:28
@@ -28,41 +28,23 @@ msgstr "Une documentation de l'API est disponible"
 
 #: src/components/domains/DNSDetail.vue:47
 #: src/components/domains/DNSDetail.vue:205
-msgid ""
-"A new key will be generated soon. Refresh the page in a moment to see it."
-msgstr ""
-"Une nouvelle clé sera générée bientôt. Actualisez dans un moment la page "
-"pour la voir."
+msgid "A new key will be generated soon. Refresh the page in a moment to see it."
+msgstr "Une nouvelle clé sera générée bientôt. Actualisez dans un moment la page pour la voir."
 
 #: src/components/identities/AccountRoleForm.vue:42
 #: src/components/identities/AccountRoleForm.vue:72
-msgid ""
-"A user with all privileges, can do anything. By default, such a user does "
-"not have a mailbox so he can't access end-user features."
-msgstr ""
-"Un utilisateur ayant tous les privilège, peut tout faire. Par défaut, il n'a"
-" pas de boîte mail et ne peut donc pas accéder aux fonctionnalités d'un "
-"utilisateur final."
+msgid "A user with all privileges, can do anything. By default, such a user does not have a mailbox so he can't access end-user features."
+msgstr "Un utilisateur ayant tous les privilège, peut tout faire. Par défaut, il n'a pas de boîte mail et ne peut donc pas accéder aux fonctionnalités d'un utilisateur final."
 
 #: src/components/identities/AccountRoleForm.vue:37
 #: src/components/identities/AccountRoleForm.vue:67
-msgid ""
-"A user with no privileges but with a mailbox. He will be allowed to use all "
-"end-user features: webmail, calendar, contacts, filters."
-msgstr ""
-"Un utilisateur sans privilèges mais ayant une boîte mail. Il sera autorisé à"
-" utiliser toutes les fonctionnalités de l'utilisateur final : webmail, "
-"calendrier, contacts, filtres."
+msgid "A user with no privileges but with a mailbox. He will be allowed to use all end-user features: webmail, calendar, contacts, filters."
+msgstr "Un utilisateur sans privilèges mais ayant une boîte mail. Il sera autorisé à utiliser toutes les fonctionnalités de l'utilisateur final : webmail, calendrier, contacts, filtres."
 
 #: src/components/identities/AccountRoleForm.vue:27
 #: src/components/identities/AccountRoleForm.vue:57
-msgid ""
-"A user with privileges on one or more domain. He will be allowed to "
-"administer mailboxes and he can also have a mailbox."
-msgstr ""
-"Un utilisateur avec des privilèges sur un ou plusieurs domaines. Il sera "
-"autorisé à administrer les boîtes mail et il peut avoir aussi une boîte aux "
-"lettres."
+msgid "A user with privileges on one or more domain. He will be allowed to administer mailboxes and he can also have a mailbox."
+msgstr "Un utilisateur avec des privilèges sur un ou plusieurs domaines. Il sera autorisé à administrer les boîtes mail et il peut avoir aussi une boîte aux lettres."
 
 #: src/components/tools/TimeSerieChart.vue:16
 msgid "Absolute time range"
@@ -98,11 +80,11 @@ msgstr "Compte mis à jour"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Actions"
 
@@ -129,11 +111,11 @@ msgstr "Ajouter l'adresse de l'expéditeur"
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Adresse"
 
@@ -187,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr "Alarme ré-ouverte"
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr "Alarmes"
 
@@ -218,12 +201,8 @@ msgstr "Alias mis à jour"
 
 #: src/components/identities/AccountAliasForm.vue:3
 #: src/components/identities/AliasRecipientForm.vue:3
-msgid ""
-"Alias(es) of this mailbox. To create a catchall alias, just enter the domain"
-" name (@domain.tld)."
-msgstr ""
-"Alias(s) de cette boîte aux lettres. Pour créer un alias fourre-tout, entrer"
-" uniquement le nom du domaine (@domain.tld)."
+msgid "Alias(es) of this mailbox. To create a catchall alias, just enter the domain name (@domain.tld)."
+msgstr "Alias(s) de cette boîte aux lettres. Pour créer un alias fourre-tout, entrer uniquement le nom du domaine (@domain.tld)."
 
 #: src/components/domains/DomainList.vue:26
 #: src/components/domains/DomainSummary.vue:31
@@ -231,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Alias"
 
@@ -270,9 +249,9 @@ msgstr "Appliquer"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr "Domaines associés"
 
@@ -345,12 +324,9 @@ msgstr "Vérifier la connexion :"
 msgid "Check out the following list to find related components"
 msgstr "Consulter la liste suivante pour trouver des composants associés"
 
-#: src/views/identities/Identities.vue:45
-#: src/views/identities/Identities.vue:1
+#: src/views/identities/Identities.vue:45 src/views/identities/Identities.vue:1
 msgid "Check this option if passwords contained in your file are not crypted"
-msgstr ""
-"Cochez cette option si les mots de passe contenus dans votre fichier ne sont"
-" pas chiffrés"
+msgstr "Cochez cette option si les mots de passe contenus dans votre fichier ne sont pas chiffrés"
 
 #: src/components/domains/DomainAliasForm.vue:56
 #: src/components/domains/DomainAliasForm.vue:26
@@ -375,8 +351,7 @@ msgstr "Fermer"
 msgid "Close alarm"
 msgstr "Fermer l'alarme"
 
-#: src/components/alarms/AlarmList.vue:22
-#: src/components/alarms/AlarmList.vue:5
+#: src/components/alarms/AlarmList.vue:22 src/components/alarms/AlarmList.vue:5
 msgid "Closed"
 msgstr "Fermé"
 
@@ -391,11 +366,8 @@ msgstr "Confirmation"
 
 #: src/components/user/TwoFactorAuthForm.vue:34
 #: src/components/user/TwoFactorAuthForm.vue:2
-msgid ""
-"Congratulations! Two-Factor Authentication is now enabled for your account."
-msgstr ""
-"Félicitations ! l'authentification à double facteur est maintenant activée "
-"sur votre compte"
+msgid "Congratulations! Two-Factor Authentication is now enabled for your account."
+msgstr "Félicitations ! l'authentification à double facteur est maintenant activée sur votre compte"
 
 #: src/views/Login.vue:23
 msgid "Connect"
@@ -407,8 +379,7 @@ msgstr "Continuer en cas d'erreur"
 
 #: src/components/domains/DomainGeneralForm.vue:8
 msgid "Control if this domain will be allowed to send and receive messages"
-msgstr ""
-"Contrôler si ce domaine sera autorisé à envoyer et recevoir des messages."
+msgstr "Contrôler si ce domaine sera autorisé à envoyer et recevoir des messages."
 
 #: src/components/domains/DomainCreationForm.vue:27
 #: src/components/domains/DomainCreationForm.vue:10
@@ -424,6 +395,11 @@ msgstr "Copier dans le presse-papiers"
 #: src/views/user/APISetup.vue:20
 msgid "Copy token to clipboard"
 msgstr "Copier le jeton dans la presse-papiers"
+
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
 
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
@@ -451,8 +427,7 @@ msgstr "Créer des aliases standard pour le domaine"
 msgid "Creation date"
 msgstr "Date de création"
 
-#: src/views/identities/Identities.vue:45
-#: src/views/identities/Identities.vue:1
+#: src/views/identities/Identities.vue:45 src/views/identities/Identities.vue:1
 msgid "Crypt passwords"
 msgstr "Chiffrer les mots de passe"
 
@@ -467,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr "Limite quotidienne d'envoi de messages"
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr "Limite d'envoi quotidienne"
 
@@ -494,12 +471,8 @@ msgid "Default mailbox quota"
 msgstr "Quota par défaut pour une boîte aux lettres"
 
 #: src/components/domains/DomainLimitationsForm.vue:6
-msgid ""
-"Default quota applied to mailboxes. Can be expressed in KB, MB (default) or "
-"GB. A value of 0 means no quota."
-msgstr ""
-"Quota par défaut appliqué aux boîtes aux lettres. Peut être exprimé en Ko, "
-"Mo (défaut) ou Go. Une valeur à 0 signifie pas de quota."
+msgid "Default quota applied to mailboxes. Can be expressed in KB, MB (default) or GB. A value of 0 means no quota."
+msgstr "Quota par défaut appliqué aux boîtes aux lettres. Peut être exprimé en Ko, Mo (défaut) ou Go. Une valeur à 0 signifie pas de quota."
 
 #: src/components/alarms/AlarmList.vue:76
 #: src/components/alarms/AlarmList.vue:102
@@ -510,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -527,8 +500,8 @@ msgstr "Supprimer le jeton"
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Description"
@@ -566,8 +539,7 @@ msgstr "Sélecteur de clé DKIM"
 
 #: src/components/domains/DNSDetail.vue:30
 #: src/components/domains/DNSDetail.vue:189
-msgid ""
-"DKIM keys already exist for this domain. Do you want to overwrite them?"
+msgid "DKIM keys already exist for this domain. Do you want to overwrite them?"
 msgstr "Des clés DKIM existent déjà pour ce domaine. Voulez-vous les écraser?"
 
 #: src/components/domains/DomainDKIMKey.vue:4
@@ -721,10 +693,10 @@ msgstr "Ne pas traiter les objets dupliqués comme des erreurs"
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr "Modifier"
 
@@ -796,8 +768,8 @@ msgstr "Activer les tests DNS"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Activé"
 
@@ -812,13 +784,8 @@ msgid "Enter an email address"
 msgstr "Entrer une adresse e-mail"
 
 #: src/views/TwoFA.vue:12
-msgid ""
-"Enter the code from the two-factor app on your mobile device. If you have "
-"lost your device, you may enter one of your recovery codes."
-msgstr ""
-"Entrez le code de l'application à double facteur sur votre téléphone mobile."
-" Si vous avez perdu votre appareil, vous pouvez entrez l'un de vos code de "
-"récupération."
+msgid "Enter the code from the two-factor app on your mobile device. If you have lost your device, you may enter one of your recovery codes."
+msgstr "Entrez le code de l'application à double facteur sur votre téléphone mobile. Si vous avez perdu votre appareil, vous pouvez entrez l'un de vos code de récupération."
 
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:11
 msgid "Enter the code you've just received by SMS"
@@ -841,8 +808,8 @@ msgstr "Ex: 10MB. Laisser vide pour aucune limite"
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Expire le"
 
@@ -864,8 +831,8 @@ msgstr "Échoué"
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr "Prénom"
@@ -882,9 +849,7 @@ msgstr "Transfert"
 
 #: src/components/user/ForwardForm.vue:6
 msgid "Forward messages and store copies into your local mailbox"
-msgstr ""
-"Transférer les messages et stocker des copies dans votre boîte aux lettres "
-"locale"
+msgstr "Transférer les messages et stocker des copies dans votre boîte aux lettres locale"
 
 #: src/components/user/ForwardForm.vue:19
 #: src/components/user/ForwardForm.vue:52
@@ -935,13 +900,13 @@ msgstr "Entièrement aligné"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Général"
 
@@ -974,12 +939,8 @@ msgid "help"
 msgstr "aide"
 
 #: src/components/domains/DomainDNSConfig.vue:8
-msgid ""
-"Here is an example of DNS configuration (bind format). Replace values "
-"between [ ] by the appropriate ones."
-msgstr ""
-"Voici un exemplaire de configuration DNS (format bind). Remplacer les "
-"valeurs entre [ ] par les valeurs appropriées."
+msgid "Here is an example of DNS configuration (bind format). Replace values between [ ] by the appropriate ones."
+msgstr "Voici un exemplaire de configuration DNS (format bind). Remplacer les valeurs entre [ ] par les valeurs appropriées."
 
 #: src/components/domains/DomainDNSConfig.vue:33
 #: src/components/domains/DomainDNSConfig.vue:34
@@ -1006,20 +967,12 @@ msgstr "Identités supprimées"
 
 #: src/components/tools/CreationForm.vue:42
 #: src/components/tools/CreationForm.vue:116
-msgid ""
-"If you close this form now, your modifications won't be saved. Do you "
-"confirm?"
-msgstr ""
-"Si vous fermez ce formulaire maintenant, vos modifications ne seront pas "
-"sauvegardées. Confirmez-vous ?"
+msgid "If you close this form now, your modifications won't be saved. Do you confirm?"
+msgstr "Si vous fermez ce formulaire maintenant, vos modifications ne seront pas sauvegardées. Confirmez-vous ?"
 
 #: src/components/dmarc/DmarcAligmentChart.vue:52
-msgid ""
-"If you configured it recently, please wait for the first report to be "
-"received and processed."
-msgstr ""
-"Si vous l'avez récemment configuré, veuillez attendre que le premier rapport"
-" soit reçu et traité. "
+msgid "If you configured it recently, please wait for the first report to be received and processed."
+msgstr "Si vous l'avez récemment configuré, veuillez attendre que le premier rapport soit reçu et traité. "
 
 #: src/components/layout/Navbar.vue:89 src/components/layout/Navbar.vue:204
 msgid "IMAP Migration"
@@ -1093,9 +1046,7 @@ msgstr "Adresse IP de votre serveur Modoboa"
 
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 msgid "Is the IMAP connection secured using SSL/TLS or StartTLS"
-msgstr ""
-"La connexion IMAP est-elle sécurisée via l'utilisation de SSL/TLS ou "
-"StartTLS"
+msgstr "La connexion IMAP est-elle sécurisée via l'utilisation de SSL/TLS ou StartTLS"
 
 #: src/views/Dashboard.vue:7
 msgid ""
@@ -1125,8 +1076,8 @@ msgstr "Date de dernière modification"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr "Nom de famille"
@@ -1165,7 +1116,7 @@ msgid "Logger"
 msgstr "Logger"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Déconnexion"
 
@@ -1187,10 +1138,17 @@ msgstr "Boîte aux lettres"
 msgid "Mailboxes"
 msgstr "Boîtes aux lettres"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Message"
 
@@ -1201,8 +1159,8 @@ msgstr "Historique des messages"
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr "Limite d'envoi des messages"
 
@@ -1250,15 +1208,15 @@ msgstr "Enregistrements MX"
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Nom"
 
@@ -1280,8 +1238,7 @@ msgid "Never logged-in"
 msgstr "Jamais connecté"
 
 #: src/views/domains/Domains.vue:15 src/views/domains/Domains.vue:3
-#: src/views/identities/Identities.vue:15
-#: src/views/identities/Identities.vue:3
+#: src/views/identities/Identities.vue:15 src/views/identities/Identities.vue:3
 #: src/views/imap_migration/Providers.vue:7
 msgid "New"
 msgstr "Nouvelle"
@@ -1318,12 +1275,12 @@ msgstr "Suivant"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr "Non"
 
@@ -1349,18 +1306,12 @@ msgid "Number of associated domains:"
 msgstr "Nombre de domaines associés :"
 
 #: src/components/domains/DomainLimitationsForm.vue:9
-msgid ""
-"Number of messages this domain can send per day. Leave empty for no limit."
-msgstr ""
-"Nombre de messages que ce domaine peut envoyer par jour. Laisser vide pour "
-"aucune limite."
+msgid "Number of messages this domain can send per day. Leave empty for no limit."
+msgstr "Nombre de messages que ce domaine peut envoyer par jour. Laisser vide pour aucune limite."
 
 #: src/components/identities/AccountMailboxForm.vue:8
-msgid ""
-"Number of messages this mailbox can send per day. Leave empty for no limit."
-msgstr ""
-"Nombre de messages que cette boîte aux lettres peut envoyer par jour. "
-"Laisser vide pour aucune limite."
+msgid "Number of messages this mailbox can send per day. Leave empty for no limit."
+msgstr "Nombre de messages que cette boîte aux lettres peut envoyer par jour. Laisser vide pour aucune limite."
 
 #: src/views/user/PasswordRecoveryForm.vue:31
 #: src/views/user/PasswordRecoveryForm.vue:77
@@ -1381,8 +1332,7 @@ msgstr "Ancien compte"
 msgid "One or more updates are available"
 msgstr "Une ou plusieurs mise à jour sont disponibles"
 
-#: src/components/alarms/AlarmList.vue:19
-#: src/components/alarms/AlarmList.vue:2
+#: src/components/alarms/AlarmList.vue:19 src/components/alarms/AlarmList.vue:2
 msgid "Opened"
 msgstr "Ouvert"
 
@@ -1397,8 +1347,8 @@ msgstr "Alarmes ouvertes"
 msgid "Options"
 msgstr "Options"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr "Paramètres mis à jour"
 
@@ -1422,9 +1372,9 @@ msgstr "Mot de passe"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr "Mot de passe copié dans la presse-papier"
 
@@ -1468,8 +1418,8 @@ msgstr "Veillez renseigner votre adresse e-mail principale"
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr "Port"
 
@@ -1495,8 +1445,7 @@ msgstr "Profil mis à jour"
 
 #: src/components/tools/ImportForm.vue:7
 msgid "Provide a CSV file where lines respect one of the following formats:"
-msgstr ""
-"Fournir un fichier CSV dont les lignes respectent l'un des formats suivants:"
+msgstr "Fournir un fichier CSV dont les lignes respectent l'un des formats suivants:"
 
 #: src/components/imap_migration/MigrationsList.vue:13
 #: src/components/imap_migration/MigrationsList.vue:68
@@ -1526,8 +1475,7 @@ msgstr "Fournisseur mis à jour"
 msgid "Providers"
 msgstr "Fournisseurs"
 
-#: src/components/logs/MessageList.vue:9
-#: src/components/logs/MessageList.vue:42
+#: src/components/logs/MessageList.vue:9 src/components/logs/MessageList.vue:42
 msgid "Queue ID"
 msgstr "ID de file"
 
@@ -1537,31 +1485,22 @@ msgstr "ID de file"
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr "Quota"
 
 #: src/components/identities/AccountMailboxForm.vue:5
-msgid ""
-"Quota for this mailbox, can be expressed in KB, MB (default) or GB. Define a"
-" custom value or use domain's default one. Leave empty to define an "
-"unlimited value (not allowed for domain administrators)."
-msgstr ""
-"Quota pour cette boite. Peut être exprimé en Ko, Mo (défaut) ou Go. Définir "
-"une valeur spécifique ou utiliser la valeur par défaut du domaine. Laisser "
-"vide pour définir une valeur illimitée (interdit pour les admins. de "
-"domaine)."
+msgid "Quota for this mailbox, can be expressed in KB, MB (default) or GB. Define a custom value or use domain's default one. Leave empty to define an unlimited value (not allowed for domain administrators)."
+msgstr "Quota pour cette boite. Peut être exprimé en Ko, Mo (défaut) ou Go. Définir une valeur spécifique ou utiliser la valeur par défaut du domaine. Laisser vide pour définir une valeur illimitée (interdit pour les admins. de domaine)."
 
 #: src/components/domains/DomainLimitationsForm.vue:3
-msgid ""
-"Quota shared between mailboxes. Can be expressed in KB, MB (default) or GB. "
-"A value of 0 means no quota."
-msgstr ""
-"Quota partagé entre les boîtes aux lettres. Peut être exprimé en Ko, Mo "
-"(défaut) ou Go. Une valeur à 0 signifie pas de quota."
+msgid "Quota shared between mailboxes. Can be expressed in KB, MB (default) or GB. A value of 0 means no quota."
+msgstr "Quota partagé entre les boîtes aux lettres. Peut être exprimé en Ko, Mo (défaut) ou Go. Une valeur à 0 signifie pas de quota."
 
 #: src/components/domains/DomainForm.vue:68
 #: src/components/identities/AccountForm.vue:64
@@ -1581,8 +1520,8 @@ msgstr "Adresse aléatoire"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Mot de passe aléatoire"
 
@@ -1673,8 +1612,8 @@ msgstr "Réessayer la rénitialisation"
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr "Retour à la connexion"
 
@@ -1710,8 +1649,8 @@ msgstr "E-mail secondaire"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr "Sécurisé"
 
@@ -1770,7 +1709,7 @@ msgstr "Service :"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr "Paramètres : thislabel"
 
@@ -1811,8 +1750,8 @@ msgstr "Statistiques"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Statut"
 
@@ -1838,12 +1777,8 @@ msgid "Tags"
 msgstr "Tags"
 
 #: src/components/tools/ImportForm.vue:9
-msgid ""
-"The first element of each line is mandatory and must be equal to one of the "
-"previous values."
-msgstr ""
-"Le premier élément de chaque ligne est obligatoire et doit être égal à l'une"
-" des valeurs précédentes."
+msgid "The first element of each line is mandatory and must be equal to one of the previous values."
+msgstr "Le premier élément de chaque ligne est obligatoire et doit être égal à l'une des valeurs précédentes."
 
 #: src/components/user/TwoFactorAuthForm.vue:39
 #: src/components/user/TwoFactorAuthForm.vue:7
@@ -1864,12 +1799,7 @@ msgid ""
 "        you regain access to your account, in case you lose your phone\n"
 "        for example. Make sure to save them in a safe place, otherwise\n"
 "        you won't be able to access your account anymore."
-msgstr ""
-"Les codes de récupération suivants peuvent être utilisés une fois chacun "
-"pour vous permettre de récupérer un accès à votre compte, au cas où vous "
-"perdriez votre téléphone par exemple. Assurez-vous de les conserver dans un "
-"lieu sûr, autrement vous ne serez définitivement plus en mesure d'accéder à "
-"votre compte."
+msgstr "Les codes de récupération suivants peuvent être utilisés une fois chacun pour vous permettre de récupérer un accès à votre compte, au cas où vous perdriez votre téléphone par exemple. Assurez-vous de les conserver dans un lieu sûr, autrement vous ne serez définitivement plus en mesure d'accéder à votre compte."
 
 #: src/views/Dashboard.vue:6
 msgid "This page is still under construction."
@@ -1889,8 +1819,8 @@ msgstr "A"
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr "Trop de tentatives sans succès, veuillez réessayer plus tard"
 
@@ -1929,13 +1859,8 @@ msgstr "Authentification à double facteur"
 
 #: src/components/user/TwoFactorAuthForm.vue:64
 #: src/components/user/TwoFactorAuthForm.vue:1
-msgid ""
-"Two-Factor Authentication (2FA) is not yet activated for your account. "
-"Enabling this feature will increase your account's security."
-msgstr ""
-"L'authentification à double facteur (2FA) n'est pas encore activée pour "
-"votre compte. L'activation de cette fonctionnalité augmentera la sécurité de"
-" votre compte."
+msgid "Two-Factor Authentication (2FA) is not yet activated for your account. Enabling this feature will increase your account's security."
+msgstr "L'authentification à double facteur (2FA) n'est pas encore activée pour votre compte. L'activation de cette fonctionnalité augmentera la sécurité de votre compte."
 
 #: src/views/TwoFA.vue:11
 msgid "Two-factor authentication code"
@@ -1991,9 +1916,7 @@ msgstr "Utiliser la valeur par défaut du domaine"
 
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:43
 msgid "User seems wrong, return to login or restart reset the process?"
-msgstr ""
-"L'utilisateur semble erroné, revenez à la connexion ou redémarrer "
-"réinitialisez le processus "
+msgstr "L'utilisateur semble erroné, revenez à la connexion ou redémarrer réinitialisez le processus "
 
 #: src/views/user/PasswordRecoveryChangeForm.vue:56
 #: src/views/user/PasswordRecoveryChangeForm.vue:116
@@ -2003,9 +1926,9 @@ msgstr "Utilisateur inconnu."
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
@@ -2032,12 +1955,12 @@ msgstr "Vérifier le code"
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr "Avertissement"
 
@@ -2070,12 +1993,12 @@ msgstr "Année"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr "Oui"
 
@@ -2099,6 +2022,10 @@ msgstr "Votre jeton API n'a pas encore été généré."
 msgid "Your API token is:"
 msgstr "Votre jeton API est :"
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr "Votre limite est atteinte, veuillez réessayer plus tard"
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr "oui"
@@ -2107,7 +2034,7 @@ msgstr "oui"
 msgid "no"
 msgstr "non"
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr "Paramètres :"
 
@@ -2130,7 +2057,3 @@ msgstr "Mot de passe incorrect"
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
 msgstr "Spécifier un numéro de port correct"
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
-msgstr "Votre limite est atteinte, veuillez réessayer plus tard"

--- a/frontend/locale/it/LC_MESSAGES/app.po
+++ b/frontend/locale/it/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -81,11 +81,11 @@ msgstr "Account aggiornato"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Azioni"
 
@@ -112,11 +112,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Indirizzo"
 
@@ -170,8 +170,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -210,10 +211,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Alias"
 
@@ -249,9 +250,9 @@ msgstr "Applica"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Domini amministrati"
@@ -398,6 +399,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -439,6 +445,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -478,12 +486,12 @@ msgstr "Valore predefinito per lo spazio massimo confiviso tra le mailbox. Può 
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -495,8 +503,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Descrizione"
@@ -688,10 +696,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -764,8 +772,8 @@ msgstr "Abilita i controlli DNS"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Abilitato"
 
@@ -804,8 +812,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Scade il"
 
@@ -827,8 +835,8 @@ msgstr "Fallito"
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -898,13 +906,13 @@ msgstr "Completamente allineato"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Generale"
 
@@ -1070,8 +1078,8 @@ msgstr "Data dell'ultima modifica"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1110,7 +1118,7 @@ msgid "Logger"
 msgstr "Logger"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Esci"
 
@@ -1132,10 +1140,17 @@ msgstr "Caselle di posta"
 msgid "Mailboxes"
 msgstr "Caselle di posta"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Utilizzo"
 
@@ -1146,8 +1161,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1197,15 +1212,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Nome"
 
@@ -1264,12 +1279,12 @@ msgstr "Successivo"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1337,8 +1352,8 @@ msgstr ""
 msgid "Options"
 msgstr "Opzioni"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1362,9 +1377,9 @@ msgstr "Password"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1408,8 +1423,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1477,10 +1492,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr "Dimensione massima"
 
@@ -1510,8 +1527,8 @@ msgstr "Indirizzo casuale"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Password casuale"
 
@@ -1602,8 +1619,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1639,8 +1656,8 @@ msgstr "Email secondaria"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1699,7 +1716,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1741,8 +1758,8 @@ msgstr "Statistiche"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Stato"
 
@@ -1806,8 +1823,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1914,9 +1931,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Nome utente"
 
@@ -1943,12 +1960,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1981,12 +1998,12 @@ msgstr "Anno"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -2010,6 +2027,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2018,7 +2039,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2040,8 +2061,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/ja/LC_MESSAGES/app.po
+++ b/frontend/locale/ja/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -395,6 +396,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -436,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -475,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -492,8 +500,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -685,10 +693,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -760,8 +768,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -800,8 +808,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -823,8 +831,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -892,13 +900,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1063,8 +1071,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1103,7 +1111,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1125,10 +1133,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1139,8 +1154,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1188,15 +1203,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1255,12 +1270,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1327,8 +1342,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1352,9 +1367,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1398,8 +1413,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1465,10 +1480,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1498,8 +1515,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1590,8 +1607,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1627,8 +1644,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1728,8 +1745,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1793,8 +1810,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1900,9 +1917,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1929,12 +1946,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1967,12 +1984,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1996,6 +2013,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2004,7 +2025,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2026,8 +2047,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/nl/LC_MESSAGES/app.po
+++ b/frontend/locale/nl/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -395,6 +396,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -436,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -475,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -492,8 +500,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -685,10 +693,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -760,8 +768,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -800,8 +808,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -823,8 +831,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -892,13 +900,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1063,8 +1071,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1103,7 +1111,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1125,10 +1133,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1139,8 +1154,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1188,15 +1203,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1255,12 +1270,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1327,8 +1342,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1352,9 +1367,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1398,8 +1413,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1465,10 +1480,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1498,8 +1515,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1590,8 +1607,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1627,8 +1644,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1728,8 +1745,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1793,8 +1810,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1900,9 +1917,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1929,12 +1946,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1967,12 +1984,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1996,6 +2013,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2004,7 +2025,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2026,8 +2047,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/pl/LC_MESSAGES/app.po
+++ b/frontend/locale/pl/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -395,6 +396,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -436,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -475,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -492,8 +500,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -685,10 +693,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -760,8 +768,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -800,8 +808,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -823,8 +831,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -892,13 +900,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1063,8 +1071,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1103,7 +1111,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1125,10 +1133,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1139,8 +1154,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1188,15 +1203,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1255,12 +1270,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1327,8 +1342,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1352,9 +1367,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1398,8 +1413,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1465,10 +1480,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1498,8 +1515,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1590,8 +1607,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1627,8 +1644,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1728,8 +1745,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1793,8 +1810,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1900,9 +1917,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1929,12 +1946,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1967,12 +1984,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1996,6 +2013,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2004,7 +2025,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2026,8 +2047,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/po/LC_MESSAGES/app.po
+++ b/frontend/locale/po/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -79,11 +79,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -110,11 +110,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -168,8 +168,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -208,10 +209,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -247,9 +248,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -394,6 +395,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -435,6 +441,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -474,12 +482,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -491,8 +499,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -684,10 +692,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -759,8 +767,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -799,8 +807,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -822,8 +830,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -891,13 +899,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1062,8 +1070,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1102,7 +1110,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1124,10 +1132,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1138,8 +1153,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1187,15 +1202,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1254,12 +1269,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1326,8 +1341,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1351,9 +1366,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1397,8 +1412,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1464,10 +1479,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1497,8 +1514,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1589,8 +1606,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1626,8 +1643,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1686,7 +1703,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1727,8 +1744,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1792,8 +1809,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1899,9 +1916,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1928,12 +1945,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1966,12 +1983,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1995,6 +2012,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2003,7 +2024,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2025,8 +2046,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/pt-br/LC_MESSAGES/app.po
+++ b/frontend/locale/pt-br/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -79,11 +79,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -110,11 +110,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -168,8 +168,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -208,10 +209,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -247,9 +248,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -394,6 +395,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -435,6 +441,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -474,12 +482,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -491,8 +499,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -684,10 +692,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -759,8 +767,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -799,8 +807,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -822,8 +830,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -891,13 +899,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1062,8 +1070,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1102,7 +1110,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1124,10 +1132,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1138,8 +1153,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1187,15 +1202,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1254,12 +1269,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1326,8 +1341,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1351,9 +1366,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1397,8 +1412,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1464,10 +1479,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1497,8 +1514,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1589,8 +1606,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1626,8 +1643,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1686,7 +1703,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1727,8 +1744,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1792,8 +1809,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1899,9 +1916,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1928,12 +1945,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1966,12 +1983,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1995,6 +2012,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2003,7 +2024,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2025,8 +2046,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/pt/LC_MESSAGES/app.po
+++ b/frontend/locale/pt/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -395,6 +396,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -436,6 +442,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -475,12 +483,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -492,8 +500,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -685,10 +693,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -760,8 +768,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -800,8 +808,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -823,8 +831,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -892,13 +900,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1063,8 +1071,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1103,7 +1111,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1125,10 +1133,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1139,8 +1154,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1188,15 +1203,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1255,12 +1270,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1327,8 +1342,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1352,9 +1367,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1398,8 +1413,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1465,10 +1480,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1498,8 +1515,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1590,8 +1607,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1627,8 +1644,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1728,8 +1745,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1793,8 +1810,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1900,9 +1917,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1929,12 +1946,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1967,12 +1984,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1996,6 +2013,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2004,7 +2025,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2026,8 +2047,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/ru/LC_MESSAGES/app.po
+++ b/frontend/locale/ru/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -81,11 +81,11 @@ msgstr "аккаунт изменен"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Действие"
 
@@ -112,11 +112,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Адрес"
 
@@ -170,8 +170,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -210,10 +211,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Синоним(ы)"
 
@@ -249,9 +250,9 @@ msgstr "Применить"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Список квот"
@@ -397,6 +398,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -438,6 +444,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -477,12 +485,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -494,8 +502,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -687,10 +695,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -763,8 +771,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Разрешено"
 
@@ -803,8 +811,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -826,8 +834,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -897,13 +905,13 @@ msgstr "Имя файла"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Основные"
 
@@ -1069,8 +1077,8 @@ msgstr "Дата последней модификации"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1109,7 +1117,7 @@ msgid "Logger"
 msgstr "Логгер"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Завершить сеанс"
 
@@ -1131,10 +1139,17 @@ msgstr "Почтовые ящики"
 msgid "Mailboxes"
 msgstr "Почтовые ящики"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "использование (%%)"
 
@@ -1145,8 +1160,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1196,15 +1211,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Логин"
 
@@ -1263,12 +1278,12 @@ msgstr "Следующая"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1336,8 +1351,8 @@ msgstr ""
 msgid "Options"
 msgstr "Опции"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1361,9 +1376,9 @@ msgstr "Пароль"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1407,8 +1422,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1476,10 +1491,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1509,8 +1526,8 @@ msgstr "Ошибочный запрос"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Ошибочный запрос"
 
@@ -1601,8 +1618,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1638,8 +1655,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1698,7 +1715,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1740,8 +1757,8 @@ msgstr "Статистика"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Статистика"
 
@@ -1805,8 +1822,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1913,9 +1930,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Логин пользователя"
 
@@ -1942,12 +1959,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1980,12 +1997,12 @@ msgstr "Год"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -2009,6 +2026,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2017,7 +2038,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2039,8 +2060,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/sv/LC_MESSAGES/app.po
+++ b/frontend/locale/sv/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -81,11 +81,11 @@ msgstr "Konto uppdaterat"
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr "Åtgärder"
 
@@ -112,11 +112,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr "Adress"
 
@@ -170,8 +170,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -210,10 +211,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr "Alias"
 
@@ -249,9 +250,9 @@ msgstr "Applicera"
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 #, fuzzy
 msgid "Associated domains"
 msgstr "Administrerade domäner"
@@ -398,6 +399,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -439,6 +445,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -478,12 +486,12 @@ msgstr "Standardkvota i MB applicerad på nya brevlådor. 0 betyder ingen kvota.
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -495,8 +503,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Beskrivning"
@@ -688,10 +696,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -764,8 +772,8 @@ msgstr "Aktivera DNS kontroller"
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -804,8 +812,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr "Går ut"
 
@@ -827,8 +835,8 @@ msgstr "Misslyckades"
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -898,13 +906,13 @@ msgstr "Helt i linje"
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Generellt"
 
@@ -1070,8 +1078,8 @@ msgstr "Senast ändrad"
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1110,7 +1118,7 @@ msgid "Logger"
 msgstr "Loggare"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Logga ut"
 
@@ -1132,10 +1140,17 @@ msgstr "Brevlådor"
 msgid "Mailboxes"
 msgstr "Brevlådor"
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "Användande"
 
@@ -1146,8 +1161,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1197,15 +1212,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "Namn"
 
@@ -1265,12 +1280,12 @@ msgstr "Nästa"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1338,8 +1353,8 @@ msgstr ""
 msgid "Options"
 msgstr "Inställningar"
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1363,9 +1378,9 @@ msgstr "Lösenord"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1409,8 +1424,8 @@ msgstr "Var vänlig fyll i din primära e-postadress"
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1478,10 +1493,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1511,8 +1528,8 @@ msgstr "Slumpmässig adress"
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr "Slumpmässigt lösenord"
 
@@ -1603,8 +1620,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1640,8 +1657,8 @@ msgstr "Sekundär e-post"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 #, fuzzy
 msgid "Secured"
 msgstr "Säkerhet"
@@ -1701,7 +1718,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Inställningar"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1743,8 +1760,8 @@ msgstr "Statistik"
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr "Status"
 
@@ -1808,8 +1825,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1916,9 +1933,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Användarnamn"
 
@@ -1945,12 +1962,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1983,12 +2000,12 @@ msgstr "År"
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -2012,6 +2029,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2020,7 +2041,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2042,8 +2063,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/tr/LC_MESSAGES/app.po
+++ b/frontend/locale/tr/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -80,11 +80,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -169,8 +169,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -209,10 +210,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -248,9 +249,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -396,6 +397,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -437,6 +443,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -476,12 +484,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -493,8 +501,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr "Tanım"
@@ -686,10 +694,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -761,8 +769,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -801,8 +809,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -824,8 +832,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -893,13 +901,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr "Genel"
 
@@ -1064,8 +1072,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1104,7 +1112,7 @@ msgid "Logger"
 msgstr "Kayıtçı"
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr "Çıkış Yapın"
 
@@ -1126,10 +1134,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr "İleti"
 
@@ -1140,8 +1155,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1190,15 +1205,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr "İsim"
 
@@ -1258,12 +1273,12 @@ msgstr "Sonraki"
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr "Hayır"
 
@@ -1330,8 +1345,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1355,9 +1370,9 @@ msgstr "Parola"
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1401,8 +1416,8 @@ msgstr "Lütfen birincil e-posta adresinizi girin"
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1470,10 +1485,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1503,8 +1520,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1595,8 +1612,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1632,8 +1649,8 @@ msgstr "İkincil e-posta"
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 #, fuzzy
 msgid "Secured"
 msgstr "Güvenlik"
@@ -1693,7 +1710,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1734,8 +1751,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1799,8 +1816,8 @@ msgstr "Kime"
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1906,9 +1923,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr "Kullanıcı adı"
 
@@ -1935,12 +1952,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1973,12 +1990,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr "Evet"
 
@@ -2002,6 +2019,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2010,7 +2031,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2032,8 +2053,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/locale/zh-hant/LC_MESSAGES/app.po
+++ b/frontend/locale/zh-hant/LC_MESSAGES/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Modoboa 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-21 15:13+0200\n"
+"POT-Creation-Date: 2023-04-23 18:55+0200\n"
 "PO-Revision-Date: 2023-02-23 11:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -79,11 +79,11 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:20
 #: src/components/imap_migration/MigrationsList.vue:16
 #: src/components/imap_migration/ProvidersList.vue:20
-#: src/components/imap_migration/ProvidersList.vue:112
-#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/domains/DomainList.vue:173
 #: src/components/identities/IdentityList.vue:102
 #: src/components/alarms/AlarmList.vue:100
-#: src/components/domains/DomainList.vue:173
+#: src/components/imap_migration/MigrationsList.vue:71
+#: src/components/imap_migration/ProvidersList.vue:112
 msgid "Actions"
 msgstr ""
 
@@ -110,11 +110,11 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:20
 #: src/components/imap_migration/ProviderCreationForm.vue:30
 #: src/components/imap_migration/ProvidersList.vue:16
-#: src/components/imap_migration/ProvidersList.vue:108
-#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/domains/DNSDetail.vue:177
 #: src/components/identities/AliasCreationForm.vue:42
 #: src/components/identities/AccountSenderAddresses.vue:63
-#: src/components/domains/DNSDetail.vue:177
+#: src/components/imap_migration/ProviderCreationForm.vue:52
+#: src/components/imap_migration/ProvidersList.vue:108
 msgid "Address"
 msgstr ""
 
@@ -168,8 +168,9 @@ msgid "Alarm re-opened"
 msgstr ""
 
 #: src/components/domains/DomainList.vue:120
-#: src/components/layout/Navbar.vue:66 src/components/layout/Navbar.vue:181
+#: src/components/layout/Navbar.vue:66
 #: src/components/domains/DomainList.vue:263
+#: src/components/layout/Navbar.vue:181
 msgid "Alarms"
 msgstr ""
 
@@ -208,10 +209,10 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:62
 #: src/components/identities/AccountCreationForm.vue:65
 #: src/components/identities/AccountCreationForm.vue:93
+#: src/components/domains/DomainList.vue:169
 #: src/components/identities/AccountCreationForm.vue:114
 #: src/components/identities/AccountCreationForm.vue:117
 #: src/components/identities/AccountCreationForm.vue:145
-#: src/components/domains/DomainList.vue:169
 msgid "Aliases"
 msgstr ""
 
@@ -247,9 +248,9 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:45
 #: src/components/imap_migration/ProviderForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:19
-#: src/components/imap_migration/ProvidersList.vue:111
 #: src/components/imap_migration/ProviderCreationForm.vue:58
 #: src/components/imap_migration/ProviderCreationForm.vue:67
+#: src/components/imap_migration/ProvidersList.vue:111
 msgid "Associated domains"
 msgstr ""
 
@@ -394,6 +395,11 @@ msgstr ""
 msgid "Copy token to clipboard"
 msgstr ""
 
+#: src/components/parameters/ParametersForm.vue:68
+#: src/components/parameters/ParametersForm.vue:158
+msgid "Could not save parameters"
+msgstr ""
+
 #: src/components/domains/DomainCreationForm.vue:54
 #: src/components/domains/DomainOptionsForm.vue:2
 #: src/components/domains/DomainCreationForm.vue:107
@@ -435,6 +441,8 @@ msgid "Daily message sending limit"
 msgstr ""
 
 #: src/components/domains/DomainSummary.vue:23
+#: src/components/identities/AccountSummary.vue:43
+#: src/components/identities/AccountSummary.vue:12
 msgid "Daily sending limit"
 msgstr ""
 
@@ -474,12 +482,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:187
 #: src/components/imap_migration/MigrationsList.vue:50
 #: src/components/imap_migration/ProvidersList.vue:45
-#: src/components/imap_migration/ProvidersList.vue:137
-#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/domains/DomainList.vue:259
 #: src/components/identities/IdentityList.vue:246
 #: src/components/identities/IdentityList.vue:258
 #: src/components/identities/IdentityList.vue:269
-#: src/components/domains/DomainList.vue:259
+#: src/components/imap_migration/MigrationsList.vue:105
+#: src/components/imap_migration/ProvidersList.vue:137
 msgid "Delete"
 msgstr ""
 
@@ -491,8 +499,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:31
 #: src/components/identities/AliasGeneralForm.vue:87
 #: src/components/identities/AliasSummary.vue:19
-#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/identities/AliasGeneralForm.vue:56
+#: src/components/identities/AliasCreationForm.vue:53
 #: src/components/admin/ComponentsInformationTable.vue:54
 msgid "Description"
 msgstr ""
@@ -684,10 +692,10 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:159
 #: src/components/identities/IdentityList.vue:171
 #: src/components/imap_migration/ProvidersList.vue:51
-#: src/components/imap_migration/ProvidersList.vue:143
+#: src/components/domains/DomainList.vue:258
 #: src/components/identities/IdentityList.vue:241
 #: src/components/identities/IdentityList.vue:253
-#: src/components/domains/DomainList.vue:258
+#: src/components/imap_migration/ProvidersList.vue:143
 msgid "Edit"
 msgstr ""
 
@@ -759,8 +767,8 @@ msgstr ""
 #: src/components/identities/AccountGeneralForm.vue:13
 #: src/components/identities/AliasForm.vue:17
 #: src/components/identities/AliasGeneralForm.vue:11
-#: src/components/identities/AccountCreationForm.vue:91
 #: src/components/domains/DomainCreationForm.vue:80
+#: src/components/identities/AccountCreationForm.vue:91
 msgid "Enabled"
 msgstr ""
 
@@ -799,8 +807,8 @@ msgstr ""
 #: src/components/identities/AliasCreationForm.vue:26
 #: src/components/identities/AliasGeneralForm.vue:79
 #: src/components/identities/AliasSummary.vue:15
-#: src/components/identities/AliasCreationForm.vue:48
 #: src/components/identities/AliasGeneralForm.vue:49
+#: src/components/identities/AliasCreationForm.vue:48
 msgid "Expire at"
 msgstr ""
 
@@ -822,8 +830,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:30
 #: src/components/identities/AccountGeneralForm.vue:32
 #: src/components/user/ProfileForm.vue:45
-#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/identities/AccountGeneralForm.vue:17
+#: src/components/identities/AccountCreationForm.vue:82
 #: src/components/user/ProfileForm.vue:9
 msgid "First name"
 msgstr ""
@@ -891,13 +899,13 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:44
 #: src/components/imap_migration/ProviderForm.vue:7
 #: src/views/domains/Domain.vue:11
-#: src/components/imap_migration/ProviderCreationForm.vue:49
-#: src/components/imap_migration/ProviderCreationForm.vue:66
-#: src/components/identities/AliasCreationForm.vue:39
-#: src/components/identities/AliasCreationForm.vue:71
 #: src/components/domains/DomainCreationForm.vue:76
 #: src/components/domains/DomainCreationForm.vue:161
 #: src/components/domains/DomainCreationForm.vue:167
+#: src/components/identities/AliasCreationForm.vue:39
+#: src/components/identities/AliasCreationForm.vue:71
+#: src/components/imap_migration/ProviderCreationForm.vue:49
+#: src/components/imap_migration/ProviderCreationForm.vue:66
 msgid "General"
 msgstr ""
 
@@ -1062,8 +1070,8 @@ msgstr ""
 #: src/components/identities/AccountCreationForm.vue:31
 #: src/components/identities/AccountGeneralForm.vue:41
 #: src/components/user/ProfileForm.vue:52
-#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/identities/AccountGeneralForm.vue:25
+#: src/components/identities/AccountCreationForm.vue:83
 #: src/components/user/ProfileForm.vue:15
 msgid "Last name"
 msgstr ""
@@ -1102,7 +1110,7 @@ msgid "Logger"
 msgstr ""
 
 #: src/components/layout/Navbar.vue:159 src/components/layout/Topbar.vue:6
-#: src/components/layout/Navbar.vue:274 src/components/layout/Topbar.vue:53
+#: src/components/layout/Topbar.vue:53 src/components/layout/Navbar.vue:274
 msgid "Logout"
 msgstr ""
 
@@ -1124,10 +1132,17 @@ msgstr ""
 msgid "Mailboxes"
 msgstr ""
 
+#: src/components/domains/DomainSummary.vue:16
+#: src/components/identities/AccountSummary.vue:37
+#: src/components/identities/AccountSummary.vue:6
+#: src/components/identities/AccountSummary.vue:1
+msgid "MB"
+msgstr ""
+
 #: src/components/alarms/AlarmList.vue:19
 #: src/components/logs/AuditTrailList.vue:11
-#: src/components/alarms/AlarmList.vue:99
 #: src/components/logs/AuditTrailList.vue:43
+#: src/components/alarms/AlarmList.vue:99
 msgid "Message"
 msgstr ""
 
@@ -1138,8 +1153,8 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:42
 #: src/components/domains/DomainLimitationsForm.vue:9
 #: src/components/identities/AccountCreationForm.vue:56
-#: src/components/identities/AccountCreationForm.vue:108
 #: src/components/domains/DomainCreationForm.vue:95
+#: src/components/identities/AccountCreationForm.vue:108
 msgid "Message sending limit"
 msgstr ""
 
@@ -1187,15 +1202,15 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:17
 #: src/components/imap_migration/ProviderCreationForm.vue:29
 #: src/components/imap_migration/ProvidersList.vue:15
-#: src/components/imap_migration/ProvidersList.vue:107
-#: src/components/imap_migration/ProviderCreationForm.vue:51
-#: src/components/identities/IdentityList.vue:99
-#: src/components/domains/DNSDetail.vue:176
-#: src/components/domains/DomainAliasForm.vue:13
 #: src/components/domains/DomainCreationForm.vue:78
-#: src/components/domains/AdministratorList.vue:87
+#: src/components/domains/DNSDetail.vue:176
 #: src/components/domains/DomainList.vue:168
+#: src/components/domains/DomainAliasForm.vue:13
+#: src/components/domains/AdministratorList.vue:87
+#: src/components/identities/IdentityList.vue:99
 #: src/components/admin/ComponentsInformationTable.vue:51
+#: src/components/imap_migration/ProviderCreationForm.vue:51
+#: src/components/imap_migration/ProvidersList.vue:107
 msgid "Name"
 msgstr ""
 
@@ -1254,12 +1269,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:68
 #: src/components/identities/IdentityList.vue:98
 #: src/components/tools/CreationForm.vue:46
-#: src/components/tools/CreationForm.vue:120
+#: src/components/domains/DNSDetail.vue:193
+#: src/components/domains/DomainList.vue:205
 #: src/components/identities/IdentityList.vue:125
 #: src/components/identities/IdentityList.vue:150
 #: src/components/identities/IdentityList.vue:180
-#: src/components/domains/DNSDetail.vue:193
-#: src/components/domains/DomainList.vue:205
+#: src/components/tools/CreationForm.vue:120
 msgid "No"
 msgstr ""
 
@@ -1326,8 +1341,8 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:61
-#: src/components/parameters/ParametersForm.vue:140
+#: src/components/parameters/ParametersForm.vue:63
+#: src/components/parameters/ParametersForm.vue:153
 msgid "Parameters updated"
 msgstr ""
 
@@ -1351,9 +1366,9 @@ msgstr ""
 #: src/components/domains/DomainCreationForm.vue:127
 #: src/components/identities/AccountCreationForm.vue:101
 #: src/components/identities/AccountPasswordForm.vue:32
-#: src/components/identities/AccountCreationForm.vue:153
-#: src/components/identities/AccountPasswordForm.vue:103
 #: src/components/domains/DomainCreationForm.vue:180
+#: src/components/identities/AccountPasswordForm.vue:103
+#: src/components/identities/AccountCreationForm.vue:153
 msgid "Password copied to clipboard"
 msgstr ""
 
@@ -1397,8 +1412,8 @@ msgstr ""
 
 #: src/components/imap_migration/ProviderCreationForm.vue:31
 #: src/components/imap_migration/ProvidersList.vue:17
-#: src/components/imap_migration/ProvidersList.vue:109
 #: src/components/imap_migration/ProviderCreationForm.vue:53
+#: src/components/imap_migration/ProvidersList.vue:109
 msgid "Port"
 msgstr ""
 
@@ -1464,10 +1479,12 @@ msgstr ""
 #: src/components/domains/DomainSummary.vue:15
 #: src/components/identities/AccountCreationForm.vue:50
 #: src/components/identities/AccountMailboxForm.vue:14
-#: src/components/identities/AccountCreationForm.vue:102
-#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountSummary.vue:33
+#: src/components/identities/AccountSummary.vue:2
 #: src/components/domains/DomainCreationForm.vue:93
 #: src/components/domains/DomainList.vue:172
+#: src/components/identities/AccountMailboxForm.vue:3
+#: src/components/identities/AccountCreationForm.vue:102
 msgid "Quota"
 msgstr ""
 
@@ -1497,8 +1514,8 @@ msgstr ""
 #: src/components/domains/DomainOptionsForm.vue:6
 #: src/components/identities/AccountCreationForm.vue:34
 #: src/components/identities/AccountPasswordForm.vue:9
-#: src/components/identities/AccountCreationForm.vue:86
 #: src/components/domains/DomainCreationForm.vue:111
+#: src/components/identities/AccountCreationForm.vue:86
 msgid "Random password"
 msgstr ""
 
@@ -1589,8 +1606,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:19
 #: src/views/user/PasswordRecoveryForm.vue:32
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:22
-#: src/views/user/PasswordRecoveryForm.vue:78
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:70
+#: src/views/user/PasswordRecoveryForm.vue:78
 msgid "Return to login"
 msgstr ""
 
@@ -1626,8 +1643,8 @@ msgstr ""
 #: src/components/imap_migration/ProviderCreationForm.vue:32
 #: src/components/imap_migration/ProviderGeneralForm.vue:11
 #: src/components/imap_migration/ProvidersList.vue:18
-#: src/components/imap_migration/ProvidersList.vue:110
 #: src/components/imap_migration/ProviderCreationForm.vue:54
+#: src/components/imap_migration/ProvidersList.vue:110
 msgid "Secured"
 msgstr ""
 
@@ -1686,7 +1703,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:20
+#: src/components/parameters/ParametersForm.vue:21
 msgid "Settings: thislabel"
 msgstr ""
 
@@ -1727,8 +1744,8 @@ msgstr ""
 
 #: src/components/alarms/AlarmList.vue:16
 #: src/components/logs/MessageList.vue:11
-#: src/components/alarms/AlarmList.vue:96
 #: src/components/logs/MessageList.vue:44
+#: src/components/alarms/AlarmList.vue:96
 msgid "Status"
 msgstr ""
 
@@ -1792,8 +1809,8 @@ msgstr ""
 #: src/views/user/PasswordRecoveryForm.vue:69
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:46 src/views/Login.vue:101
 #: src/views/user/PasswordRecoveryChangeForm.vue:122
-#: src/views/user/PasswordRecoveryForm.vue:115
 #: src/views/user/PasswordRecoverySmsTotpForm.vue:94
+#: src/views/user/PasswordRecoveryForm.vue:115
 msgid "Too many unsuccessful attempts, please try later."
 msgstr ""
 
@@ -1899,9 +1916,9 @@ msgstr ""
 #: src/components/domains/AdministratorList.vue:18
 #: src/components/identities/AccountCreationForm.vue:29
 #: src/components/identities/AccountGeneralForm.vue:19 src/views/Login.vue:9
-#: src/components/identities/AccountCreationForm.vue:81
-#: src/components/identities/AccountGeneralForm.vue:7
 #: src/components/domains/AdministratorList.vue:86
+#: src/components/identities/AccountGeneralForm.vue:7
+#: src/components/identities/AccountCreationForm.vue:81
 msgid "Username"
 msgstr ""
 
@@ -1928,12 +1945,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:61
 #: src/components/identities/IdentityList.vue:92
 #: src/components/tools/CreationForm.vue:41 src/views/user/APISetup.vue:40
-#: src/components/tools/CreationForm.vue:115
+#: src/components/domains/DNSDetail.vue:187
+#: src/components/domains/DomainList.vue:198
 #: src/components/identities/IdentityList.vue:118
 #: src/components/identities/IdentityList.vue:143
 #: src/components/identities/IdentityList.vue:174
-#: src/components/domains/DNSDetail.vue:187
-#: src/components/domains/DomainList.vue:198 src/views/user/APISetup.vue:81
+#: src/components/tools/CreationForm.vue:115 src/views/user/APISetup.vue:81
 msgid "Warning"
 msgstr ""
 
@@ -1966,12 +1983,12 @@ msgstr ""
 #: src/components/identities/IdentityList.vue:69
 #: src/components/identities/IdentityList.vue:99
 #: src/components/tools/CreationForm.vue:45
-#: src/components/tools/CreationForm.vue:119
+#: src/components/domains/DNSDetail.vue:194
+#: src/components/domains/DomainList.vue:206
 #: src/components/identities/IdentityList.vue:126
 #: src/components/identities/IdentityList.vue:151
 #: src/components/identities/IdentityList.vue:181
-#: src/components/domains/DNSDetail.vue:194
-#: src/components/domains/DomainList.vue:206
+#: src/components/tools/CreationForm.vue:119
 msgid "Yes"
 msgstr ""
 
@@ -1995,6 +2012,10 @@ msgstr ""
 msgid "Your API token is:"
 msgstr ""
 
+#: src/api/repository.js:38
+msgid "You are throttled, please try later."
+msgstr ""
+
 #: src/filters/index.js:7
 msgid "yes"
 msgstr ""
@@ -2003,7 +2024,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/components/parameters/ParametersForm.vue:99
+#: src/components/parameters/ParametersForm.vue:111
 msgid "Settings: "
 msgstr ""
 
@@ -2025,8 +2046,4 @@ msgstr ""
 
 #: src/plugins/vee-validate.js:46
 msgid "Specify a valid port number"
-msgstr ""
-
-#: src/api/repository.js:38
-msgid "You are throttled, please try later."
 msgstr ""

--- a/frontend/src/components/parameters/ParametersForm.vue
+++ b/frontend/src/components/parameters/ParametersForm.vue
@@ -159,9 +159,7 @@ export default {
         this.formErrors = error.response.data
         Object.keys(this.formErrors).forEach(element => {
           for (let i = 0; i < this.structure.length; i++) {
-            const isIn = (this.structure[i].parameters.filter(function (val, index, array) {
-              return val.name === element
-            }).length > 0)
+            const isIn = this.structure[i].parameters.filter(param => param.name === element).length > 0
             if (isIn) {
               this.tab_error.push(i)
             }


### PR DESCRIPTION
* Added a notification when parameters fail to save and highlighted tabs with parameters containing errors in red:
![image](https://user-images.githubusercontent.com/45575529/233853775-eb42453d-b2f6-4d55-8572-458114bb1c60.png)
* Updated translation
 