### PR TITLE
Sieve filters editor fixes

### DIFF
--- a/frontend/src/components/account/FilterForm.vue
+++ b/frontend/src/components/account/FilterForm.vue
@@ -98,7 +98,7 @@
                   v-if="arg.type === 'list'"
                   v-model="action.args[arg.name]"
                   :items="arg.choices"
-                  item-title="label"
+                  :item-title="(item) => buildItemTitle(arg.name, item)"
                   density="compact"
                   variant="outlined"
                   :rules="[rules.required]"
@@ -246,6 +246,18 @@ function getConditionType(index) {
       }
     }
   }
+}
+
+function buildItemTitle(argName, item) {
+  if (argName !== 'mailbox') {
+    return item.label
+  }
+  const name = item.name
+  if (!name.includes('/')) {
+    return name
+  }
+  const parts = name.split('/')
+  return '\u00A0'.repeat((parts.length - 1) * 4) + parts[parts.length - 1]
 }
 
 function getActionArguments(action) {

--- a/modoboa/sievefilters/api/v2/viewsets.py
+++ b/modoboa/sievefilters/api/v2/viewsets.py
@@ -12,6 +12,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import permissions, response, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from modoboa.lib.viewsets import HasMailbox
 from modoboa.sievefilters import constants
@@ -38,6 +39,21 @@ class FilterSetViewSet(viewsets.ViewSet):
         HasMailbox,
     )
     serializer_class = serializers.FilterSetSerializer
+    lookup_value_regex = "[^/]+"
+
+    # Characters forbidden in ManageSieve quoted-string arguments (RFC 5804).
+    # Rejecting them prevents protocol injection through script/filter names
+    # and CRLF injection in the Content-Disposition header used by `download`.
+    FORBIDDEN_NAME_CHARS = ("\r", "\n", "\x00", '"', "\\")
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+        for key in ("pk", "filter"):
+            value = kwargs.get(key)
+            if value is None:
+                continue
+            if any(c in value for c in self.FORBIDDEN_NAME_CHARS):
+                raise DRFValidationError({key: _("Name contains forbidden characters")})
 
     def get_sieve_client(self, request):
         return SieveClient(user=request.user.username, password=str(request.auth))


### PR DESCRIPTION
- Allow all characters in filter set names (prevent 404 error when trying to retrieve filterset previously created)
- Added indentation in mailbox selection field
