### PR TITLE
Allow `bcrypt` 5.0.0 again

### DIFF
--- a/modoboa/core/password_hashers/advanced.py
+++ b/modoboa/core/password_hashers/advanced.py
@@ -39,11 +39,15 @@ class BLFCRYPTHasher(PasswordHasher):
         # when using the bcrypt hasher.
         # rounds = parameters.get_global_parameter("rounds_number")
         # To get around this, I use the default of 12.
+        if isinstance(clearvalue, str):
+            clearvalue = clearvalue.encode("utf-8")
         rounds = 12
-        return bcrypt.using(rounds=rounds).hash(clearvalue)
+        return bcrypt.using(rounds=rounds).hash(clearvalue[:72])
 
     def verify(self, clearvalue, hashed_value):
-        return bcrypt.verify(clearvalue, hashed_value)
+        if isinstance(clearvalue, str):
+            clearvalue = clearvalue.encode("utf-8")
+        return bcrypt.verify(clearvalue[:72], hashed_value)
 
 
 class MD5CRYPTHasher(PasswordHasher):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 	"django-oauth-toolkit",
 	"django-cors-headers",
 	"passlib~=1.7.4",
-	"bcrypt==4.3.0", # Requires libffi-dev and python-dev
+	"bcrypt~=5.0", # Requires libffi-dev and python-dev
 	"asgiref",
 	"dnspython==2.8.0",
 	"feedparser==6.0.12",


### PR DESCRIPTION
The only breaking change is that passwords will no longer automatically be truncated to 72 bytes, so truncate them on input instead.

This reverts commit a7ba1570814e659d0a50faefaf46c5054c0e09f3.