### PR TITLE
fix FutureWarning in python3.13

### DIFF
--- a/modoboa/maillog/management/commands/logparser.py
+++ b/modoboa/maillog/management/commands/logparser.py
@@ -84,7 +84,7 @@ class LogParser:
         self._date_expressions = [re.compile(v) for v in self._date_expressions]
         self.date_expr = None
         self._regex = {
-            "line": r"\s+([-\w\.]+)\s+(\w+)/?(\w*)[[](\d+)[]]:\s+(.*)",
+            "line": r"\s+([-\w\.]+)\s+(\w+)/?(\w*)\[(\d+)\]:\s+(.*)",
             "id": r"(\w+): (.*)",
             "reject": r"reject: .*from=<.*>,? to=<[^@]+@([^>]+)>",
             "message-id": r"message-id=<([^>]*)>",


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
A minor fix for Python 3.13 

Current behavior before PR:
`root@mail:~# /srv/modoboa/env/bin/python /srv/modoboa/instance/manage.py logparser --force

/srv/modoboa/env/lib/python3.13/site-packages/modoboa/maillog/management/commands/logparser.py:101: FutureWarning: Possible nested set at position 29

  self._regex = {k: re.compile(v) for k, v in self._regex.items()}`

Desired behavior after PR is merged:
