### PR TITLE
Add YesorNo Field option for a special char in random password generation, also make sure that special char always present if intended

### DIFF
--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -325,16 +325,13 @@ def make_password():
         for possible_chars in possible_chars_types:
             all_possible_chars += possible_chars
             certain_chars += random.SystemRandom().choice(possible_chars)
-        
         password = "".join(
             random.SystemRandom().choice(all_possible_chars) \
                 for _ in range(length - len(possible_chars_types))
         ) + certain_chars
-        
         li_password = list(password)
         random.shuffle(li_password)
         password = "".join(li_password)
-        
         try:
             password_validation.validate_password(password)
         except ValidationError:

--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -314,13 +314,27 @@ def make_password():
     """Create a random password."""
     length = int(param_tools.get_global_parameter("random_password_length", app="core"))
     allow_special_characters = bool(param_tools.get_global_parameter("allow_special_characters", app="core"))
-    possible_chars = string.ascii_letters + string.digits
+    possible_chars_types = [string.ascii_letters, string.digits]
+    all_possible_chars = ''
+    certain_chars = ''
     for i in range(10): # limit tries
         if allow_special_characters: # add special characters in random passwd
-            possible_chars += string.punctuation
+            possible_chars_types.append(string.punctuation)
+        # make it so there is always one character of each type in password
+        # and then will randomize their placement
+        for possible_chars in possible_chars_types:
+            all_possible_chars += possible_chars
+            certain_chars += random.SystemRandom().choice(possible_chars)
+        
         password = "".join(
-            random.SystemRandom().choice(possible_chars) for _ in range(length)
-        )
+            random.SystemRandom().choice(all_possible_chars) \
+                for _ in range(length - len(possible_chars_types))
+        ) + certain_chars
+        
+        li_password = list(password)
+        random.shuffle(li_password)
+        password = "".join(li_password)
+        
         try:
             password_validation.validate_password(password)
         except ValidationError:

--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -313,10 +313,13 @@ def domain_has_authorized_mx(name):
 def make_password():
     """Create a random password."""
     length = int(param_tools.get_global_parameter("random_password_length", app="core"))
-    while True:
+    allow_special_characters = bool(param_tools.get_global_parameter("allow_special_characters", app="core"))
+    possible_chars = string.ascii_letters + string.digits
+    for i in range(10): # limit tries
+        if allow_special_characters: # add special characters in random passwd
+            possible_chars += string.punctuation
         password = "".join(
-            random.SystemRandom().choice(string.ascii_letters + string.digits)
-            for _ in range(length)
+            random.SystemRandom().choice(possible_chars) for _ in range(length)
         )
         try:
             password_validation.validate_password(password)

--- a/modoboa/admin/tests/test_account.py
+++ b/modoboa/admin/tests/test_account.py
@@ -346,6 +346,10 @@ class AccountTestCase(ModoTestCase):
             "email": "tester@test.com",
             "stepid": "step2",
         }
+        # TODO: add test to check if unhashed password created with 
+        # make_password() from modoboa\modoboa\admin\lib.py has at least one
+        # letter, one digit(and one special character if option chosen by user) 
+
         self.ajax_post(reverse("admin:account_add"), values)
 
         account = User.objects.get(username=values["username"])

--- a/modoboa/core/api/v2/serializers.py
+++ b/modoboa/core/api/v2/serializers.py
@@ -74,6 +74,7 @@ class CoreGlobalParametersSerializer(serializers.Serializer):
     update_scheme = serializers.BooleanField(default=True)
     default_password = serializers.CharField(default="ChangeMe1!")
     random_password_length = serializers.IntegerField(min_value=8, default=8)
+    allow_special_characters = serializers.BooleanField(default=False)
     update_password_url = serializers.URLField(required=False, allow_blank=True)
     password_recovery_msg = serializers.CharField(required=False, allow_blank=True)
     sms_password_recovery = serializers.BooleanField(default=False)

--- a/modoboa/core/app_settings.py
+++ b/modoboa/core/app_settings.py
@@ -88,6 +88,15 @@ class GeneralParametersForm(param_forms.AdminParametersForm):
         help_text=gettext_lazy("Length of randomly generated passwords."),
     )
 
+    allow_special_characters = YesNoField(
+        label=gettext_lazy("Allow special characters for random password"),
+        initial=False,
+        help_text=gettext_lazy(
+            "Enable special characters in randomly generated "
+            "passwords."
+        ),
+    )
+
     update_password_url = forms.URLField(
         label=gettext_lazy("Update password service URL"),
         initial="",
@@ -774,6 +783,16 @@ GLOBAL_PARAMETERS_STRUCT = collections.OrderedDict(
                                     "Length of randomly generated passwords."
                                 ),
                             },
+                        ),
+                        (
+                            "allow_special_characters",
+                            {
+                                "label": gettext_lazy("Allow special characters for random password"),
+                                "help_text": gettext_lazy(
+                                    "Enable special characters in randomly generated "
+                                    "passwords."
+                                ),   
+                            }
                         ),
                         (
                             "update_password_url",


### PR DESCRIPTION
cf issue #3327 - Setting a password policy that requires "special" symbols breaks the random password generator

Before PR, if user wanted to have a special character in their randomly generated password upon user creation, they had to directely change AUTH_PASSWORD_VALIDATORS in settings.py. That behavior could lead to an infinite while loop bug with custom make_password() function in modoboa\modoboa\admin\lib.py.

After PR :

- User directly has option (with yes/no radiobutton) in its account parameters to **allow for special characters** in new randomly generated user passwords.
-  Now random password generator function make_password() always include at least one of the possible string groups **ascii_letters**, **digits** (and **punctuation**/**special characters**, if user chose so in its account parameters).
- Set a max of **10 tries** of make_password() call.