### PR TITLE
Documenting use of Redis socket and fixing configuration

### DIFF
--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -766,7 +766,7 @@ Add the following settings to your ``settings.py`` file:
    REDIS_QUOTA_DB = 0
    REDIS_URL = 'redis://{}:{}/{}'.format(REDIS_HOST, REDIS_PORT, REDIS_QUOTA_DB)
 
-Or, if Redis listen on unix socket:
+Or, if Redis listen on unix socket and you are not using the Modoboa installer:
 
 .. sourcecode:: python
 

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -766,6 +766,15 @@ Add the following settings to your ``settings.py`` file:
    REDIS_QUOTA_DB = 0
    REDIS_URL = 'redis://{}:{}/{}'.format(REDIS_HOST, REDIS_PORT, REDIS_QUOTA_DB)
 
+Or, if Redis listen on unix socket:
+
+.. sourcecode:: python
+
+   REDIS_HOST = '/path/to/redis/socket'
+   REDIS_PORT = 6379
+   REDIS_QUOTA_DB = 0
+   REDIS_URL = 'unix://{}?db={}'.format(REDIS_HOST, REDIS_QUOTA_DB)
+
 Once done, you can start the policy daemon using the following commands:
 
 .. sourcecode:: bash

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -253,6 +253,9 @@ REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 REDIS_QUOTA_DB = 0
 REDIS_URL = 'redis://{}:{}/{}'.format(REDIS_HOST, REDIS_PORT, REDIS_QUOTA_DB)
+# To use unix socket, use this scheme instead
+# REDIS_HOST must point to the socket path
+# REDIS_URL = 'unix://{}?db={}'.format(REDIS_HOST, REDIS_QUOTA_DB)
 
 # RQ
 
@@ -260,12 +263,14 @@ RQ_QUEUES = {
     'dkim': {
         'HOST': REDIS_HOST,
         'PORT': REDIS_PORT,
-        'DB': 0,
+        'DB': REDIS_QUOTA_DB,
+        'URL': REDIS_URL,
     },
     'modoboa': {
         'HOST': REDIS_HOST,
         'PORT': REDIS_PORT,
-        'DB': 0,
+        'DB': REDIS_QUOTA_DB,
+        'URL': REDIS_URL,
     },
 }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes #3241.

Current behavior before PR:
Can't get Modoboa working with Redis socket.

Desired behavior after PR is merged:
Using Redis socket is fixed in `settings.py` and documented.