### PR TITLE
fix(imap_migration): prevent code injection via folder filter params

### DIFF
--- a/modoboa/imap_migration/api/v2/serializers.py
+++ b/modoboa/imap_migration/api/v2/serializers.py
@@ -1,5 +1,7 @@
 """API v2 serializers."""
 
+import re
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -8,6 +10,20 @@ from modoboa.admin.models import Mailbox
 from modoboa.admin.models.domain import Domain
 
 from modoboa.imap_migration import models
+
+
+def validate_no_code_injection(value):
+    """Reject characters allowing breakout from the offlineimap config.
+
+    The folder filter parameters are interpolated into Python expressions
+    that offlineimap evaluates (``lambda`` / list literal). A single quote,
+    backslash or newline would let an attacker escape the surrounding string
+    literal and inject arbitrary code (CWE-94).
+    """
+    if any(c in value for c in ("'", "\\", "\n", "\r")):
+        raise serializers.ValidationError(
+            _("Quotes, backslashes and newlines are not allowed.")
+        )
 
 
 class IMAPMigrationSettingsSerializer(serializers.Serializer):
@@ -27,6 +43,20 @@ class IMAPMigrationSettingsSerializer(serializers.Serializer):
     folder_filter_include = serializers.CharField(
         required=False, allow_blank=True, default=""
     )
+
+    def validate_folder_filter_exclude(self, value):
+        validate_no_code_injection(value)
+        try:
+            re.compile(value)
+        except re.error:
+            raise serializers.ValidationError(
+                _("Invalid regular expression.")
+            ) from None
+        return value
+
+    def validate_folder_filter_include(self, value):
+        validate_no_code_injection(value)
+        return value
 
 
 class EmailProviderDomainSerializer(serializers.ModelSerializer):

--- a/modoboa/imap_migration/tests.py
+++ b/modoboa/imap_migration/tests.py
@@ -290,3 +290,50 @@ class ChecksTestCase(ModoTestCase):
         self.assertEqual(checks.check_auto_creation_is_enabled(None), [])
         self.set_global_parameter("auto_create_domain_and_mailbox", False, app="admin")
         self.assertEqual(checks.check_auto_creation_is_enabled(None), [checks.W001])
+
+
+class SettingsTestCase(ModoAPITestCase):
+    """Global parameters validation test case."""
+
+    def _update(self, data):
+        url = reverse("v2:parameter-global-detail", args=["imap_migration"])
+        return self.client.put(url, data, format="json")
+
+    def test_folder_filters_reject_code_injection(self):
+        """Folder filters must not allow breaking out of the offlineimap config.
+
+        ``folder_filter_exclude`` and ``folder_filter_include`` are
+        interpolated into Python expressions evaluated by offlineimap. A
+        single quote would let a SuperAdmin escape the surrounding string
+        literal and achieve arbitrary code execution (CWE-94).
+        """
+        # PoC payload from the report.
+        payload = (
+            ".*)', folder) or __import__('os').system('id > /tmp/pwned') "
+            "or re.search('(.*"
+        )
+        response = self._update({"folder_filter_exclude": payload})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("folder_filter_exclude", response.json())
+
+        response = self._update({"folder_filter_include": "a','b']);__import__"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("folder_filter_include", response.json())
+
+        # A newline could inject extra offlineimap config directives.
+        response = self._update({"folder_filter_exclude": "Trash\npythonfile = /x"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_folder_filter_exclude_rejects_invalid_regex(self):
+        response = self._update({"folder_filter_exclude": "(unbalanced"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("folder_filter_exclude", response.json())
+
+    def test_legitimate_folder_filters_accepted(self):
+        response = self._update(
+            {
+                "folder_filter_exclude": "^Trash$|Del",
+                "folder_filter_include": "debian.user, debian.personal",
+            }
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Credits: @iys8