### PR TITLE
Update offline.css

### DIFF
--- a/modoboa/static/css/offline.css
+++ b/modoboa/static/css/offline.css
@@ -72,7 +72,7 @@ h2 {
 }
 
 .input-group input {
-    width: calc(100% - 20px);
+    width: calc(100% - 22px);
     padding: 10px;
     border: 1px solid #ddd;
     border-radius: 5px;


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fixed an issue on the login page where the username and password inputs where 22px wider than the login button due to padding.

Current behavior before PR: On the login page the text inputs are 22px wider than the login button.
<img width="541" height="446" alt="image" src="https://github.com/user-attachments/assets/ee5cc593-cc2a-41b7-8064-a057610f5d55" />


Desired behavior after PR is merged: The text inputs are the same size as the button.
<img width="515" height="467" alt="image" src="https://github.com/user-attachments/assets/df858be2-6096-4a8d-8f5d-644a1dc77ea9" />
