### PR TITLE
Use asyncio from redis instead of aioredis to make app python 3.11 compatible

### DIFF
--- a/.github/workflows/modoboa.yml
+++ b/.github/workflows/modoboa.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         database: ['postgres', 'mysql']
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
       fail-fast: false
 
     steps:

--- a/modoboa/policyd/core.py
+++ b/modoboa/policyd/core.py
@@ -8,7 +8,7 @@ import logging
 
 import aiosmtplib
 from dateutil.relativedelta import relativedelta
-import aioredis
+from redis import asyncio as aioredis
 
 from django.conf import settings
 from django.db import connections

--- a/modoboa/policyd/tests.py
+++ b/modoboa/policyd/tests.py
@@ -1,8 +1,7 @@
 """Policy daemon related tests."""
 
 import asyncio
-# from mock import patch
-from asynctest import patch
+from mock import patch
 from multiprocessing import Process
 import socket
 import time
@@ -200,8 +199,7 @@ sasl_username=user@test.com
             await policyd_core.reset_counters()
 
         # Run the async test
-        coro = asyncio.coroutine(run_test)
-        event_loop.run_until_complete(coro())
+        event_loop.run_until_complete(run_test())
         event_loop.close()
 
         self.assertEqual(

--- a/modoboa/policyd/tests.py
+++ b/modoboa/policyd/tests.py
@@ -1,7 +1,8 @@
 """Policy daemon related tests."""
 
 import asyncio
-from mock import patch
+from aiosmtplib import send
+from unittest.mock import AsyncMock
 from multiprocessing import Process
 import socket
 import time
@@ -56,8 +57,7 @@ class PolicyDaemonTestCase(
         self.admin.role = "SuperAdmins"
 
         db.connections.close_all()
-        patcher = patch("aiosmtplib.send")
-        self.send_mock = patcher.start()
+        self.send_mock = AsyncMock(send)
         self.process = Process(target=start_policy_daemon)
         self.process.daemon = True
         self.process.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ lxml
 chardet
 ovh
 oath
-redis
+redis>=4.2.0rc1
 rrdtool>=0.1.10
 qrcode
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,6 @@ rrdtool>=0.1.10
 qrcode
 
 aiosmtplib
-aioredis==2.0.1
 
 # PDF credentials
 reportlab

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,3 @@ factory-boy<3.3.0
 httmock==1.4.0
 testfixtures==7.1.0
 tox
-asynctest


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Policyd part crash on debian 12

Current behavior before PR:

The policyd supervisor crash with a well known bug on aioredis with python 3.11. Like I found [here](https://github.com/aio-libs/aioredis-py/issues/1443), aioredis is not maintained anymore, but we can replace it by redis with asyncio (with redis >= 4.2.0rc1)

Desired behavior after PR is merged:

I made the change and all seems to work well with python 3.11, but we should want more testers!