### PR TITLE
Use `redis.from_url`, rather than the seperate fields in Modoboa policyd

### DIFF
--- a/modoboa/policyd/utils.py
+++ b/modoboa/policyd/utils.py
@@ -10,11 +10,7 @@ from . import constants
 def get_redis_connection():
     """Return a client connection to Redis server."""
     if not getattr(settings, "REDIS_SENTINEL", False):
-        rclient = redis.Redis(
-            host=settings.REDIS_HOST,
-            port=settings.REDIS_PORT,
-            db=settings.REDIS_QUOTA_DB,
-        )
+        rclient = redis.from_url(settings.REDIS_URL)
     else:
         sentinel = redis.sentinel.Sentinel(
             settings.REDIS_SENTINELS, socket_timeout=0.1, db=settings.REDIS_QUOTA_DB


### PR DESCRIPTION
This is the suggested way to handle all of TCP/TLS/Unix in a compact way by the redis-py project:
https://redis.readthedocs.io/en/stable/examples/connection_examples.html#Connecting-to-Redis-instances-by-specifying-a-URL-scheme.

It also makes it possible to specify extra connection agruments in a consistent way for all Redis clients used by Modoboa.

Current behavior before PR:
policyd uses separate connection arguments while everything else uses the Redis URL-

Desired behavior after PR is merged:
Redis URL is always used everywhere.