### PR TITLE
Improved alias management

### DIFF
--- a/frontend/src/components/identities/AccountAliasForm.vue
+++ b/frontend/src/components/identities/AccountAliasForm.vue
@@ -15,7 +15,7 @@
       />
   </validation-provider>
   <v-chip
-    v-for="(alias, index) in aliases"
+    v-for="(alias, index) in form.aliases"
     :key="index"
     class="mr-2 mt-2"
     close
@@ -37,19 +37,25 @@ export default {
   },
   data () {
     return {
-      currentAlias: '',
-      aliases: []
+      form: {
+        mailbox: {},
+        aliases: []
+      },
+      currentAlias: ''
     }
   },
   methods: {
     reset () {
       this.currentAlias = ''
-      this.aliases = []
+      this.form.aliases = []
+    },
+    update () {
+      this.$emit('input', this.form)
     },
     async addAlias () {
       try {
-        await accounts.validate({ aliases: [this.currentAlias] })
-        this.aliases.push(this.currentAlias)
+        await accounts.validate({ aliases: [this.currentAlias], mailbox: this.form.mailbox })
+        this.form.aliases.push(this.currentAlias)
         this.$refs.aliasField.reset()
       } catch (error) {
         let errorMsg = null
@@ -62,15 +68,20 @@ export default {
       }
     },
     removeAlias (index) {
-      this.aliases.splice(index, 1)
+      this.form.aliases.splice(index, 1)
       this.update()
-    },
-    update () {
-      this.$emit('input', this.aliases)
     }
   },
   mounted () {
-    this.aliases = [...this.value]
+    this.form = { ...this.value }
+  },
+  watch: {
+    value: {
+      handler (newValue) {
+        this.form = { ...newValue }
+      },
+      deep: true
+    }
   }
 }
 </script>

--- a/frontend/src/components/identities/AccountCreationForm.vue
+++ b/frontend/src/components/identities/AccountCreationForm.vue
@@ -20,7 +20,7 @@
     <account-mailbox-form :ref="`form_${step}`" v-model="account" />
   </template>
   <template v-slot:form.aliases="{ step }">
-    <account-alias-form v-if="step >= 4" :ref="`form_${step}`" v-model="account.aliases" />
+    <account-alias-form v-if="step >= 4" :ref="`form_${step}`" v-model="account" />
   </template>
   <template v-slot:item.random_password="{ item }">
     <template v-if="item.value">

--- a/frontend/src/components/identities/AccountForm.vue
+++ b/frontend/src/components/identities/AccountForm.vue
@@ -103,6 +103,37 @@
         <account-mailbox-form ref="mailboxForm" v-model="editedAccount" />
       </v-expansion-panel-content>
     </v-expansion-panel>
+    <v-expansion-panel v-if="usernameIsEmail">
+      <v-expansion-panel-header v-slot="{ open }">
+        <v-row no-gutters>
+          <v-col cols="4">
+            <translate>Alias</translate>
+          </v-col>
+          <v-col
+            cols="8"
+            class="text--secondary"
+            >
+            <v-fade-transition leave-absolute>
+              <span v-if="open"></span>
+              <v-row
+                v-else
+                no-gutters
+                style="width: 100%"
+                >
+                <template v-if="account.aliases">
+                  <v-col cols="6">
+                    <translate class="mr-2">Aliases: </translate> <translate>Number of associated alias: </translate> {{ account.aliases.length }}
+                  </v-col>
+                </template>
+              </v-row>
+            </v-fade-transition>
+          </v-col>
+        </v-row>
+      </v-expansion-panel-header>
+      <v-expansion-panel-content>
+        <account-alias-form ref="aliasForm" v-model="editedAccount" />
+      </v-expansion-panel-content>
+    </v-expansion-panel>
     <v-expansion-panel
       v-if="limitsConfig.params && limitsConfig.params.enable_admin_limits && account.role !== 'SimpleUsers' && account.role !== 'SuperAdmins'"
       >
@@ -135,6 +166,7 @@ import { bus } from '@/main'
 import accounts from '@/api/accounts'
 import AccountGeneralForm from './AccountGeneralForm'
 import AccountMailboxForm from './AccountMailboxForm'
+import AccountAliasForm from './AccountAliasForm'
 import AccountRoleForm from './AccountRoleForm'
 import ResourcesForm from '@/components/tools/ResourcesForm'
 import parameters from '@/api/parameters'
@@ -143,6 +175,7 @@ export default {
   components: {
     AccountGeneralForm,
     AccountMailboxForm,
+    AccountAliasForm,
     AccountRoleForm,
     ResourcesForm
   },

--- a/frontend/src/components/identities/AliasCreationForm.vue
+++ b/frontend/src/components/identities/AliasCreationForm.vue
@@ -101,7 +101,14 @@ export default {
       if (data.recipients.length === 0) {
         delete data.recipients
       }
-      return aliases.validate(data)
+      const validation = aliases.validate(data)
+      validation.catch(error => {
+        if (error.response.status === 409 && error.response.data.id !== undefined) {
+          bus.$emit('notification', { msg: this.$gettext('Alias already exists, redirecting to edit page'), type: 'warning' })
+          this.$router.push({ name: 'AliasEdit', params: { id: error.response.data.id } })
+        }
+      })
+      return validation
     },
     submit () {
       aliases.create(this.alias).then(resp => {

--- a/frontend/src/components/tools/ImportForm.vue
+++ b/frontend/src/components/tools/ImportForm.vue
@@ -29,13 +29,19 @@
           dense
           />
       </validation-provider>
-      <label class="m-label"><translate>Separator</translate></label>
-      <v-text-field
-        v-model="form.sepchar"
-        :error-messages="errors"
-        outlined
-        dense
-        />
+      <validation-provider
+        v-slot="{ errors }"
+        name="name"
+        rules="required"
+        >
+        <label class="m-label"><translate>Separator</translate></label>
+        <v-text-field
+          v-model="form.sepchar"
+          :error-messages="errors"
+          outlined
+          dense
+          />
+      </validation-provider>
       <v-switch
         v-model="form.continue_if_exists"
         :label="'Continue on error'|translate"

--- a/frontend/src/mixins/importExport.js
+++ b/frontend/src/mixins/importExport.js
@@ -18,6 +18,12 @@ export const importExportMixin = {
         } else {
           bus.$emit('notification', { msg: resp.data.message, type: 'error' })
         }
+      }).catch(error => {
+        console.error(error)
+        bus.$emit('notification', {
+          msg: this.$gettext('CSV seems to be badly formatted'),
+          type: 'error'
+        })
       })
     }
   }

--- a/frontend/src/mixins/importExport.js
+++ b/frontend/src/mixins/importExport.js
@@ -19,7 +19,6 @@ export const importExportMixin = {
           bus.$emit('notification', { msg: resp.data.message, type: 'error' })
         }
       }).catch(error => {
-        console.error(error)
         bus.$emit('notification', {
           msg: this.$gettext('CSV seems to be badly formatted'),
           type: 'error'

--- a/frontend/src/views/identities/Identities.vue
+++ b/frontend/src/views/identities/Identities.vue
@@ -62,7 +62,7 @@
       :title="'Import identities'|translate"
       @beforeSubmit="prepareData"
       @submit="importIdentities"
-      @close="showImportForm = false"
+      @close="closeImportForm"
       >
       <template v-slot:help>
         <ul>
@@ -124,10 +124,16 @@ export default {
       })
     },
     prepareData (data) {
-      data.append('crypt_passwords', this.form.crypt_passwords)
+      if (this.form !== undefined) {
+        data.append('crypt_passwords', this.form.crypt_passwords)
+      }
     },
     importIdentities (data) {
       this.importContent(identities, data)
+    },
+    closeImportForm () {
+      this.showImportForm = false
+      this.updateIdentities()
     }
   }
 }

--- a/frontend/src/views/identities/Identities.vue
+++ b/frontend/src/views/identities/Identities.vue
@@ -67,7 +67,7 @@
       <template v-slot:help>
         <ul>
           <li><em>account; loginname; password; first name; last name; enabled; group; address; quota; [, domain, ...]</em></li>
-          <li><em>alias; address; enabled; recipient; recipient; ...</em></li>
+          <li><em>alias; address; enabled; recipient; [more recipients; ...]</em></li>
         </ul>
       </template>
       <template v-slot:extraFields="{ form }">

--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -543,7 +543,7 @@ class WritableAccountSerializer(v1_serializers.WritableAccountSerializer):
         self.set_permissions(user, domains)
         if aliases:
             for alias in aliases:
-                models.alias.modify_or_create_alias(
+                models.Alias.objects.modify_or_create(
                     address="{}@{}".format(alias["localpart"], alias["domain"]),
                     recipients=[user.username],
                     creator=creator,
@@ -577,7 +577,7 @@ class WritableAccountSerializer(v1_serializers.WritableAccountSerializer):
             alias_recipients = instance.mailbox.alias_addresses
             for alias in aliases:
                 address = "{}@{}".format(alias["localpart"], alias["domain"])
-                models.alias.modify_or_create_alias(
+                models.Alias.objects.modify_or_create(
                     address=address,
                     recipients=[validated_data["username"]],
                     creator=creator,

--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -582,7 +582,7 @@ class WritableAccountSerializer(v1_serializers.WritableAccountSerializer):
                     recipients=[validated_data["username"]],
                     creator=creator,
                     domain=alias["domain"]
-                    )
+                )
                 try:
                     alias_recipients.remove(address)
                 except ValueError:
@@ -591,8 +591,9 @@ class WritableAccountSerializer(v1_serializers.WritableAccountSerializer):
                 alias = models.Alias.objects.filter(
                     address=alias_address, internal=False)
                 if alias.exists():
-                    alias.first().remove_recipient_from_alias(
-                        validated_data["username"])
+                    alias.first().remove_recipient_or_delete(
+                        validated_data["username"]
+                    )
         instance.save()
         resources = validated_data.get("resources")
         if resources:

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -458,7 +458,10 @@ class AliasViewSetTestCase(ModoAPITestCase):
 
         data = {"address": "alias@test.com"}
         resp = self.client.post(url, data, format="json")
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 409)
+
+        al_id = models.Alias.objects.get(address="alias@test.com").pk
+        self.assertEqual(resp.json()["id"], al_id)
 
         data = {"address": "alias2@test.com"}
         resp = self.client.post(url, data, format="json")

--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -166,15 +166,15 @@ def _import_alias(user, row, **kwargs):
 
 
 def import_alias(user, row, formopts):
-    _import_alias(user, row, expected_elements=4)
+    _import_alias(user, row, expected_elements=4, formopts=formopts)
 
 
 def import_forward(user, row, formopts):
-    _import_alias(user, row, expected_elements=4)
+    _import_alias(user, row, expected_elements=4, formopts=formopts)
 
 
 def import_dlist(user, row, formopts):
-    _import_alias(user, row)
+    _import_alias(user, row, formopts=formopts)
 
 
 def get_dns_resolver():

--- a/modoboa/admin/management/commands/subcommands/_import.py
+++ b/modoboa/admin/management/commands/subcommands/_import.py
@@ -61,16 +61,9 @@ class ImportCommand(BaseCommand):
             for row in reader:
                 if not row:
                     continue
-                try:
-                    fct = signals.import_object.send(
-                        sender=self.__class__, objtype=row[0].strip())
-                    fct = [func for x_, func in fct if func is not None]
-                except ValidationError as e:
-                    raise CommandError(
-                        _("It seems that your CSV is badly formatted at row: ") +
-                        options["sepchar"].join(row) +
-                        _(f"Details: {e.message}")
-                        )
+                fct = signals.import_object.send(
+                    sender=self.__class__, objtype=row[0].strip())
+                fct = [func for x_, func in fct if func is not None]
                 if not fct:
                     continue
                 fct = fct[0]

--- a/modoboa/admin/management/commands/subcommands/_import.py
+++ b/modoboa/admin/management/commands/subcommands/_import.py
@@ -79,8 +79,8 @@ class ImportCommand(BaseCommand):
                     if options["continue_if_exists"]:
                         continue
                     raise CommandError(
-                        "Object already exists: {}".format(
-                            options["sepchar"].join(row[:2])))
+                        "Object already exists at line {}: {}".format(
+                            i+1, options["sepchar"].join(row[:2])))
                 i += 1
                 pbar.update(i)
 

--- a/modoboa/admin/management/commands/subcommands/_import.py
+++ b/modoboa/admin/management/commands/subcommands/_import.py
@@ -68,7 +68,8 @@ class ImportCommand(BaseCommand):
                 except ValidationError as e:
                     raise CommandError(
                         _("It seems that your CSV is badly formatted at row: ") +
-                        options["sepchar"].join(row)
+                        options["sepchar"].join(row) +
+                        _(f"Details: {e.message}")
                         )
                 if not fct:
                     continue

--- a/modoboa/admin/models/__init__.py
+++ b/modoboa/admin/models/__init__.py
@@ -1,7 +1,8 @@
 """Admin models."""
 
 from .alarm import Alarm
-from .alias import Alias, AliasRecipient, validate_alias_address
+from .alias import (
+    Alias, AliasRecipient, validate_alias_address, modify_or_create_alias)
 from .base import AdminObject
 from .domain import Domain
 from .domain_alias import DomainAlias
@@ -22,4 +23,5 @@ __all__ = [
     "Quota",
     "SenderAddress",
     "validate_alias_address",
+    "modify_or_create_alias",
 ]

--- a/modoboa/admin/models/__init__.py
+++ b/modoboa/admin/models/__init__.py
@@ -2,7 +2,11 @@
 
 from .alarm import Alarm
 from .alias import (
-    Alias, AliasRecipient, validate_alias_address, modify_or_create_alias)
+    Alias,
+    AliasRecipient,
+    validate_alias_address,
+    modify_or_create_alias,
+    remove_recipient_from_alias)
 from .base import AdminObject
 from .domain import Domain
 from .domain_alias import DomainAlias
@@ -24,4 +28,5 @@ __all__ = [
     "SenderAddress",
     "validate_alias_address",
     "modify_or_create_alias",
+    "remove_recipient_from_alias",
 ]

--- a/modoboa/admin/models/__init__.py
+++ b/modoboa/admin/models/__init__.py
@@ -4,9 +4,7 @@ from .alarm import Alarm
 from .alias import (
     Alias,
     AliasRecipient,
-    validate_alias_address,
-    modify_or_create_alias,
-    remove_recipient_from_alias)
+    validate_alias_address)
 from .base import AdminObject
 from .domain import Domain
 from .domain_alias import DomainAlias
@@ -27,6 +25,4 @@ __all__ = [
     "Quota",
     "SenderAddress",
     "validate_alias_address",
-    "modify_or_create_alias",
-    "remove_recipient_from_alias",
 ]

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -56,39 +56,6 @@ def validate_alias_address(
     return local_part, domain
 
 
-def modify_or_create_alias(address, recipients, creator, domain):
-    """Add recipient if the alias already exists or create it."""
-
-    alias = Alias.objects.filter(address=address, internal=False)
-    if alias.exists():
-        alias.first().add_recipients(recipients)
-    else:
-        Alias.objects.create(
-                creator=creator,
-                domain=domain,
-                address=address,
-                recipients=recipients
-                )
-
-
-def remove_recipient_from_alias(address, recipient_to_delete):
-    """Delete the selected recipient from an alias
-    or delete the whole alias if only one is left."""
-    alias = Alias.objects.filter(
-       address=address, internal=False)
-    if alias.exists():
-        alias_recipients = list(alias.first().recipients)
-        if recipient_to_delete in alias_recipients:
-            if len(alias_recipients) == 1:
-                # Only recipient, we delete the AliasExists
-                alias.delete()
-            else:
-                alias_recipients.remove(recipient_to_delete)
-                alias = alias.first()
-                alias.set_recipients(alias_recipients)
-                alias.save()
-
-
 class AliasManager(models.Manager):
     """Custom manager for Alias."""
 
@@ -102,6 +69,20 @@ class AliasManager(models.Manager):
         if recipients:
             alias.set_recipients(recipients)
         return alias
+
+    def modify_or_create_alias(self, address, recipients, creator, domain):
+        """Add recipient if the alias already exists or create it."""
+
+        alias = Alias.objects.filter(address=address, internal=False)
+        if alias.exists():
+            alias.first().add_recipients(recipients)
+        else:
+            self.create(
+                    creator=creator,
+                    domain=domain,
+                    address=address,
+                    recipients=recipients
+                    )
 
 
 class Alias(AdminObject):
@@ -226,6 +207,19 @@ class Alias(AdminObject):
                 else:
                     kwargs["r_mailbox"] = rcpt
             AliasRecipient(**kwargs).save()
+
+    def remove_recipient_from_alias(self, recipient_to_delete):
+        """Delete the selected recipient from an alias
+        or delete the whole alias if only one is left."""
+        alias_recipients = list(self.recipients)
+        if recipient_to_delete in alias_recipients:
+            if len(alias_recipients) == 1:
+                # Only recipient, we delete the AliasExists
+                self.delete()
+            else:
+                alias_recipients.remove(recipient_to_delete)
+                self.set_recipients(alias_recipients)
+                self.save()
 
     def set_recipients(self, address_list):
         """Set recipients for this alias."""

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -56,7 +56,7 @@ def validate_alias_address(
     return local_part, domain
 
 
-def modify_or_create_alias(address, recipients, creator=None, domain=None):
+def modify_or_create_alias(address, recipients, creator, domain):
     """Add recipient if the alias already exists or create it."""
 
     alias = Alias.objects.filter(address=address, internal=False)
@@ -69,6 +69,24 @@ def modify_or_create_alias(address, recipients, creator=None, domain=None):
                 address=address,
                 recipients=recipients
                 )
+
+
+def remove_recipient_from_alias(address, recipient_to_delete):
+    """Delete the selected recipient from an alias
+    or delete the whole alias if only one is left."""
+    alias = Alias.objects.filter(
+       address=address, internal=False)
+    if alias.exists():
+        alias_recipients = list(alias.first().recipients)
+        if recipient_to_delete in alias_recipients:
+            if len(alias_recipients) == 1:
+                # Only recipient, we delete the AliasExists
+                alias.delete()
+            else:
+                alias_recipients.remove(recipient_to_delete)
+                alias = alias.first()
+                alias.set_recipients(alias_recipients)
+                alias.save()
 
 
 class AliasManager(models.Manager):

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -62,7 +62,7 @@ def modify_or_create_alias(address, recipients, creator, domain):
     alias = Alias.objects.filter(address=address, internal=False)
     if alias.exists():
         alias.first().add_recipients(recipients)
-    elif creator is not None and domain is not None:
+    else:
         Alias.objects.create(
                 creator=creator,
                 domain=domain,

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -70,7 +70,7 @@ class AliasManager(models.Manager):
             alias.set_recipients(recipients)
         return alias
 
-    def modify_or_create_alias(self, address, recipients, creator, domain):
+    def modify_or_create(self, address, recipients, creator, domain):
         """Add recipient if the alias already exists or create it."""
 
         alias = Alias.objects.filter(address=address, internal=False)

--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -16,7 +16,7 @@ from reversion import revisions as reversion
 from modoboa.core import signals as core_signals
 from modoboa.lib.email_utils import split_mailbox
 from modoboa.lib.exceptions import (
-    BadRequest, Conflict, NotFound, ModoboaException
+    BadRequest, Conflict, NotFound, ModoboaException, AliasExists
 )
 from .. import signals
 from .base import AdminObject
@@ -24,7 +24,9 @@ from .domain import Domain
 from .mailbox import Mailbox
 
 
-def validate_alias_address(address, creator, internal=False, instance=None):
+def validate_alias_address(
+        address, creator, internal=False, instance=None, ignore_existing=False
+        ):
     """Check if the given alias address can be created by creator."""
     local_part, domain = split_mailbox(address)
     domain = Domain.objects.filter(name=domain).first()
@@ -33,8 +35,13 @@ def validate_alias_address(address, creator, internal=False, instance=None):
     if not creator.can_access(domain):
         raise ValidationError(_("Permission denied."))
     if not instance or instance.address != address:
-        if Alias.objects.filter(address=address, internal=internal).exists():
-            raise ValidationError(_("An alias with this name already exists."))
+        alias = Alias.objects.filter(address=address, internal=internal)
+        condition = (
+            alias.exists()
+            and not ignore_existing
+            )
+        if condition:
+            raise AliasExists(alias.first().pk)
     if instance is None:
         try:
             # Check creator limits
@@ -47,6 +54,21 @@ def validate_alias_address(address, creator, internal=False, instance=None):
         except ModoboaException as inst:
             raise ValidationError(str(inst))
     return local_part, domain
+
+
+def modify_or_create_alias(address, recipients, creator=None, domain=None):
+    """Add recipient if the alias already exists or create it."""
+
+    alias = Alias.objects.filter(address=address, internal=False)
+    if alias.exists():
+        alias.first().add_recipients(recipients)
+    elif creator is not None and domain is not None:
+        Alias.objects.create(
+                creator=creator,
+                domain=domain,
+                address=address,
+                recipients=recipients
+                )
 
 
 class AliasManager(models.Manager):
@@ -209,12 +231,33 @@ class Alias(AdminObject):
         """Return the number of recipients of this alias."""
         return self.aliasrecipient_set.count()
 
-    def from_csv(self, user, row, expected_elements=5):
+    def from_csv(self,
+                 user,
+                 row,
+                 expected_elements=5,
+                 formopts=False,
+                 **kwargs):
         """Create a new alias from a CSV file entry."""
         if len(row) < expected_elements:
             raise BadRequest(_("Invalid line: {}").format(row))
         self.address = row[1].strip().lower()
-        local_part, self.domain = validate_alias_address(self.address, user)
+        try:
+            local_part, self.domain = validate_alias_address(self.address, user)
+        except AliasExists as e:
+            # If continue_if_exists is true, we simply update the alias
+            # Else we throw the conflict issue
+            continue_if_exists = False
+            if formopts:
+                continue_if_exists = formopts.get("continue_if_exists", False)
+            if continue_if_exists:
+                alias = Alias.objects.filter(address=self.address,
+                                             internal=False).first()
+                alias.add_recipients([raddress.strip() for raddress in row[3:]])
+                alias.save()
+                return
+            else:
+                raise e
+
         self.enabled = (row[2].strip().lower() in ["true", "1", "yes", "y"])
         self.save()
         self.set_recipients([raddress.strip() for raddress in row[3:]])

--- a/modoboa/admin/tests/test_data/import_aliases.csv
+++ b/modoboa/admin/tests/test_data/import_aliases.csv
@@ -1,1 +1,2 @@
+
 alias; alias1@test.com; True; truc@test.com

--- a/modoboa/admin/tests/test_data/import_aliases.csv
+++ b/modoboa/admin/tests/test_data/import_aliases.csv
@@ -1,0 +1,1 @@
+alias; alias1@test.com; True; truc@test.com

--- a/modoboa/core/commands/templates/urls.py.tpl
+++ b/modoboa/core/commands/templates/urls.py.tpl
@@ -1,4 +1,4 @@
-from django.conf.urls import include, path
+from django.urls import include, path
 
 urlpatterns = [
     path(r'', include('modoboa.urls')),

--- a/modoboa/core/extensions.py
+++ b/modoboa/core/extensions.py
@@ -1,7 +1,7 @@
 """Extension management."""
 
 from django.conf import settings
-from django.conf.urls import include
+from django.urls import include
 from django.urls import re_path
 from django.utils.encoding import smart_str
 

--- a/modoboa/lib/exceptions.py
+++ b/modoboa/lib/exceptions.py
@@ -52,6 +52,16 @@ class Conflict(ModoboaException):
     http_code = 409
 
 
+class AliasExists(Conflict):
+    """
+    Use this exception to indicate that the requested alias already exists
+    and that it should be updated instead of created.
+    """
+
+    def __init__(self, alias_id):
+        self.alias_id = alias_id
+
+
 class PermDeniedException(ModoboaException):
     """
     Use this exception when a user tries to do something he is not


### PR DESCRIPTION
- Fix Admin not able to add alias with the user creation wizard
- Changed behavior of aliases creation in general : trying to create an already existing alias will simply add the recipient to the existing one silently
- Using continue-if-exists option on alias import from csv will now modify the alias instead of throwing an error (because of bad formatting). Without the option, the error will be thrown
- Improved error message regarding alias creation/modification/importation
- Trying to create an already existing alias on new admin will automatically redirect to the edit page of said alias