### PR TITLE
fix: retrieve version when not installed as package

### DIFF
--- a/modoboa/__init__.py
+++ b/modoboa/__init__.py
@@ -6,7 +6,7 @@ try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     # package is not installed
-    pass
+    __version__ = None
 
 
 def modoboa_admin():

--- a/modoboa/core/tests/test_version.py
+++ b/modoboa/core/tests/test_version.py
@@ -1,0 +1,8 @@
+from modoboa.lib.tests import SimpleModoTestCase
+
+from modoboa import __version__
+
+class VersionTestCase(SimpleModoTestCase):
+
+    def test_version(self):
+        self.assertIsNot(__version__, None)


### PR DESCRIPTION
Fix #3892 