### PR TITLE
Fix to logparser.py for timezones with a negative time offset.

### DIFF
--- a/modoboa/maillog/management/commands/logparser.py
+++ b/modoboa/maillog/management/commands/logparser.py
@@ -82,6 +82,7 @@ class LogParser:
         self._date_expressions = [
             r"(?P<month>\w+)\s+(?P<day>\d+)\s+(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+)(?P<eol>.*)",  # noqa
             r"(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)T(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+)\.\d+\+\d+:\d+(?P<eol>.*)",  # noqa
+            r"(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)T(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+)\.\d+\-\d+:\d+(?P<eol>.*)",  # noqa
         ]
         self._date_expressions = [re.compile(v) for v in self._date_expressions]
         self.date_expr = None


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fix to logparser.py for timezones with a negative time offset.

Current behavior before PR: Negative timezone offsets in the logs are not correctly parsed.

Desired behavior after PR is merged: Negative timezone offsets are correctly parsed.
