### PR TITLE
Prevent numbers used in templates as part of JavaScript or CSS from locale-aware formatting applied if `USE_THOUSANDS_SEPARATOR` is True

### DIFF
--- a/modoboa/templates/common/buttons_list.html
+++ b/modoboa/templates/common/buttons_list.html
@@ -9,14 +9,14 @@
       {% if entry.menu %}
         {% if entry.url %}
       <a name="{{ entry.name }}" class="btn {{ entry.class }}" href="{{ entry.url }}" title="{{ entry.title }}">
-        {% if entry.img %}<span class="{{ entry.img}}"></span> {% endif %}{{ entry.label }}</a>
+        {% if entry.img %}<span class="{{ entry.img }}"></span> {% endif %}{{ entry.label }}</a>
       <button type="button" class="btn {{ entry.class }} dropdown-toggle" data-toggle="dropdown">
         <span class="caret"></span>
         <span class="sr-only">Toggle Dropdown</span>
       </button>
         {% else %}
       <button type="button" title="{{ entry.title }}" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-        {% if entry.img %}<span class="{{ entry.img}}"></span> {% endif %}{{ entry.label }}
+        {% if entry.img %}<span class="{{ entry.img }}"></span> {% endif %}{{ entry.label }}
         <span class="caret"></span>
       </button>
         {% endif %}

--- a/modoboa/templates/common/menulist.html
+++ b/modoboa/templates/common/menulist.html
@@ -8,7 +8,7 @@
     <a class="dropdown-toggle" name="{{ entry.name }}" data-toggle="dropdown" href="{{ entry.url }}">
       {% if entry.img %}<span class="{{ entry.img }}"></span> {% endif %}{{ entry.label }}
     </a>
-    <ul class="dropdown-menu" {% if entry.width %}style="width: {{ entry.width }}px"{% endif %}>
+    <ul class="dropdown-menu" {% if entry.width %}style="width: {{ entry.width | stringformat:"s" }}px"{% endif %}>
       {% for sentry in entry.menu %}
       <li>{% if sentry.method == "post" %}{% render_post_link sentry request %}{% else %}{% render_link sentry %}{% endif %}</li>
       {% endfor %}

--- a/modoboa/templates/common/progressbar.html
+++ b/modoboa/templates/common/progressbar.html
@@ -1,5 +1,5 @@
 {% load lib_tags %}
 
-<div id="{{ id }}" rel="tooltip" title="{{ value }}%" class="progress">
-  <div class="{% progress_color value %}" style="width: {{ value }}%"></div>
+<div id="{{ id }}" rel="tooltip" title="{{ value | stringformat:"s" }}%" class="progress">
+  <div class="{% progress_color value %}" style="width: {{ value | stringformat:"s" }}%"></div>
 </div>

--- a/modoboa/templates/common/wizard_forms.html
+++ b/modoboa/templates/common/wizard_forms.html
@@ -13,7 +13,7 @@
         <div id="wizard" class="carousel slide" data-ride="carousel">
           <div class="carousel-inner">
             {% for step in wizard.steps %}
-            <div id="step{{ forloop.counter }}"
+            <div id="step{{ forloop.counter | stringformat:"s" }}"
                  class="item{% if forloop.first %} active{% endif %}">
               {% if step.formtpl %}{% render_form step.form step.formtpl %}{% else %}{% render_form step.form %}{% endif %}
             </div>
@@ -26,7 +26,7 @@
       <div class="buttons_list">
         <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
         {% for step in wizard.steps %}
-        <div id="step{{ forloop.counter }}_buttons" 
+        <div id="step{{ forloop.counter | stringformat:"s" }}_buttons" 
              class="bset{% if forloop.first %} active{% endif %}">
           {% if step.prev %}<a href="#" class="btn btn-primary prev">{% trans "Previous" %}</a>{% endif %}
           {% if step.next %}<a href="#" class="btn btn-primary next">{% trans "Next" %}</a>{% else %}<a href="#" class="btn btn-primary submit">{{ wizard.submit_button_label }}</a>{% endif %}

--- a/modoboa/templates/nlayout.html
+++ b/modoboa/templates/nlayout.html
@@ -95,7 +95,7 @@
       $(document).ready(function() {
           top_notifications = new TopNotifications({
               url: "{% url 'core:top_notifications_check' %}",
-              interval: {{ notifications_check_interval }}
+              interval: {{ notifications_check_interval | stringformat:"s" }}
           });
       });
     </script>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently setting `USE_THOUSANDS_SEPARATOR = True` in “settings.py” causes the calendar view of modoboa-radicale to break since it expects the global `userLang` value to be set, but the block containing this value fails to parse as valid JavaScript due to a local-aware number being inserted:

```javascript
      var root_url = "/".replace(/\/$/, "");
      var top_notifications;
      var userLang = "de";

      set_static_url("/sitestatic/");
      $(document).ready(function() {
          top_notifications = new TopNotifications({
              url: "/core/top_notifications/check/",
              interval: 30'000  // ← Doesn’t parse!
          });
      });
```

I tried to review and fix all other templates that seem to be affected (only inline CSS rules that wouldn’t cause any major breakage if the failed to parse), but there might be omissions…

Current behavior before PR:
Setting `USE_THOUSANDS_SEPARATOR = True` in “settings.py” caused subtle breakage and the modoboa-radicale view to not render.

Desired behavior after PR is merged:
That issue no longer applies.