### PR TITLE
fix(dmarc): bound decompression of aggregate report archives

### DIFF
--- a/modoboa/dmarc/lib.py
+++ b/modoboa/dmarc/lib.py
@@ -16,6 +16,7 @@ from dns import resolver, reversename
 import magic
 import io
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
@@ -43,11 +44,18 @@ FILE_TYPES = [
 ]
 
 # Size bounds to protect the importer against decompression bombs
-# (CWE-409/CWE-400). DMARC aggregate reports are small in practice, so
+# (CWE-409/CWE-400). Defaults live in the project settings so they can be
+# tuned per deployment; DMARC aggregate reports are small in practice, so
 # these caps are generous while still preventing resource exhaustion.
-MAX_COMPRESSED_SIZE = 1 * 1024 * 1024  # 1 MiB of compressed attachment
-MAX_DECOMPRESSED_SIZE = 20 * 1024 * 1024  # 20 MiB once decompressed
-MAX_ZIP_MEMBERS = 20  # number of files allowed inside a zip archive
+MAX_COMPRESSED_SIZE = getattr(
+    settings, "DMARC_MAX_COMPRESSED_SIZE", 1 * 1024 * 1024
+)  # 1 MiB of compressed attachment
+MAX_DECOMPRESSED_SIZE = getattr(
+    settings, "DMARC_MAX_DECOMPRESSED_SIZE", 20 * 1024 * 1024
+)  # 20 MiB once decompressed
+MAX_ZIP_MEMBERS = getattr(
+    settings, "DMARC_MAX_ZIP_MEMBERS", 20
+)  # number of files allowed inside a zip archive
 
 
 def _read_bounded(fileobj, limit):

--- a/modoboa/dmarc/lib.py
+++ b/modoboa/dmarc/lib.py
@@ -42,6 +42,25 @@ FILE_TYPES = [
     "text/xml",
 ]
 
+# Size bounds to protect the importer against decompression bombs
+# (CWE-409/CWE-400). DMARC aggregate reports are small in practice, so
+# these caps are generous while still preventing resource exhaustion.
+MAX_COMPRESSED_SIZE = 1 * 1024 * 1024  # 1 MiB of compressed attachment
+MAX_DECOMPRESSED_SIZE = 20 * 1024 * 1024  # 20 MiB once decompressed
+MAX_ZIP_MEMBERS = 20  # number of files allowed inside a zip archive
+
+
+def _read_bounded(fileobj, limit):
+    """Read at most ``limit`` bytes and reject anything larger.
+
+    Reading ``limit + 1`` bytes lets us detect oversized payloads
+    without materializing the whole (potentially huge) stream.
+    """
+    data = fileobj.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError("Decompressed payload exceeds the allowed size")
+    return data
+
 
 def import_record(xml_node, report):
     """Import a record."""
@@ -146,14 +165,28 @@ def import_archive(archive, content_type=None):
     - a xml file.
     """
     if content_type == "text/xml":
-        import_report(archive.read())
+        import_report(_read_bounded(archive, MAX_DECOMPRESSED_SIZE))
     elif content_type in ["application/gzip", "application/octet-stream"]:
         with gzip.GzipFile(mode="r", fileobj=archive) as zfile:
-            import_report(zfile.read())
+            import_report(_read_bounded(zfile, MAX_DECOMPRESSED_SIZE))
     else:
         with zipfile.ZipFile(archive, "r") as zfile:
-            for fname in zfile.namelist():
-                import_report(zfile.read(fname))
+            infos = zfile.infolist()
+            if len(infos) > MAX_ZIP_MEMBERS:
+                raise ValueError("Too many members in zip archive")
+            total = 0
+            for info in infos:
+                total += info.file_size
+                if (
+                    info.file_size > MAX_DECOMPRESSED_SIZE
+                    or total > MAX_DECOMPRESSED_SIZE
+                ):
+                    raise ValueError("Decompressed payload exceeds the allowed size")
+            for info in infos:
+                with zfile.open(info, "r") as member:
+                    # Enforce the cap on the real stream too: the declared
+                    # file_size above cannot be fully trusted.
+                    import_report(_read_bounded(member, MAX_DECOMPRESSED_SIZE))
 
 
 def import_report_from_email(content):
@@ -169,7 +202,12 @@ def import_report_from_email(content):
         if part.get_content_type() not in ZIP_CONTENT_TYPES:
             continue
         try:
-            fpo = io.BytesIO(part.get_payload(decode=True))
+            payload = part.get_payload(decode=True)
+            if payload is None:
+                continue
+            if len(payload) > MAX_COMPRESSED_SIZE:
+                raise ValueError("Compressed attachment exceeds the allowed size")
+            fpo = io.BytesIO(payload)
             # Try to get the actual file type of the buffer
             # required to make sure we are dealing with an XML file
             file_type = magic.Magic(uncompress=True, mime=True).from_buffer(
@@ -178,7 +216,7 @@ def import_report_from_email(content):
             fpo.seek(0)
             if file_type in FILE_TYPES:
                 import_archive(fpo, content_type=part.get_content_type())
-        except OSError:
+        except (OSError, ValueError, zipfile.BadZipFile):
             print("Error: the attachment does not match the mimetype")
             err = True
         else:

--- a/modoboa/dmarc/tests/test_decompression_limits.py
+++ b/modoboa/dmarc/tests/test_decompression_limits.py
@@ -1,0 +1,95 @@
+"""Regression tests for decompression bomb protection (CWE-409/CWE-400)."""
+
+import gzip
+import io
+import zipfile
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from .. import lib
+
+
+def _gzip_bytes(data: bytes) -> io.BytesIO:
+    buf = io.BytesIO()
+    with gzip.GzipFile(mode="wb", fileobj=buf) as fp:
+        fp.write(data)
+    buf.seek(0)
+    return buf
+
+
+def _zip_bytes(members: dict) -> io.BytesIO:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    buf.seek(0)
+    return buf
+
+
+@mock.patch.object(lib, "import_report")
+class ImportArchiveLimitsTestCase(SimpleTestCase):
+    """import_archive must reject oversized / abusive archives."""
+
+    def test_gzip_within_limit_is_imported(self, import_report_mock):
+        with mock.patch.object(lib, "MAX_DECOMPRESSED_SIZE", 1000):
+            archive = _gzip_bytes(b"<feedback>ok</feedback>")
+            lib.import_archive(archive, content_type="application/gzip")
+        import_report_mock.assert_called_once_with(b"<feedback>ok</feedback>")
+
+    def test_gzip_bomb_is_rejected(self, import_report_mock):
+        with mock.patch.object(lib, "MAX_DECOMPRESSED_SIZE", 1000):
+            # ~1 KB compressed expands to 2 MB of zeros.
+            archive = _gzip_bytes(b"\x00" * (2 * 1024 * 1024))
+            with self.assertRaises(ValueError):
+                lib.import_archive(archive, content_type="application/gzip")
+        import_report_mock.assert_not_called()
+
+    def test_zip_member_too_large_is_rejected(self, import_report_mock):
+        with mock.patch.object(lib, "MAX_DECOMPRESSED_SIZE", 1000):
+            archive = _zip_bytes({"report.xml": b"\x00" * (2 * 1024 * 1024)})
+            with self.assertRaises(ValueError):
+                lib.import_archive(archive, content_type="application/zip")
+        import_report_mock.assert_not_called()
+
+    def test_zip_too_many_members_is_rejected(self, import_report_mock):
+        with mock.patch.object(lib, "MAX_ZIP_MEMBERS", 3):
+            members = {f"r{i}.xml": b"<feedback/>" for i in range(5)}
+            archive = _zip_bytes(members)
+            with self.assertRaises(ValueError):
+                lib.import_archive(archive, content_type="application/zip")
+        import_report_mock.assert_not_called()
+
+    def test_zip_within_limits_is_imported(self, import_report_mock):
+        with (
+            mock.patch.object(lib, "MAX_DECOMPRESSED_SIZE", 1000),
+            mock.patch.object(lib, "MAX_ZIP_MEMBERS", 5),
+        ):
+            archive = _zip_bytes({"report.xml": b"<feedback>ok</feedback>"})
+            lib.import_archive(archive, content_type="application/zip")
+        import_report_mock.assert_called_once_with(b"<feedback>ok</feedback>")
+
+
+@mock.patch.object(lib, "import_archive")
+class CompressedAttachmentSizeTestCase(SimpleTestCase):
+    """import_report_from_email must reject oversized compressed attachments."""
+
+    def _build_email(self, payload: bytes) -> str:
+        import base64
+
+        encoded = base64.b64encode(payload).decode()
+        return (
+            "MIME-Version: 1.0\n"
+            'Content-Type: application/gzip; name="r.gz"\n'
+            "Content-Transfer-Encoding: base64\n"
+            "\n"
+            f"{encoded}\n"
+        )
+
+    def test_oversized_compressed_attachment_is_rejected(self, import_archive_mock):
+        with mock.patch.object(lib, "MAX_COMPRESSED_SIZE", 100):
+            msg = self._build_email(b"\x00" * 500)
+            with self.assertRaises(SystemExit) as ctx:
+                lib.import_report_from_email(msg)
+        self.assertEqual(ctx.exception.code, 65)
+        import_archive_mock.assert_not_called()

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -428,6 +428,14 @@ WEBMAIL_DEV_MODE = os.environ.get("WEBMAIL_DEV_MODE", "off") == "on"
 WEBMAIL_DEV_USERNAME = os.environ.get("WEBMAIL_DEV_USERNAME", "")
 WEBMAIL_DEV_PASSWORD = os.environ.get("WEBMAIL_DEV_PASSWORD", "")
 
+# DMARC aggregate report importer size bounds. These protect the importer
+# against decompression bombs (CWE-409/CWE-400). DMARC aggregate reports
+# are small in practice, so these caps are generous while still preventing
+# resource exhaustion.
+DMARC_MAX_COMPRESSED_SIZE = 1 * 1024 * 1024  # 1 MiB of compressed attachment
+DMARC_MAX_DECOMPRESSED_SIZE = 20 * 1024 * 1024  # 20 MiB once decompressed
+DMARC_MAX_ZIP_MEMBERS = 20  # number of files allowed inside a zip archive
+
 # Amavis
 
 MIGRATION_MODULES = {"amavis": None}


### PR DESCRIPTION
The DMARC aggregate report importer fully decompressed gzip/zip attachments into memory before parsing, with no size or member-count limits. A remote sender able to deliver mail to the configured report import address could supply a small compressed attachment that expands to a large payload (decompression/zip bomb), exhausting memory and CPU in the importer process (CWE-409 / CWE-400).

Enforce limits before and during decompression in import_archive() and import_report_from_email():
- reject MIME attachments above MAX_COMPRESSED_SIZE before any decompression (also bounds the magic uncompress probe);
- read gzip and xml streams through _read_bounded(), capping output at MAX_DECOMPRESSED_SIZE without materializing the whole stream;
- for zip archives, enforce MAX_ZIP_MEMBERS, a per-member and total uncompressed size cap (checked against ZipInfo.file_size and the real stream, which cannot be fully trusted);
- broaden attachment error handling to (OSError, ValueError, zipfile.BadZipFile) so rejected archives exit with EX_DATAERR (65).