### PR TITLE
Revert "Try to fix outdated migration"

### DIFF
--- a/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
+++ b/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
@@ -18,7 +18,7 @@ class RenameIndexIfExists(migrations.RenameIndex):
         )
         if len(matching_index_name) != 1:
             return
-        super.database_forwards(app_label, schema_editor, from_state, to_state)
+        super().database_forwards(app_label, schema_editor, from_state, to_state)
 
 
 class Migration(migrations.Migration):

--- a/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
+++ b/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
@@ -3,13 +3,31 @@
 from django.db import migrations
 
 
+class RenameIndexIfExists(migrations.RenameIndex):
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        from_model = from_state.apps.get_model(app_label, self.model_name)
+        columns = [
+            from_model._meta.get_field(field).column for field in ["email", "is_active"]
+        ]
+        matching_index_name = schema_editor._constraint_names(
+            from_model,
+            column_names=columns,
+            index=True,
+            unique=False,
+        )
+        if len(matching_index_name) != 1:
+            return
+        super.database_forwards(app_label, schema_editor, from_state, to_state)
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("core", "0024_alter_user_language"),
     ]
 
     operations = [
-        migrations.RenameIndex(
+        RenameIndexIfExists(
             model_name="user",
             new_name="core_user_email_c0c03f_idx",
             old_fields=("email", "is_active"),

--- a/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
+++ b/modoboa/core/migrations/0025_rename_user_email_is_active_core_user_email_c0c03f_idx.py
@@ -9,9 +9,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # migrations.RenameIndex(
-        #     model_name="user",
-        #     new_name="core_user_email_c0c03f_idx",
-        #     old_fields=("email", "is_active"),
-        # ),
+        migrations.RenameIndex(
+            model_name="user",
+            new_name="core_user_email_c0c03f_idx",
+            old_fields=("email", "is_active"),
+        ),
     ]


### PR DESCRIPTION
Ref : #3670 

It seems that although no SQL is executed, django does want this migration to be included. 

Perhaps the fix should be by extending the Migration class and bypassing the exception for sqlite ?  
