### PR TITLE
Support running local tests using `tox` without running Redis instance, installed LDAP dependencies and network access

### DIFF
--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 from django.core.files.base import ContentFile
+from django.test import tag
 from django.urls import reverse
 from django.utils.encoding import force_str
 
@@ -729,6 +730,7 @@ class AccountViewSetTestCase(ModoAPITestCase):
             .exists()
         )
 
+    @tag("redis")
     def test_mailbox_options_update(self):
         account = core_models.User.objects.get(username="user@test.com")
         url = reverse("v2:account-detail", args=[account.pk])

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 from django.core.files.base import ContentFile
+from django.test import tag
 from django.urls import reverse
 from django.utils.encoding import force_str
 
@@ -718,6 +719,7 @@ class AccountViewSetTestCase(ModoAPITestCase):
             .exists()
         )
 
+    @tag("redis")
     def test_mailbox_options_update(self):
         account = core_models.User.objects.get(username="user@test.com")
         url = reverse("v2:account-detail", args=[account.pk])

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -9,6 +9,7 @@ from rq import SimpleWorker
 from testfixtures import compare
 
 from django.core.management import call_command
+from django.test import tag
 from django.urls import reverse
 
 import django_rq
@@ -96,6 +97,7 @@ class DomainTestCase(ModoAPITestCase):
         self.assertEqual(domain.identities_count, 5)
 
 
+@tag("redis")
 class DKIMTestCase(ModoAPITestCase):
     """Test case for DKIM."""
 

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -10,6 +10,7 @@ from rq import SimpleWorker
 from testfixtures import compare
 
 from django.core.management import call_command
+from django.test import tag
 from django.urls import reverse
 
 import django_rq
@@ -98,6 +99,7 @@ class DomainTestCase(ModoAPITestCase):
         self.assertEqual(domain.identities_count, 5)
 
 
+@tag("redis")
 class DKIMTestCase(ModoAPITestCase):
     """Test case for DKIM."""
 

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -8,7 +8,7 @@ from rq import SimpleWorker
 from testfixtures import LogCapture
 
 from django.core import mail
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.utils.translation import gettext as _
 
 import django_rq
@@ -219,6 +219,7 @@ class DNSBLTestCase(ModoTestCase):
         )
         models.DNSBLResult.objects.all().delete()
 
+    @tag("redis")
     @mock.patch("socket.gethostbyname")
     @mock.patch("socket.getaddrinfo")
     @mock.patch.object(dns.resolver.Resolver, "resolve")

--- a/modoboa/admin/tests/test_need_dovecot_update.py
+++ b/modoboa/admin/tests/test_need_dovecot_update.py
@@ -2,11 +2,12 @@
 
 import os
 import shutil
+from unittest import skipIf
 
 from django.core.management import call_command
 from django.urls import reverse
 
-from modoboa.lib.tests import ModoAPITestCase, SETTINGS_SAMPLE
+from modoboa.lib.tests import NO_LDAP, ModoAPITestCase, SETTINGS_SAMPLE
 from .. import factories
 
 
@@ -37,6 +38,7 @@ class NeedDovecotUpdateTestCase(ModoAPITestCase):
         self.localconfig.refresh_from_db()
         self.assertTrue(self.localconfig.need_dovecot_update)
 
+    @skipIf(NO_LDAP, "No ldap module installed")
     def test_update_dovecot_ldap_conf(self):
         self.localconfig.need_dovecot_update = True
         self.localconfig.save()

--- a/modoboa/amavis/tests/test_viewsets.py
+++ b/modoboa/amavis/tests/test_viewsets.py
@@ -4,7 +4,7 @@ from unittest import mock
 from rq import SimpleWorker
 
 from django.core import mail
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 
 import django_rq
@@ -374,6 +374,7 @@ class QuarantineViewSetTestCase(TestDataMixin, ModoAPITestCase):
         self.msgrcpt.refresh_from_db()
         self.assertEqual(self.msgrcpt.rs, status)
 
+    @tag("redis")
     def test_mark_as_ham(self):
         """Test mark_as_ham view."""
         self._test_mark_selection("ham", "H")
@@ -400,10 +401,12 @@ class QuarantineViewSetTestCase(TestDataMixin, ModoAPITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 204)
 
+    @tag("redis")
     def test_mark_as_spam(self):
         """Test mark_as_spam view."""
         self._test_mark_selection("spam", "S")
 
+    @tag("redis")
     def test_manual_learning_as_user(self):
         """Test learning when connected as a simple user."""
         user = core_models.User.objects.get(username="user@test.com")

--- a/modoboa/contacts/tests.py
+++ b/modoboa/contacts/tests.py
@@ -6,7 +6,7 @@ import httmock
 from rq import SimpleWorker
 
 from django.core import management
-from django.test import TestCase
+from django.test import tag, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -133,6 +133,7 @@ class AddressBookViewSetTestCase(TestDataMixin, ModoAPITestCase):
         contact = abook.contact_set.first()
         self.assertIsNot(contact.etag, None)
 
+    @tag("redis")
     def test_sync_from_cdav(self):
         """Test sync from CardDAV endpoint."""
         data = {"username": self.user.username, "password": "toto"}

--- a/modoboa/core/api/v2/tests.py
+++ b/modoboa/core/api/v2/tests.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 
 from modoboa.admin import (
@@ -543,6 +543,7 @@ class NewsFeedAPIViewTestCase(ModoAPITestCase):
         super().setUpTestData()
         factories.populate_database()
 
+    @tag("network")
     def test_get(self):
         url = reverse("v2:news-feed")
         response = self.client.get(url)
@@ -556,6 +557,7 @@ class NewsFeedAPIViewTestCase(ModoAPITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 0)
 
+    @tag("network")
     def test_custom_rss_feed(self):
         self.set_global_parameter(
             "rss_feed_url", "https://www.djangoproject.com/rss/weblog/"

--- a/modoboa/core/api/v2/tests.py
+++ b/modoboa/core/api/v2/tests.py
@@ -13,7 +13,7 @@ from PIL import Image
 from django.core import mail
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
@@ -876,6 +876,7 @@ class NewsFeedAPIViewTestCase(ModoAPITestCase):
         super().setUpTestData()
         factories.populate_database()
 
+    @tag("network")
     def test_get(self):
         url = reverse("v2:news-feed")
         response = self.client.get(url)
@@ -889,6 +890,7 @@ class NewsFeedAPIViewTestCase(ModoAPITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 0)
 
+    @tag("network")
     def test_custom_rss_feed(self):
         self.set_global_parameter(
             "rss_feed_url", "https://www.djangoproject.com/rss/weblog/"

--- a/modoboa/policyd/tests.py
+++ b/modoboa/policyd/tests.py
@@ -13,7 +13,7 @@ import time
 
 from django import db
 from django.core.management import call_command
-from django.test import TransactionTestCase
+from django.test import tag, TransactionTestCase
 
 from modoboa.admin import factories as admin_factories
 from modoboa.admin import models as admin_models
@@ -121,6 +121,7 @@ class SocketActivationTestCase(TransactionTestCase):
 			process.join()
 
 
+@tag("redis")
 class PolicyDaemonTestCase(RedisTestCaseMixin, ParametersMixin, TransactionTestCase):
     """Test cases for policy daemon.
 
@@ -297,6 +298,7 @@ sasl_username=user@test.com
         self.assertEqual(self.rclient.hget(constants.REDIS_HASHNAME, account.email), 10)
 
 
+@tag("redis")
 class ModelsTestCase(RedisTestCaseMixin, ModoAPITestCase):
     """Admin models test cases."""
 

--- a/modoboa/rspamd/tests.py
+++ b/modoboa/rspamd/tests.py
@@ -4,7 +4,7 @@ import shutil
 from rq import SimpleWorker
 from testfixtures import LogCapture
 
-from django.test import modify_settings
+from django.test import modify_settings, tag
 from django.urls import reverse
 
 import django_rq
@@ -82,6 +82,7 @@ class ManagementCommandTestCase(ModoAPITestCase):
             content = fp.read()
         self.assertNotIn(domain.name, content)
 
+    @tag("redis")
     def test_signal_handler(self):
         self.set_global_parameter("dkim_keys_storage_dir", self.workdir, app="admin")
         self.configure()

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from rq import SimpleWorker
 
 from django.core import mail
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -315,6 +315,7 @@ class UserEmailViewSetTestCase(WebmailTestCase):
         )
 
 
+@tag("redis")
 class ComposeSessionViewSetTestCase(WebmailTestCase):
 
     def _create_compose_session(self):

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from rq import SimpleWorker
 
 from django.core import mail
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -393,6 +393,7 @@ class UserEmailViewSetTestCase(WebmailTestCase):
         )
 
 
+@tag("redis")
 class ComposeSessionViewSetTestCase(WebmailTestCase):
 
     def _create_compose_session(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Support running local tests using `tox` without running Redis instance, installed LDAP dependencies and network access.

Current behavior before PR:
Running `tox` without a local Redis instance, installed LDAP dependencies or network access fails.

Desired behavior after PR is merged:
Most tests still pass, tests that actually depend on these features are skipped.

UPDATE: Commits are now split to for each logical change made.