### PR TITLE
Add autofocus to TFA code input field

### DIFF
--- a/modoboa/templates/registration/twofactor_code_verify.html
+++ b/modoboa/templates/registration/twofactor_code_verify.html
@@ -25,7 +25,7 @@
         <input type="hidden" id="id_next" name="next" value="{{ nextlocation }}">
         <div class="input-group{% if form.tfa_code.errors %} error{% endif %}">
           <label>{% translate "One-time password" %}</label>
-          <input id="id_tfa_code" name="tfa_code" required>
+          <input id="id_tfa_code" name="tfa_code" required autofocus>
           <span class="error-message">
             {% for error in form.tfa_code.errors %}
               {{ error }}


### PR DESCRIPTION
Added autofocus attribute to the TFA code input field.

Description of the issue/feature this PR addresses:
When users reach the two-factor authentication code entry page, they must manually click the input field before typing their code.

Current behavior before PR:
The TFA code input field does not have focus when the page loads, requiring an extra click or tab to select it.

Desired behavior after PR is merged:
The TFA code input field is automatically focused on page load, allowing users to immediately type their authentication code.