### PR TITLE
Try to fix outdated migration

### DIFF
--- a/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
+++ b/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
@@ -9,9 +9,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameIndex(
-            model_name="user",
-            new_name="core_user_email_c0c03f_idx",
-            old_fields=("email", "is_active"),
-        ),
+        # migrations.RenameIndex(
+        #     model_name="user",
+        #     new_name="core_user_email_c0c03f_idx",
+        #     old_fields=("email", "is_active"),
+        # ),
     ]


### PR DESCRIPTION
It seems that the rename index is not needed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
