### PR TITLE
Replaced call to deprecated caldav method.

### DIFF
--- a/modoboa/calendars/backends/caldav_.py
+++ b/modoboa/calendars/backends/caldav_.py
@@ -141,7 +141,7 @@ class Caldav_Backend(CalendarBackend):
 
     def get_events(self, start, end):
         """Retrieve a list of events."""
-        orig_events = self.remote_cal.search(start=start, end=end)
+        orig_events = self.remote_cal.search(server_expand=True, start=start, end=end)
         events = []
         for event in orig_events:
             events.append(self._serialize_event(event))

--- a/modoboa/calendars/mocks.py
+++ b/modoboa/calendars/mocks.py
@@ -53,7 +53,7 @@ class Calendar:
         res = objects.Event(url=url, data=EV1, parent=self)
         return res
 
-    def date_search(self, start, end):
+    def search(self, **kwargs):
         return [
             objects.Event(data=EV1, parent=self),
             objects.Event(data=EV2, parent=self),


### PR DESCRIPTION
date_search() has been deprecated in favor of search()
