### PR TITLE
chore: use stale process as Github Actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
+          exempt-issue-labels: 'pinned,security,bug,dependencies,enhancement,looking-for-sponsors,documentation'
+          stale-issue-label: 'stale'
+          exempt-all-issue-assignees: true
+          exempt-all-issue-milestones: true
+
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
+          exempt-pr-labels: 'pinned,security,bug,dependencies,enhancement,looking-for-sponsors,documentation'
+          stale-pr-label: 'stale'
+          exempt-all-pr-assignees: true
+          exempt-all-pr-milestones: true


### PR DESCRIPTION
Stale Bot is not active anymore, we need to use Github Actions instead
