### PR TITLE
Update MessageList.vue

### DIFF
--- a/frontend/src/components/admin/logs/MessageList.vue
+++ b/frontend/src/components/admin/logs/MessageList.vue
@@ -25,7 +25,9 @@
         {{ $date(item.date) }}
       </template>
       <template #[`item.sender`]="{ item }">
-        {{ $truncate(item.sender, 50) }}
+        <span :title="item.sender">
+          {{ $truncate(item.sender, 50) }}
+        </span>
       </template>
     </v-data-table-server>
   </v-card>


### PR DESCRIPTION
Make it so that on hover of sender address in admin message list log it shows a tooltip of the full untruncated sender email, but still keeps the truncation in the ui.

Description of the issue/feature this PR addresses: Currently if in the admin message list ui there is a long sender email the user only sees the truncated email and has no way to view full email. 

Current behavior before PR: Currently if in the admin message list ui there is a long sender email the user only sees the truncated email and has no way to view full email. 

Desired behavior after PR is merged: Now if the user hovers over the truncated email their browser will show a tooltip showing the full sender email while still keeping the sender email truncated in the ui.
