### PR TITLE
Fixed addresses test not aligned with RFC 2822

### DIFF
--- a/ldap-requirements.txt
+++ b/ldap-requirements.txt
@@ -1,1 +1,1 @@
-django-auth-ldap>=1.3.0
+django-auth-ldap<5.0.0

--- a/ldap-requirements.txt
+++ b/ldap-requirements.txt
@@ -1,1 +1,1 @@
-django-auth-ldap<5.0.0
+django-auth-ldap<5.1.0

--- a/ldap-requirements.txt
+++ b/ldap-requirements.txt
@@ -1,1 +1,1 @@
-django-auth-ldap<5.1.0
+django-auth-ldap<5.0.0

--- a/modoboa/lib/tests/test_email_utils.py
+++ b/modoboa/lib/tests/test_email_utils.py
@@ -153,7 +153,7 @@ class EmailAddressParserTests(SimpleTestCase):
         """Check a list of e-mail addresses is sepearted correctly."""
         # value is an array with one long string not 3 sepearte values.
         value = [
-            '"Doe, John" <doe.john@sub.example.com>;'
+            '"Doe, John" <doe.john@sub.example.com>,'
             '"John Smith" <john.smith@sub.example.com>,'
             "admin@sub.example.com"
         ]
@@ -169,7 +169,7 @@ class EmailAddressParserTests(SimpleTestCase):
         """Check a list of e-mail addresses is sepearted correctly."""
         # value is an array with one long string not 3 sepearte values.
         value = [
-            '"Doe, John" <doe.john@sub.example.com>;'
+            '"Doe, John" <doe.john@sub.example.com>,'
             '"John Smith" <john.smith@sub.example.com>,'
             "admin@sub.example.com"
         ]
@@ -186,7 +186,7 @@ class EmailAddressParserTests(SimpleTestCase):
         # value is one long string not 3 sepearte values, prepare_addresses
         # should convert it to a list.
         value = (
-            '"Doe, John" <doe.john@sub.example.com>;'
+            '"Doe, John" <doe.john@sub.example.com>,'
             '"John Smith" <john.smith@sub.example.com>,'
             "admin@sub.example.com"
         )


### PR DESCRIPTION
RFC 2822 [states that the separator for mailboxes is the comma](https://datatracker.ietf.org/doc/html/rfc2822#section-3.6.2) however the test tries with a semi-column. It used to work but was fixed as part of the [CVE-2023-27043](https://nvd.nist.gov/vuln/detail/CVE-2023-27043).

As far as I checked, the webmail do use the comma as a separator in the webmail...