### PR TITLE
Backport CVE-2026-27602 (exec_cmd OS command injection) to 2.3.x

### DIFF
--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -228,7 +228,7 @@ class AdminGlobalParametersSerializer(serializers.Serializer):
     def validate_dkim_keys_storage_dir(self, value):
         """Check that directory exists."""
         if value:
-            code, output = exec_cmd("which openssl")
+            code, output = exec_cmd("which openssl", shell=True)
             if code:
                 raise serializers.ValidationError(
                     _("openssl not found, please make sure it is installed.")

--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -198,7 +198,7 @@ class AdminParametersForm(param_forms.AdminParametersForm):
         self.field_widths = {"default_domain_quota": 2, "default_mailbox_quota": 2}
         hide_fields = False
         dpath = None
-        code, output = exec_cmd("which dovecot")
+        code, output = exec_cmd("which dovecot", shell=True)
         if not code:
             dpath = force_str(output).strip()
         else:
@@ -212,7 +212,7 @@ class AdminParametersForm(param_forms.AdminParametersForm):
                     dpath = fpath
         if dpath:
             try:
-                code, version = exec_cmd("%s --version" % dpath)
+                code, version = exec_cmd([dpath, "--version"])
             except OSError:
                 hide_fields = True
             else:
@@ -242,7 +242,7 @@ class AdminParametersForm(param_forms.AdminParametersForm):
         if storage_dir:
             if not os.path.isdir(storage_dir):
                 raise forms.ValidationError(gettext_lazy("Directory not found."))
-            code, output = exec_cmd("which openssl")
+            code, output = exec_cmd("which openssl", shell=True)
             if code:
                 raise forms.ValidationError(
                     gettext_lazy("openssl not found, please make sure it is installed.")

--- a/modoboa/admin/management/commands/handle_mailbox_operations.py
+++ b/modoboa/admin/management/commands/handle_mailbox_operations.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                 os.makedirs(dirname)
             except os.error as e:
                 raise OperationError(str(e))
-        code, output = exec_cmd("mv %s %s" % (operation.argument, new_mail_home))
+        code, output = exec_cmd(["mv", operation.argument, new_mail_home])
         if code:
             raise OperationError(output)
 
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             with open(path) as fp:
                 pid = fp.read().strip()
             code, output = exec_cmd(
-                "grep handle_mailbox_operations /proc/%s/cmdline" % pid
+                ["grep", "handle_mailbox_operations", "/proc/%s/cmdline" % pid]
             )
             if not code:
                 return False

--- a/modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py
+++ b/modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py
@@ -44,7 +44,7 @@ class ManageDKIMKeys(BaseCommand):
             else self.default_key_length
         )
         code, output = sysutils.exec_cmd(
-            "openssl genrsa -out {} {}".format(pkey_path, key_size)
+            ["openssl", "genrsa", "-out", pkey_path, str(key_size)]
         )
         if code:
             print(
@@ -57,7 +57,9 @@ class ManageDKIMKeys(BaseCommand):
             )
             return
         domain.dkim_private_key_path = pkey_path
-        code, output = sysutils.exec_cmd("openssl rsa -in {} -pubout".format(pkey_path))
+        code, output = sysutils.exec_cmd(
+            ["openssl", "rsa", "-in", pkey_path, "-pubout"]
+        )
         if code:
             print(
                 "Failed to generate DKIM public key for domain {}: {}".format(

--- a/modoboa/admin/models/mailbox.py
+++ b/modoboa/admin/models/mailbox.py
@@ -147,7 +147,7 @@ class Mailbox(mixins.MessageLimitMixin, AdminObject):
         if not admin_params.get("handle_mailboxes"):
             return None
         if self.__mail_home is None:
-            code, output = doveadm_cmd("user -f home %s" % self.full_address)
+            code, output = doveadm_cmd(["user", "-f", "home", self.full_address])
             if code:
                 raise lib_exceptions.InternalError(
                     _("Failed to retrieve mailbox location (%s)") % output

--- a/modoboa/core/commands/deploy.py
+++ b/modoboa/core/commands/deploy.py
@@ -225,11 +225,9 @@ class DeployCommand(Command):
                 (extension, extension.replace("-", "_")) for extension in extensions
             ]
             if not parsed_args.dont_install_extensions:
-                cmd = (
-                    sys.executable
-                    + " -m pip install "
-                    + " ".join([extension[0] for extension in extensions])
-                )
+                cmd = [sys.executable, "-m", "pip", "install"] + [
+                    extension[0] for extension in extensions
+                ]
                 exec_cmd(cmd, capture_output=False)
             extra_settings = self.find_extra_settings(extensions)
             extensions = [extension[1] for extension in extensions]

--- a/modoboa/core/password_hashers/utils.py
+++ b/modoboa/core/password_hashers/utils.py
@@ -30,7 +30,7 @@ def get_dovecot_schemes():
 
     if not schemes:
         try:
-            retcode, schemes = doveadm_cmd("pw -l")
+            retcode, schemes = doveadm_cmd(["pw", "-l"])
         except OSError:
             schemes = default_schemes
             status = 2

--- a/modoboa/lib/sysutils.py
+++ b/modoboa/lib/sysutils.py
@@ -19,7 +19,13 @@ def exec_cmd(cmd, sudo_user=None, pinput=None, capture_output=True, **kwargs):
     Run a command using the current user. Set :keyword:`sudo_user` if
     you need different privileges.
 
-    :param str cmd: the command to execute
+    Backport of CVE-2026-27602: callers must now pass ``shell=True``
+    explicitly when ``cmd`` is a shell string. Prefer passing ``cmd``
+    as a ``list[str]`` (with ``shell`` left unset/False) so arguments
+    are not subject to shell interpretation.
+
+    :param cmd: the command to execute (``str`` with ``shell=True``,
+        or ``list[str]``)
     :param str sudo_user: a valid system username
     :param str pinput: data to send to process's stdin
     :param bool capture_output: capture process output or not
@@ -27,8 +33,10 @@ def exec_cmd(cmd, sudo_user=None, pinput=None, capture_output=True, **kwargs):
     :return: return code, command output
     """
     if sudo_user is not None:
-        cmd = "sudo -u %s %s" % (sudo_user, cmd)
-    kwargs["shell"] = True
+        if isinstance(cmd, list):
+            cmd = ["sudo", "-u", sudo_user] + cmd
+        else:
+            cmd = "sudo -u %s %s" % (sudo_user, cmd)
     if pinput is not None:
         kwargs["stdin"] = subprocess.PIPE
     if capture_output:
@@ -49,7 +57,10 @@ def doveadm_cmd(params, pinput=None, capture_output=True, **kwargs):
     Run doveadm command using the current user. Set :keyword:`sudo_user` if
     you need different privileges.
 
-    :param str params: the parameters to give to doveadm
+    Backport of CVE-2026-27602: ``params`` must be a ``list[str]`` so the
+    arguments are passed to ``subprocess`` without shell interpretation.
+
+    :param list params: the parameters to give to doveadm
     :param str sudo_user: a valid system username
     :param str pinput: data to send to process's stdin
     :param bool capture_output: capture process output or not
@@ -57,7 +68,7 @@ def doveadm_cmd(params, pinput=None, capture_output=True, **kwargs):
     :return: return code, command output
     """
     dpath = None
-    code, output = exec_cmd("which doveadm")
+    code, output = exec_cmd("which doveadm", shell=True)
     if not code:
         dpath = force_str(output).strip()
     else:
@@ -75,7 +86,7 @@ def doveadm_cmd(params, pinput=None, capture_output=True, **kwargs):
     sudo_user = dovecot_user if curuser != dovecot_user else None
     if dpath:
         return exec_cmd(
-            "{} {}".format(dpath, params),
+            [dpath] + list(params),
             sudo_user=sudo_user,
             pinput=pinput,
             capture_output=capture_output,

--- a/modoboa/maillog/graphics.py
+++ b/modoboa/maillog/graphics.py
@@ -7,7 +7,7 @@ from itertools import chain
 import os
 
 from django.conf import settings
-from django.utils.encoding import smart_bytes, smart_str
+from django.utils.encoding import smart_str
 from django.utils.translation import gettext as _, gettext_lazy
 
 from modoboa.admin import models as admin_models
@@ -75,7 +75,7 @@ class Graphic:
     def rrdtool_binary(self):
         """Return path to rrdtool binary."""
         dpath = None
-        code, output = exec_cmd("which rrdtool")
+        code, output = exec_cmd("which rrdtool", shell=True)
         if not code:
             dpath = output.strip()
         else:
@@ -102,11 +102,17 @@ class Graphic:
             cmdargs += curve.to_rrd_command_args(rrdfile)
         code = 0
 
-        cmd = "{} xport --json -t --start {} --end {} ".format(
-            self.rrdtool_binary, str(start), str(end)
-        )
-        cmd += " ".join(cmdargs)
-        code, output = exec_cmd(smart_bytes(cmd))
+        cmd = [
+            self.rrdtool_binary,
+            "xport",
+            "--json",
+            "-t",
+            "--start",
+            str(start),
+            "--end",
+            str(end),
+        ] + cmdargs
+        code, output = exec_cmd(cmd)
         if code:
             return []
 

--- a/tests.py
+++ b/tests.py
@@ -38,7 +38,7 @@ class DeployTest(unittest.TestCase):
             "--dburl %s --domain %s --admin-username admin %s"
             % (dburl, "localhost", self.projname)
         )
-        code, output = exec_cmd(cmd, cwd=self.workdir)
+        code, output = exec_cmd(cmd, shell=True, cwd=self.workdir)
         self.assertEqual(code, 0)
 
 


### PR DESCRIPTION
Per @kryskool in #4016: this PR backports the upstream fix [27a7aa1](https://github.com/modoboa/modoboa/commit/27a7aa133d3608fe8c25ae39125d1012c333cbfa) ("Prevent OS command injection using `exec_cmd()`") to the `2.3.x` maintenance branch.

## What's in scope

The architectural change in `modoboa/lib/sysutils.py` is preserved: `exec_cmd` and `doveadm_cmd` no longer set `shell=True` by default, so call sites must pass `list[str]` argv (preferred) or opt back into shell parsing explicitly.

All call sites that interpolated state/user-controlled data into a shell string have been moved to argv form:

- `modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py` -- `openssl genrsa`/`openssl rsa` invocations now use argv (was `"... {pkey_path} {key_size}"`).
- `modoboa/admin/models/mailbox.py` -- `doveadm user -f home <full_address>` now argv-form.
- `modoboa/admin/app_settings.py` -- `<dovecot_path> --version` now argv-form (the `which dovecot` lookup itself stays a constant string with explicit `shell=True`).
- `modoboa/maillog/graphics.py` -- `rrdtool xport ...` argv-form, plus removal of the now-unused `smart_bytes` import.
- `modoboa/lib/sysutils.py` -- `doveadm_cmd(params)` now expects `params` as `list[str]`; `[dpath] + list(params)` is what gets handed to `subprocess`. Also handles the `sudo_user` prefix correctly for both string and list forms.

`which <bin>` / `<bin> --version` invocations whose command line is a fixed constant keep the string form with `shell=True` -- they are not exploitable and changing them risks behavioural differences (`PATH` resolution, builtin lookup).

## 2.3.x-specific deltas vs the upstream patch

- The upstream patch modifies `modoboa/admin/jobs.py`, `modoboa/amavis/lib.py`, and `modoboa/webmail/models.py`. None of those files exist on `2.3.x`, so they are skipped.
- 2.3.x has additional `exec_cmd` callers that the upstream patch did not need to update (because they were refactored away on `master` already). These are updated here to match the new signature, otherwise they would silently break:
  - `modoboa/admin/management/commands/handle_mailbox_operations.py` -- `mv <argument> <new_mail_home>` and the `grep /proc/<pid>/cmdline` PID-file check are switched to argv form. The `mv` call is the same vulnerability class the upstream patch fixed in `jobs.py`.
  - `modoboa/core/commands/deploy.py` -- `pip install <ext1> <ext2> ...` switched to argv.
  - `tests.py` -- the deploy-test command is kept as a shell string (it is a CLI string assembled in test code) with explicit `shell=True`.
- The upstream patch annotates `exec_cmd` with `cmd: str | list[str]`, which is PEP 604 union syntax requiring Python 3.10+. `2.3.x`'s `pyproject.toml` declares `requires-python = ">=3.8"`, so the annotation is omitted here and the runtime behaviour preserved instead.

## Test plan

- [x] `python -c "import ast; [ast.parse(open(f).read(), f) for f in [...]]"` passes for all touched files.
- [x] All `exec_cmd(` call sites in the tree either pass `shell=True` or use `list[str]` argv (`git grep -n exec_cmd\\(` reviewed).
- [x] All `doveadm_cmd(` call sites pass a `list[str]` (`git grep -n doveadm_cmd\\(` reviewed).
- [ ] CI on this PR / your existing test suite is the authoritative check; happy to push fixups if anything fails.

Refs #4016. Thanks @kryskool for offering to merge if the tests pass!