### PR TITLE
Revert "Bump caldav from 2.0.1 to 2.1.2"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
         # User
         "drf-nested-routers",
         "vobject",
-        "caldav==2.1.2",
+        "caldav==2.0.1",
         # Amavis
         "html2text",
         "idna",


### PR DESCRIPTION
Reverts modoboa/modoboa#3788

Calendar backend not working anymore starting with version 2.1.x of caldav. Need to investigate