### PR TITLE
fix(core): pin rq<2.10.0 to prevent rqcron scheduler crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,10 @@ dependencies = [
 	"defusedxml>=0.6.0",
 	"python-magic>=0.4.24",
 	# RQ
-	"rq>=2.7.0",
+	# rq>=2.10.0 added a `webhooks` kwarg to cron.register() that
+	# django-rq==4.1.0's DjangoCronScheduler.register() override doesn't
+	# accept yet, breaking `rqcron` (TypeError, 0 jobs registered).
+	"rq>=2.7.0,<2.10.0",
 	"django-rq>=4.0.1",
 	# Sieve
 	"sievelib>=1.4.1",


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR fixes a critical breakdown in Modoboa's periodic task scheduler by pinning the `rq` dependency to a supported version.

**Current behavior before PR:**
The recent `rq` version `2.10.0` silently added a new mandatory `webhooks` argument to its internal job registration function. However, the integrating `django-rq` library (version `4.1.0`) is not yet prepared to handle this new keyword argument. Because Modoboa installs `rq>=2.7.0`, it automatically pulls the newer version, causing an immediate `TypeError` when the `rqcron` scheduler runs. As a result, 0 jobs are registered, the cron scheduler fails to connect to Redis, and all background periodic tasks (e.g., log parsing, DNS checks, quota cleanup) stop working entirely.

**Desired behavior after PR is merged:**
By pinning `rq>=2.7.0,<2.10.0` in `pyproject.toml`, Modoboa pairs perfectly with the current `django-rq` API. The scheduler starts correctly, registers vital jobs into Redis, and guarantees background tasks continue to function smoothly. No modifications to `settings.py` are required; just a `pip install -e .` (or requirements update) after the merge.

**Steps to reproduce / Prove the bug (Ubuntu CLI):**
You can prove this crash on any Modoboa server running `rq>=2.10.0`. Run the following commands in your environment:
```bash
# Force install the incompatible RQ version
pip install "rq>=2.10.0"

# Attempt to start the cron scheduler
python manage.py rqcron

# ❌ You will see the scheduler crash immediately:
# TypeError: DjangoCronScheduler.register() got an unexpected keyword argument 'webhooks'
```
After applying this PR, the `rqcron` command will execute and register jobs successfully without crashing.

---
