### PR TITLE
Document MariaDB support in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ as an administration panel and webmail.
 
 Modoboa integrates with well known software such as `Postfix
 <http://postfix.org/>`_ or `Dovecot <http://dovecot.org/>`_. A SQL
-database (`MySQL <http://www.mysql.com>`_, `PostgreSQL
-<http://www.postgresql.org/>`_ or `SQLite <http://www.sqlite.org>`_)
+database (`MySQL <http://www.mysql.com>`_, `MariaDB <https://mariadb.org/>`_,
+`PostgreSQL <http://www.postgresql.org/>`_ or `SQLite <http://www.sqlite.org>`_)
 is used as a central point of communication between all components.
 
 Modoboa is developed with modularity in mind, expanding it is really


### PR DESCRIPTION
## Summary
- List MariaDB alongside MySQL in README.rst as a supported SQL database.
## Context
Modoboa’s `docker-compose.yml` and GitHub Actions workflows use a MariaDB image
(`mariadb:11`) for MySQL compatibility tests. The application UI already
mentions MariaDB (e.g. “Try using PostgreSQL, MySQL or MariaDB”); the README
database list only named MySQL, PostgreSQL, and SQLite.
## Test plan
- [x] Documentation only; no code changes.