### PR TITLE
Don’t depend on running Redis for caching when executing tests

### DIFF
--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -327,8 +327,8 @@ RQ_QUEUES = {
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}",
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": f"{BASE_DIR}/cache",
     }
 }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Redis may still be used in other cases, but it shouldn’t be a needless baseline requirement.

Current behavior before PR:
Tests are not runnable without having a running Redis instance.

Desired behavior after PR is merged:
Most tests work, tests that explicitly use Redis *queues* still fail.
