### PR TITLE
Update upgrade.rst imap_migration module fix.

### DIFF
--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -171,7 +171,7 @@ to ``MODOBOA_APPS``:
 And remove any reference to ``'modoboa_dmarc'``, ``'modoboa_pdfcredentials'`` or ``'modoboa_imap_migration'``
 in this same variable.
 
-You need to add ``'modoboa_imap_migration.auth_backends.IMAPBackend',`` at the end of ``AUTHENTICATION_BACKENDS``:
+You need to add ``'modoboa.imap_migration.auth_backends.IMAPBackend',`` at the end of ``AUTHENTICATION_BACKENDS``:
 
 .. sourcecode:: python
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

It's just a `.` rather than a `_`. 

Current behavior before PR:

I copied this line and ran into an 500 Internal server error after login and needed to figure out why via `DEBUG=True` because there where no logs found anywhere pointing to that error.

Desired behavior after PR is merged:

Logging in is possible again.
