### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/contributing/getting_started.rst
+++ b/doc/contributing/getting_started.rst
@@ -14,8 +14,8 @@ install `docker <https://docs.docker.com/install/>`_ and
 
 If not already done, clone the repo and open it::
 
-$ git clone https://github.com/modoboa/modoboa.git
-$ cd modoboa
+  $ git clone https://github.com/modoboa/modoboa.git
+  $ cd modoboa
 
 Then, just run the following command::
 

--- a/doc/contributing/getting_started.rst
+++ b/doc/contributing/getting_started.rst
@@ -12,6 +12,11 @@ A docker image is available for developers. To use it, you must
 install `docker <https://docs.docker.com/install/>`_ and
 `docker-compose <https://docs.docker.com/compose/install/>`_ first.
 
+If not already done, clone the repo and open it::
+
+$ git clone https://github.com/modoboa/modoboa.git
+$ cd modoboa
+
 Then, just run the following command::
 
   $ docker-compose up


### PR DESCRIPTION
In the "With Docker" section, add missing commands for optional cloning of repo before launching docker-compose command.
