### PR TITLE
Fix empty Actions dropdown on Domains page

### DIFF
--- a/frontend/src/api/domains.js
+++ b/frontend/src/api/domains.js
@@ -53,6 +53,12 @@ export default {
   deleteDomain(domainId, data) {
     return repository.post(`/${domainResource}/${domainId}/delete/`, data)
   },
+  bulkDeleteDomains(ids, keepFolder = false) {
+    return repository.post(`/${domainResource}/bulk_delete/`, {
+      ids,
+      keep_folder: keepFolder,
+    })
+  },
   createDomainAlias(data) {
     return repository.post(`/${domainAliasResource}/`, data)
   },

--- a/frontend/src/components/admin/domains/DomainList.vue
+++ b/frontend/src/components/admin/domains/DomainList.vue
@@ -29,7 +29,7 @@
             class="flex-grow-0 w-33 mr-4"
           ></v-text-field>
           <slot name="extraActions" />
-          <v-menu location="bottom">
+          <v-menu v-if="selected.length > 1" location="bottom">
             <template #activator="{ props }">
               <v-btn
                 variant="flat"
@@ -40,7 +40,9 @@
                 {{ $gettext('Actions') }}
               </v-btn>
             </template>
-            <v-list density="compact"> </v-list>
+            <v-list density="compact">
+              <MenuItems :items="getActionMenuItems()" />
+            </v-list>
           </v-menu>
           <v-btn
             variant="text"
@@ -344,6 +346,47 @@ async function loadAliases(item, internalItem, isItemExpanded, toggleExpand) {
 function openAdminList(domain) {
   selectedDomain.value = domain
   showAdminList.value = true
+}
+
+function getActionMenuItems() {
+  const result = []
+  if (selected.value.length > 0) {
+    result.push({
+      label: $gettext('Delete'),
+      icon: 'mdi-delete-outline',
+      onClick: deleteSelectedDomains,
+      color: 'red',
+    })
+  }
+  return result
+}
+
+async function deleteSelectedDomains() {
+  const result = await confirm.value.open(
+    $gettext('Warning'),
+    $gettext('Do you really want to delete the selected domains?'),
+    {
+      color: 'error',
+      cancelLabel: $gettext('No'),
+      agreeLabel: $gettext('Yes'),
+    }
+  )
+  if (!result) {
+    return
+  }
+  loading.value = true
+  try {
+    const data = { keep_folder: keepDomainFolder.value }
+    for (const pk of selected.value) {
+      await domainsApi.deleteDomain(pk, data)
+    }
+    selected.value = []
+    reloadDomains()
+    busStore.displayNotification({ msg: $gettext('Domains deleted') })
+    keepDomainFolder.value = false
+  } finally {
+    loading.value = false
+  }
 }
 
 function getDomainMenuItems(domain) {

--- a/frontend/src/components/admin/domains/DomainList.vue
+++ b/frontend/src/components/admin/domains/DomainList.vue
@@ -376,10 +376,7 @@ async function deleteSelectedDomains() {
   }
   loading.value = true
   try {
-    const data = { keep_folder: keepDomainFolder.value }
-    for (const pk of selected.value) {
-      await domainsApi.deleteDomain(pk, data)
-    }
+    await domainsApi.bulkDeleteDomains(selected.value, keepDomainFolder.value)
     selected.value = []
     reloadDomains()
     busStore.displayNotification({ msg: $gettext('Domains deleted') })

--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -79,7 +79,7 @@ class DomainViewSet(
         return models.Domain.objects.none()
 
     def get_serializer_class(self, *args, **kwargs):
-        if self.action == "delete":
+        if self.action in ("delete", "bulk_delete"):
             return serializers.DeleteDomainSerializer
         if self.action == "administrators":
             return serializers.DomainAdminSerializer
@@ -99,6 +99,28 @@ class DomainViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         domain.delete(request.user, serializer.validated_data["keep_folder"])
+        return response.Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(methods=["post"], detail=False, url_path="bulk_delete")
+    def bulk_delete(self, request, **kwargs):
+        """Delete multiple domains at once."""
+        ids = request.data.get("ids", [])
+        if not ids:
+            return response.Response(
+                {"ids": [_("This field is required.")]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        keep_folder = serializer.validated_data["keep_folder"]
+        queryset = self.get_queryset().filter(pk__in=ids)
+        mb = getattr(request.user, "mailbox", None)
+        for domain in queryset:
+            if mb and mb.domain == domain:
+                raise PermissionDenied(
+                    _("You can't delete your own domain (%s)") % domain.name
+                )
+            domain.delete(request.user, keep_folder)
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=["get"], detail=True)


### PR DESCRIPTION
## Summary

- The Actions dropdown in the Domains list toolbar was always visible but contained an empty `<v-list>` with no menu items
- Added a `bulk_delete` API endpoint (`POST /api/v2/domains/bulk_delete/`) that accepts `{ids: [...], keep_folder: bool}` for deleting multiple domains in a single request
- Frontend now only shows the Actions dropdown when multiple rows are selected (matching the pattern in `IdentityList.vue`), and calls the new bulk endpoint

## Changes

**Backend: `modoboa/admin/api/v2/viewsets.py`**
- Added `bulk_delete` action to `DomainViewSet`
- Accepts `{ids: [1, 2, 3], keep_folder: false}`
- Validates permissions for each domain before deletion

**Frontend: `frontend/src/api/domains.js`**
- Added `bulkDeleteDomains(ids, keepFolder)` method

**Frontend: `frontend/src/components/admin/domains/DomainList.vue`**
- Added `v-if="selected.length > 1"` to Actions menu (same pattern as IdentityList)
- Added `getActionMenuItems()` and `deleteSelectedDomains()` using the bulk endpoint

Fixes #3974