### PR TITLE
Disable check when radicale related plugins are missing.

### DIFF
--- a/modoboa/core/checks.py
+++ b/modoboa/core/checks.py
@@ -100,6 +100,11 @@ def check_dovecot_oauth_app(*args, **kwargs):
 
 @register(deploy=True)
 def check_radicale_oauth_app(*args, **kwargs):
+    if (
+        "modoboa.contacts" not in settings.MODOBOA_APPS
+        and "modoboa.calendars" not in settings.MODOBOA_APPS
+    ):
+        return []
     error = []
     if not oauth_app_exists("Radicale"):
         error.append(E002)

--- a/modoboa/core/tests/test_checks.py
+++ b/modoboa/core/tests/test_checks.py
@@ -72,3 +72,30 @@ class CheckSessionCookieSecureTest(SimpleModoTestCase):
         )
         msgs = checks.check_radicale_oauth_app()
         self.assertEqual(len(msgs), 0)
+
+    @override_settings(
+        MODOBOA_APPS=[
+            "modoboa",
+            "modoboa.core",
+            "modoboa.lib",
+            "modoboa.admin",
+            "modoboa.autoconfig",
+            "modoboa.transport",
+            "modoboa.relaydomains",
+            "modoboa.limits",
+            "modoboa.parameters",
+            "modoboa.dnstools",
+            "modoboa.policyd",
+            "modoboa.maillog",
+            "modoboa.pdfcredentials",
+            "modoboa.dmarc",
+            "modoboa.imap_migration",
+            "modoboa.autoreply",
+            "modoboa.sievefilters",
+            "modoboa.webmail",
+        ]
+    )
+    def test_radicale_oauth_app_skipped(self):
+        get_application_model().objects.filter(name="Radicale").delete()
+        msgs = checks.check_radicale_oauth_app()
+        self.assertEqual(len(msgs), 0)


### PR DESCRIPTION
fix #3808

