### PR TITLE
Tfa setup improvement

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -7,7 +7,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 FROM base as build
 
 RUN apk add --update openssl librrd python3-dev libffi-dev gcc g++ musl-dev libxml2-dev libxslt-dev \
-    libressl-dev jpeg-dev rrdtool-dev file make gettext freetype-dev cairo-dev \
+    libressl-dev jpeg-dev rrdtool-dev file make gettext freetype-dev cairo-dev cargo \
     && rm -rf /var/cache/apk/*
 RUN python3 -m venv $VIRTUAL_ENV
 WORKDIR /tmp

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "vue-gettext": "^2.1.12",
     "vue-router": "^3.2.0",
     "vuetify": "^2.6.10",
-    "vuex": "^3.4.0"
+    "vuex": "^3.4.0",
+    "qrcode.vue": "~1.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/frontend/src/api/account.js
+++ b/frontend/src/api/account.js
@@ -16,8 +16,8 @@ export default {
   startTFASetup () {
     return repository.post(`${resource}/tfa/setup/`)
   },
-  getQRCodeForTFASetup () {
-    return repository.get(`${resource}/tfa/setup/qr_code/`)
+  getKeyForTFASetup () {
+    return repository.get(`${resource}/tfa/setup/key/`)
   },
   finalizeTFASetup (pinCode) {
     const payload = { pin_code: pinCode }

--- a/frontend/src/api/account.js
+++ b/frontend/src/api/account.js
@@ -23,11 +23,11 @@ export default {
     const payload = { pin_code: pinCode }
     return repository.post(`${resource}/tfa/setup/check/`, payload)
   },
-  disableTFA () {
-    return repository.post(`${resource}/tfa/disable/`)
+  disableTFA (data) {
+    return repository.post(`${resource}/tfa/disable/`, data)
   },
-  resetRecoveryCodes () {
-    return repository.post(`${resource}/tfa/reset_codes/`)
+  resetRecoveryCodes (data) {
+    return repository.post(`${resource}/tfa/reset_codes/`, data)
   },
   getForward () {
     return repository.get(`${resource}/forward/`)

--- a/frontend/src/plugins/vee-validate.js
+++ b/frontend/src/plugins/vee-validate.js
@@ -15,6 +15,13 @@ extend('numeric', {
   ...numeric,
   message: () => $gettext('This field must be a valid number')
 })
+extend('minmax', {
+  validate: async (value, args) => {
+    return value.length >= args.length && value.length <= args.length
+  },
+  params: ['length'],
+  message: $gettext('This field must have a length of {length} characters')
+})
 extend('required', {
   ...required,
   message: () => $gettext('This field is required')

--- a/frontend/src/views/TwoFA.vue
+++ b/frontend/src/views/TwoFA.vue
@@ -20,6 +20,7 @@
           <v-col cols="6" offset="3">
             <label class="m-label"><translate>Two-factor authentication code</translate></label>
             <v-otp-input
+              ref="otpInput"
               v-model="code"
               length="6"
               :error-messages="errors"
@@ -51,6 +52,9 @@ export default {
       errors: {},
       loading: false
     }
+  },
+  mounted: function () {
+    this.$refs.otpInput.focus()
   },
   methods: {
     async verifyCode () {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6350,6 +6350,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+qrcode.vue@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/qrcode.vue/-/qrcode.vue-1.7.0.tgz#c54b2934f0650c10d92785d08aaad36c55e0fc56"
+  integrity sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==
+
 qs@6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"

--- a/modoboa/core/api/v1/serializers.py
+++ b/modoboa/core/api/v1/serializers.py
@@ -1,8 +1,13 @@
 """Core API serializers."""
 
+import logging
+
+from django.utils.html import escape
 from django.utils.translation import gettext as _
 
 from rest_framework import serializers
+
+logger = logging.getLogger("modoboa.auth")
 
 
 class CheckTFASetupSerializer(serializers.Serializer):
@@ -21,3 +26,20 @@ class CheckTFASetupSerializer(serializers.Serializer):
         if user.tfa_enabled or user.staticdevice_set.exists():
             raise serializers.ValidationError(_("2FA is already enabled"))
         return data
+
+
+class CheckPasswordTFASerializer(serializers.Serializer):
+    """Serializer used to check user password when modifying TFA."""
+
+    password = serializers.CharField()
+
+    def validate_password(self, value):
+        user = self.context["user"]
+        if not user.check_password(value):
+            logger.warning(
+                _("Failed TFA settings editing attempt from '%s' as user '%s'"),
+                self.context["remote_addr"],
+                escape(user.username)
+            )
+            raise serializers.ValidationError(_("Invalid password"))
+        return value

--- a/modoboa/core/api/v1/viewsets.py
+++ b/modoboa/core/api/v1/viewsets.py
@@ -67,8 +67,8 @@ class AccountViewSet(GetThrottleViewsetMixin, viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
         if not request.user.tfa_enabled:
             # We include it as "password" to display the error
-            return response.Response({"password": _("2FA is not enabled")},
-                                     status=400)
+            return response.Response({"error": _("2FA is not enabled")},
+                                     status=403)
         request.user.totpdevice_set.all().delete()
         request.user.staticdevice_set.all().delete()
         request.user.tfa_enabled = False
@@ -89,8 +89,8 @@ class AccountViewSet(GetThrottleViewsetMixin, viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
         device = request.user.staticdevice_set.first()
         if device is None:
-            return response.Response({"password": _("2FA is not enabled")},
-                                     status=400)
+            return response.Response({"error": _("2FA is not enabled")},
+                                     status=403)
         device.token_set.all().delete()
         for cpt in range(10):
             token = StaticToken.random_token()

--- a/modoboa/core/api/v1/viewsets.py
+++ b/modoboa/core/api/v1/viewsets.py
@@ -62,8 +62,8 @@ class AccountViewSet(GetThrottleViewsetMixin, viewsets.ViewSet):
             context={
                 "user": request.user,
                 "remote_addr": request.META["REMOTE_ADDR"]
-                }
-            )
+            }
+        )
         serializer.is_valid(raise_exception=True)
         if not request.user.tfa_enabled:
             # We include it as "password" to display the error
@@ -84,8 +84,8 @@ class AccountViewSet(GetThrottleViewsetMixin, viewsets.ViewSet):
             context={
                 "user": request.user,
                 "remote_addr": request.META["REMOTE_ADDR"]
-                }
-            )
+            }
+        )
         serializer.is_valid(raise_exception=True)
         device = request.user.staticdevice_set.first()
         if device is None:

--- a/modoboa/core/api/v2/viewsets.py
+++ b/modoboa/core/api/v2/viewsets.py
@@ -1,10 +1,5 @@
 """Core API v2 viewsets."""
 
-import io
-
-import qrcode
-import qrcode.image.svg
-
 from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions, response, viewsets
@@ -102,19 +97,16 @@ class AccountViewSet(core_v1_viewsets.AccountViewSet):
             "access": str(refresh.access_token)
         })
 
-    @action(methods=["get"], detail=False, url_path="tfa/setup/qr_code")
-    def tfa_setup_get_qr_code(self, request):
+    @action(methods=["get"], detail=False, url_path="tfa/setup/key")
+    def tfa_setup_get_key(self, request):
         """Get a QR code to finalize the setup process."""
         if request.user.tfa_enabled:
             return response.Response(status=404)
         device = request.user.totpdevice_set.first()
         if not device:
             return response.Response(status=404)
-        factory = qrcode.image.svg.SvgPathImage
-        img = qrcode.make(device.config_url, image_factory=factory)
-        buf = io.BytesIO()
-        img.save(buf)
-        return response.Response(buf.getvalue(), content_type="application/xml")
+        return response.Response({"key": device.key, "url":device.config_url},
+                                 content_type="application/json")
 
     @extend_schema(
         request=core_v1_serializers.CheckTFASetupSerializer

--- a/modoboa/core/api/v2/viewsets.py
+++ b/modoboa/core/api/v2/viewsets.py
@@ -99,7 +99,7 @@ class AccountViewSet(core_v1_viewsets.AccountViewSet):
 
     @action(methods=["get"], detail=False, url_path="tfa/setup/key")
     def tfa_setup_get_key(self, request):
-        """Get a QR code to finalize the setup process."""
+        """Get a key and url to finalize the setup process."""
         if request.user.tfa_enabled:
             return response.Response(status=404)
         device = request.user.totpdevice_set.first()

--- a/modoboa/core/templates/core/user_security.html
+++ b/modoboa/core/templates/core/user_security.html
@@ -54,10 +54,10 @@
             Two-Factor Authentication is enabled for your account.
           {% endblocktrans %}
         </div>
-        <a id="deactivate-tfa" class="btn btn-danger" href="{% url 'api:account-tfa-disable' %}">
+        <a id="deactivate-tfa" class="btn btn-danger" data-href="{% url 'api:account-tfa-disable' %}" data-toggle="modal" data-target="#disable-modal" data-content="{% trans 'This will invalidate your registered application.' %}">
           {% trans "Disable 2FA" %}
         </a>
-        <a id="tfa-refresh-codes" class="btn btn-default" href="{% url 'api:account-tfa-reset-codes' %}">
+        <a id="tfa-refresh-codes" class="btn btn-default" data-href="{% url 'api:account-tfa-reset-codes' %}" data-toggle="modal" data-target="#disable-modal" data-content="{% trans 'This will regenerate your tokens.' %}">
           {% trans "Reset recovery codes" %}
         </a>
     {% else %}
@@ -101,3 +101,82 @@
       </div>
     </div>
   </div>
+  <div id="disable-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="passwordConfirmModal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <form id="password-confirm">
+          <div class="modal-header">
+            <h3 class="modal-title">Are you sure?</h3>
+          </div>
+          <div class="modal-body">
+            <div class="alert alert-danger">
+              <h4>Warning</h4>
+              <div id="password-confirm-content">
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="password">{% trans "Confirm your password" %}</label>
+              <input name="password" id="password" class="form-control" type="password" placeholder="{% trans 'password' %}" required>
+              <div class="col-sm-3">
+                <small id="password-error" class="text-danger"></small>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary">Ok</button>
+            <a data-dismiss="modal" class="btn btn-default">Cancel</a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script type="text/javascript">
+    const passwordError = document.getElementById("password-error")
+    var buttonClicked;
+    $('#disable-modal').on('shown.bs.modal', function (event) {
+      buttonClicked = $(event.relatedTarget); // Button that triggered the modal
+      document.getElementById("password-confirm-content").innerHTML = buttonClicked.attr("data-content")
+    });
+    const form = document.getElementById('password-confirm')
+    form.addEventListener("submit", async function(event) {
+      event.preventDefault()
+      passwordError.innerHTML = ""
+      const url = buttonClicked.attr("data-href")
+      const formData = new FormData(event.target);
+      const plainFormData = Object.fromEntries(formData.entries());
+      const formDataJsonString = JSON.stringify(plainFormData);
+      const fetchOptions = {
+		method: "POST",
+		credentials: 'same-origin',
+		headers: {
+			"Content-Type": "application/json",
+			"Accept": "application/json",
+			"X-CSRFToken": getCookie("csrftoken")
+		},
+        body: formDataJsonString,
+      };
+      const response = await fetch(url, fetchOptions);
+
+      if (!response.ok && response.status === 400) {
+        const text = await response.json();
+        passwordError.innerHTML = text.password[0];
+        return;
+      } else {
+        if (buttonClicked.attr("id") === "tfa-refresh-codes") {
+          var $container = $('#tfa-codes-area');
+          var $ul = $('<ul>');
+          const resp = await response.json()
+          $.each(resp.tokens, function (index, value) {
+              var $li = $('<li />', { html: value });
+              $ul.append($li);
+          });
+          $container.append($ul);
+          $('#codes-modal').modal();
+          $('#disable-modal').modal('hide')
+          return;
+        }
+      }
+      window.location.reload();
+    })
+  </script>

--- a/modoboa/static/js/twocols_nav.js
+++ b/modoboa/static/js/twocols_nav.js
@@ -166,12 +166,6 @@ TwocolsNav.prototype = {
         this.update_content(data);
         $('#start-tfa-setup').click(this.startTFASetup);
         $('#finalize-tfa-setup').click(this.finalizeTFASetup);
-        $('#deactivate-tfa').confirm({
-            question: gettext('Are you sure?'),
-            warning: gettext('This will invalidate your registered application.'),
-            method: 'POST'
-        });
-        $('#tfa-refresh-codes').click(this.resetTFARecoveryCodes);
     },
 
     startTFASetup: function (evt) {
@@ -201,24 +195,6 @@ TwocolsNav.prototype = {
         }).fail(function (jqxhr) {
             var errors = JSON.parse(jqxhr.responseText);
             display_field_error($('#pin-code'), errors.pin_code.join(' '));
-        });
-    },
-
-    resetTFARecoveryCodes: function (evt) {
-        evt.preventDefault();
-        $.ajax({
-            url: $(this).attr('href'),
-            type: 'post',
-            contentType: 'application/json'
-        }).done(function (resp) {
-            var $container = $('#tfa-codes-area');
-            var $ul = $('<ul>');
-            $.each(resp.tokens, function (index, value) {
-                var $li = $('<li />', { html: value });
-                $ul.append($li);
-            });
-            $container.append($ul);
-            $('#codes-modal').modal();
         });
     }
 };


### PR DESCRIPTION
- Added password verification when editing TFA setup ( disable and reset backup codes).
- Added a click to copy button to copy the key directly
- Changed api to send the url of the TOTP instead of the QRcode (to send the key as well), the QR code is now generated on the frontend (client side)
- On frontend added length check to form validation
- Updated tests