### PR TITLE
Allow policy daemon to listen on Unix domain socket and systemd socket activation

### DIFF
--- a/modoboa/policyd/management/commands/policy_daemon.py
+++ b/modoboa/policyd/management/commands/policy_daemon.py
@@ -27,6 +27,7 @@ class Command(BaseCommand):
         """Add command line arguments."""
         parser.add_argument("--host", type=str, default="localhost")
         parser.add_argument("--port", type=int, default=9999)
+        parser.add_argument("--socket", type=str, default=None)
         parser.add_argument("--debug", action="store_true", help="Enable debug mode")
 
     def handle(self, *args, **options):
@@ -36,9 +37,14 @@ class Command(BaseCommand):
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        coro = asyncio.start_server(
-            core.new_connection, options["host"], options["port"]
-        )
+        if options["socket"] is None:
+            coro = asyncio.start_server(
+                core.new_connection, options["host"], options["port"]
+            )
+        else:
+            coro = asyncio.start_unix_server(
+                core.new_connection, options["socket"]
+            )
         server = loop.run_until_complete(coro)
 
         # Schedule reset task
@@ -59,8 +65,9 @@ class Command(BaseCommand):
 
         logger.info("Stopping policy daemon...")
         # Close the server
-        server.close()
-        loop.run_until_complete(server.wait_closed())
+        for s in server:
+            s.close()
+            loop.run_until_complete(s.wait_closed())
         # Cancel pending tasks
         for task in asyncio.all_tasks(loop):
             task.cancel()

--- a/modoboa/policyd/management/commands/policy_daemon.py
+++ b/modoboa/policyd/management/commands/policy_daemon.py
@@ -36,6 +36,9 @@ class Command(BaseCommand):
         """Entry point."""
         try:
             loop = asyncio.get_event_loop()
+            if loop.is_closed():
+                # Raised on Python 3.11- after fork when *using* the loop
+                raise RuntimeError("Event loop is closed")
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/modoboa/policyd/management/commands/policy_daemon.py
+++ b/modoboa/policyd/management/commands/policy_daemon.py
@@ -5,6 +5,8 @@ from contextlib import suppress
 import functools
 import logging
 import signal
+import socket
+import os
 
 from django.core.management.base import BaseCommand
 
@@ -37,7 +39,22 @@ class Command(BaseCommand):
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        if options["socket"] is None:
+        if os.environ.get("LISTEN_PID", "") == str(os.getpid()) and os.environ.get("LISTEN_FDS", "").isnumeric():
+            num_sockets = int(os.environ["LISTEN_FDS"])
+
+            del os.environ["LISTEN_PID"]
+            del os.environ["LISTEN_FDS"]
+
+            servers = []
+            for fileno in range(3, 3 + num_sockets):  # It’s always FD 3+
+                listen_sock = socket.socket(fileno=fileno)
+                listen_sock.set_inheritable(False)  # Mark as CLOEXEC
+
+                servers.append(asyncio.start_server(
+                    core.new_connection, sock=listen_sock
+                ))
+            coro = asyncio.gather(*servers)
+        elif options["socket"] is None:
             coro = asyncio.start_server(
                 core.new_connection, options["host"], options["port"]
             )
@@ -45,7 +62,9 @@ class Command(BaseCommand):
             coro = asyncio.start_unix_server(
                 core.new_connection, options["socket"]
             )
-        server = loop.run_until_complete(coro)
+        servers = loop.run_until_complete(coro)
+        if not isinstance(servers, list):
+            servers = [servers]
 
         # Schedule reset task
         core.start_reset_counters_coro()
@@ -55,7 +74,7 @@ class Command(BaseCommand):
                 getattr(signal, signame), functools.partial(ask_exit, signame, loop)
             )
 
-        logger.info(f"Serving on {server.sockets[0].getsockname()}")
+        logger.info(f"Started policy daemon")
 
         if options["debug"]:
             loop.set_debug(True)
@@ -65,7 +84,7 @@ class Command(BaseCommand):
 
         logger.info("Stopping policy daemon...")
         # Close the server
-        for s in server:
+        for s in servers:
             s.close()
             loop.run_until_complete(s.wait_closed())
         # Cancel pending tasks

--- a/modoboa/policyd/tests.py
+++ b/modoboa/policyd/tests.py
@@ -5,7 +5,10 @@ from aiosmtplib import send
 from unittest.mock import AsyncMock
 import multiprocessing
 from multiprocessing import Process
+import os
 import socket
+import subprocess
+import sys
 import time
 
 from django import db
@@ -24,8 +27,8 @@ from . import constants
 multiprocessing.set_start_method("fork")
 
 
-def start_policy_daemon():
-    call_command("policy_daemon")
+def start_policy_daemon(*args):
+    call_command("policy_daemon", *args)
 
 
 class RedisTestCaseMixin:
@@ -35,6 +38,87 @@ class RedisTestCaseMixin:
         super().setUp()
         self.rclient = get_redis_connection()
         self.rclient.delete(constants.REDIS_HASHNAME)
+
+
+class SocketActivationTestCase(TransactionTestCase):
+	def test_socket_activation(self):
+		self.assertTrue(os.path.basename(sys.argv[0]) == "manage.py")
+
+		child_sock = socket.socket(socket.AF_UNIX)
+		child_sock.bind("\0modoboa_test")
+		child_sock.listen(1)
+		client_sock = socket.socket(socket.AF_UNIX)
+		client_sock.connect("\0modoboa_test")
+
+		# Extract file descriptor without Python wrapper
+		child_fd = child_sock.detach()
+
+		def set_up_activation_env():
+			"""
+			Called in child process before execve()
+			"""
+			# Move file descriptor to number 3 if not already
+			#
+			# Must be inheritable to survive the imminent execve().
+			if child_fd != 3:
+				os.dup2(child_fd, 3, inheritable=True)
+				os.close(child_fd)
+
+			# Expose expected process environment variables
+			os.environ["LISTEN_FDS"] = "1"
+			os.environ["LISTEN_PID"] = str(os.getpid())
+
+			# Child environment setup complete
+
+		# Launch policy daemon as external process with socket activation process
+		# environment
+		#
+		# To do this, `sock_b` is inherited to the child process, then moved to
+		# FD number 3 and the expected environment variables are set. We expect
+		# to be able to communicate with the policy daemon from `sock_a` after this.
+		proc = subprocess.Popen(
+			[sys.executable, sys.argv[0], "policy_daemon"],
+			pass_fds=(3,),  # FD number post dup2!
+			preexec_fn=set_up_activation_env,
+		)
+		try:
+			os.close(child_fd)  # Now belongs to child
+
+			client_sock.send(b"protocol_state=RCPT\n\n")
+			res = client_sock.recv(1024)
+			self.assertEqual(res, b"action=dunno\n\n")
+		finally:
+			client_sock.close()
+			proc.terminate()
+			proc.wait()
+
+	def test_socket_path(self):
+		try:
+			os.remove("/tmp/modoboa_socket_path")
+		except FileNotFoundError:
+			pass
+
+		process = Process(target=start_policy_daemon, args=("--socket", "/tmp/modoboa_socket_path"))
+		process.daemon = True
+		process.start()
+		try:
+			# Wait a bit for the daemon to start
+			process.join(1.0)
+
+			# Socket file should now exist
+			self.assertTrue(os.path.exists("/tmp/modoboa_socket_path"))
+
+			# Ensure that daemon is responding on other end of socket
+			with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+				s.connect("/tmp/modoboa_socket_path")
+				s.send(b"protocol_state=RCPT\n\n")
+				res = s.recv(1024)
+				self.assertEqual(res, b"action=dunno\n\n")
+
+			os.remove("/tmp/modoboa_socket_path")
+		finally:
+			process.terminate()
+			process.join()
 
 
 class PolicyDaemonTestCase(RedisTestCaseMixin, ParametersMixin, TransactionTestCase):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

1. Allowing policy daemon to listen on Unix domain socket means no port conflicts and less attack surface (since only processes with appropriate permissions may connect to the socket)
2. systemd socket activation means policy daemon is only started on first received message rather than directly on boot

Current behavior before PR:
Policy daemon must be started on boot and bind on loopback TCP

Desired behavior after PR is merged:
Both limitations are lifted
