### PR TITLE
to avoid CSRF error due to multiple click

### DIFF
--- a/modoboa/templates/registration/login.html
+++ b/modoboa/templates/registration/login.html
@@ -40,6 +40,9 @@
 {% block extra_js %}
   <script type="text/javascript">
    $(document).ready(function() {
+       $("form").submit(function(){  
+           $(":submit",this).attr("disabled","disabled");  
+       });
        $('#id_username').focus();
    });
   </script>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If the network is terrible, the user clicks rapidly and many times, it will show a CSRF error because the last time click had the wrong CSRF token.

Current behavior before PR:
You can click the login button multiple times in the login page to submit multiple times to the login api.

Desired behavior after PR is merged:
after you click one time, the submit button be disabled. after the current request has been processed, you can click again.
