### PR TITLE
Pin chardet version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 	"pytz",
 	"requests",
 	"lxml_html_clean",
-	"chardet",
+	"chardet==6.0.0.post1",
 	"ovh",
 	"oath",
         "packaging",


### PR DESCRIPTION
CI is broken with Chardet 7.0.x

