### PR TITLE
Support dates without without high-precision part.

### DIFF
--- a/modoboa/maillog/management/commands/logparser.py
+++ b/modoboa/maillog/management/commands/logparser.py
@@ -78,6 +78,7 @@ class LogParser:
         # set up regular expression
         self._date_expressions = [
             r"(?P<month>\w+)\s+(?P<day>\d+)\s+(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+)(?P<eol>.*)",  # noqa
+            r"(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)T(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+)[\+\-]\d+:\d+(?P<eol>.*)",  # noqa
             r"(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)T(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+)\.\d+[\+\-]\d+:\d+(?P<eol>.*)",  # noqa
         ]
         self._date_expressions = [re.compile(v) for v in self._date_expressions]


### PR DESCRIPTION
When parsing postfix logs to build stats and message history
