### PR TITLE
Fix/i18n core improvements v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ modoboa/frontend_dist
 /frontend_dist/
 # JS stuff
 node_modules
+yarn-error.log
+npm-debug.log*
 /static/dist
 /frontend/webpack-stats.json
 /frontend/src/translations.json

--- a/frontend/src/components/account/ProfileForm.vue
+++ b/frontend/src/components/account/ProfileForm.vue
@@ -37,7 +37,7 @@
           </label>
           <v-autocomplete
             v-model="form.language"
-            :items="languages"
+            :items="languageStore.selectableLanguages"
             item-title="label"
             item-value="code"
             variant="outlined"
@@ -85,8 +85,7 @@
 </template>
 
 <script setup>
-import { useBusStore, useAuthStore } from '@/stores'
-import languagesApi from '@/api/languages'
+import { useBusStore, useAuthStore, useLanguageStore } from '@/stores'
 import AccountPasswordForm from '@/components/admin/identities/form_steps/AccountPasswordSubForm.vue'
 import { useGettext } from 'vue3-gettext'
 import { ref, computed, onMounted, watch } from 'vue'
@@ -95,6 +94,7 @@ import rules from '@/plugins/rules'
 const { $gettext, available } = useGettext()
 const busStore = useBusStore()
 const authStore = useAuthStore()
+const languageStore = useLanguageStore()
 
 const account = computed(() => authStore.authUser)
 
@@ -102,7 +102,6 @@ const form = ref({})
 const profileForm = ref()
 const passwordForm = ref()
 const passwordFormErrors = ref({})
-const languages = ref([])
 const panel = ref(0)
 const loadingUpdateProfile = ref(false)
 const loadingPasswordUpdate = ref(false)
@@ -157,11 +156,11 @@ async function updatePassword() {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   initFormFromAccount(account.value)
-  languagesApi.getAll().then((resp) => {
-    languages.value = resp.data
-  })
+  if (!languageStore.loaded) {
+    await languageStore.getLanguages()
+  }
 })
 
 watch(

--- a/frontend/src/components/admin/identities/form_steps/AccountProfileForm.vue
+++ b/frontend/src/components/admin/identities/form_steps/AccountProfileForm.vue
@@ -3,7 +3,7 @@
     <label class="m-label">{{ $gettext('Language') }}</label>
     <v-autocomplete
       v-model="model.language"
-      :items="languageStore.availableLanguages"
+      :items="languageStore.selectableLanguages"
       item-title="label"
       item-value="code"
       variant="outlined"

--- a/frontend/src/plugins/filters.js
+++ b/frontend/src/plugins/filters.js
@@ -1,6 +1,7 @@
 import gettext from './gettext'
 import { DateTime } from 'luxon'
 import { filesize } from 'filesize'
+import { localeToBCP47 } from '@/utils'
 
 const { $gettext } = gettext
 
@@ -11,7 +12,7 @@ export default {
     }
     app.config.globalProperties.$date = (value) => {
       return DateTime.fromISO(value)
-        .setLocale(gettext.current)
+        .setLocale(localeToBCP47(gettext.current))
         .toLocaleString(DateTime.DATETIME_MED)
     }
     app.config.globalProperties.$truncate = (value, length, clamp) => {
@@ -19,7 +20,7 @@ export default {
       return value.length > length ? value.slice(0, length) + clamp : value
     }
     app.config.globalProperties.$filesize = (value) => {
-      return filesize(value, { locale: gettext.current })
+      return filesize(value, { locale: localeToBCP47(gettext.current) })
     }
   },
 }

--- a/frontend/src/plugins/gettext.js
+++ b/frontend/src/plugins/gettext.js
@@ -21,9 +21,11 @@ const availableLanguages = {
   zh: 'Chinese',
 }
 
+export const DEFAULT_LANGUAGE = 'en'
+
 export default createGettext({
   availableLanguages,
-  defaultLanguage: 'en',
+  defaultLanguage: DEFAULT_LANGUAGE,
   translations: translations,
   silent: true, // stop warnings
 })

--- a/frontend/src/stores/auth.store.js
+++ b/frontend/src/stores/auth.store.js
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie'
 
 import { defineStore } from 'pinia'
 import { computed, inject, ref } from 'vue'
-import gettext from '@/plugins/gettext'
+import gettext, { DEFAULT_LANGUAGE } from '@/plugins/gettext'
 import { useLocale } from 'vuetify'
 import router from '@/router/index.js'
 import { UserManager } from 'oidc-client-ts'
@@ -11,7 +11,7 @@ import repository from '@/api/repository'
 import accountApi from '@/api/account'
 import accountsApi from '@/api/accounts'
 import authApi from '@/api/auth.js'
-import { getAbsoluteUrl } from '@/utils'
+import { getAbsoluteUrl, toGettextLocale } from '@/utils'
 import { useGlobalConfig } from '@/main'
 
 export const useAuthStore = defineStore('auth', () => {
@@ -42,18 +42,25 @@ export const useAuthStore = defineStore('auth', () => {
   })
 
   const accountLanguage = computed(() => {
-    if (authUser.value.language.indexOf('-') !== -1) {
-      const parts = authUser.value.language.split('-')
-      return `${parts[0]}_${parts[1].toUpperCase()}`
-    }
-    return authUser.value.language
+    return toGettextLocale(authUser.value.language)
   })
+
+  function applyLanguage() {
+    // Only switch to locales vue3-gettext actually knows about, falling
+    // back to the default language otherwise so we never select an
+    // unsupported locale.
+    const locale =
+      accountLanguage.value in gettext.available
+        ? accountLanguage.value
+        : DEFAULT_LANGUAGE
+    gettext.current = locale
+    current.value = locale
+  }
 
   async function fetchUser() {
     const resp = await accountApi.getMe()
     authUser.value = resp.data
-    gettext.current = accountLanguage.value
-    current.value = accountLanguage.value
+    applyLanguage()
     isAuthenticated.value = true
   }
 
@@ -163,10 +170,7 @@ export const useAuthStore = defineStore('auth', () => {
       const newAuthUser = { ...authUser.value, ...response.data }
       delete newAuthUser.password
       authUser.value = { ...newAuthUser }
-      if (accountLanguage.value in gettext.available) {
-        gettext.current = accountLanguage.value
-        current.value = accountLanguage.value
-      }
+      applyLanguage()
     })
   }
 

--- a/frontend/src/stores/language.store.js
+++ b/frontend/src/stores/language.store.js
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import languagesApi from '@/api/languages'
+import gettext, { DEFAULT_LANGUAGE } from '@/plugins/gettext'
+import { languageHasCoverage } from '@/utils'
 
 export const useLanguageStore = defineStore('language', () => {
   const availableLanguages = ref([])
@@ -17,6 +19,19 @@ export const useLanguageStore = defineStore('language', () => {
     loaded.value = true
   }
 
+  // Whether a backend language code has actual UI coverage. The source
+  // language (English) needs no translations and is always available.
+  const hasTranslation = (languageCode) =>
+    languageHasCoverage(gettext.translations, languageCode, DEFAULT_LANGUAGE)
+
+  // Languages offered in selectors: only those that are actually
+  // translated, so users aren't shown 0%-coverage languages that would
+  // just fall back to English. The full list (availableLanguages) is
+  // kept for label resolution of existing values.
+  const selectableLanguages = computed(() =>
+    availableLanguages.value.filter((item) => hasTranslation(item.code))
+  )
+
   const getLanguageLabel = (languageCode) => {
     const language = availableLanguages.value.find(
       (item) => item.code === languageCode
@@ -26,8 +41,10 @@ export const useLanguageStore = defineStore('language', () => {
 
   return {
     availableLanguages,
+    selectableLanguages,
     getLanguages,
     getLanguageLabel,
+    hasTranslation,
     loaded,
     $reset,
   }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -5,4 +5,16 @@ function getAbsoluteUrl(url) {
   return url
 }
 
-export { getAbsoluteUrl }
+/**
+ * Convert an internal gettext locale code to a BCP 47 language tag.
+ *
+ * vue3-gettext uses locale identifiers such as `pt_BR` (with an
+ * underscore), while the `Intl` API (used by luxon and filesize) only
+ * accepts BCP 47 tags such as `pt-BR`. Passing an underscore form to
+ * `Intl` throws a `RangeError`, which crashes component rendering.
+ */
+function localeToBCP47(locale) {
+  return locale ? locale.replace(/_/g, '-') : locale
+}
+
+export { getAbsoluteUrl, localeToBCP47 }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -50,4 +50,19 @@ function toGettextLocale(code) {
   return code
 }
 
-export { getAbsoluteUrl, localeToBCP47, toGettextLocale }
+/**
+ * Whether a backend language code has actual UI coverage.
+ *
+ * A language is considered covered when the compiled gettext
+ * `translations` object has a non-empty entry for its locale. The source
+ * language needs no translations and is always considered covered.
+ */
+function languageHasCoverage(translations, code, sourceLanguage) {
+  if (code === sourceLanguage) {
+    return true
+  }
+  const messages = translations[toGettextLocale(code)]
+  return !!messages && Object.keys(messages).length > 0
+}
+
+export { getAbsoluteUrl, localeToBCP47, toGettextLocale, languageHasCoverage }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -17,4 +17,37 @@ function localeToBCP47(locale) {
   return locale ? locale.replace(/_/g, '-') : locale
 }
 
-export { getAbsoluteUrl, localeToBCP47 }
+/**
+ * Backend language codes that do not follow the generic
+ * `xx-yy` -> `xx_YY` rule when mapped to the frontend locale.
+ */
+const LANGUAGE_CODE_ALIASES = {
+  'zh-hant': 'zh',
+}
+
+/**
+ * Map a backend language code to the locale identifier used by
+ * vue3-gettext.
+ *
+ * The backend (`modoboa/core/constants.py`) serves codes such as
+ * `pt-br` or `zh-hant`, while vue3-gettext expects keys such as `pt_BR`
+ * or `zh`. The generic rule turns `xx-yy` into `xx_YY`; aliases handle
+ * the cases that rule gets wrong (e.g. `zh-hant`, which must map to the
+ * existing `zh` locale instead of a non-existent `zh_HANT`).
+ */
+function toGettextLocale(code) {
+  if (!code) {
+    return code
+  }
+  const alias = LANGUAGE_CODE_ALIASES[code.toLowerCase()]
+  if (alias) {
+    return alias
+  }
+  if (code.includes('-')) {
+    const [language, region] = code.split('-')
+    return `${language}_${region.toUpperCase()}`
+  }
+  return code
+}
+
+export { getAbsoluteUrl, localeToBCP47, toGettextLocale }

--- a/modoboa/core/migrations/0031_normalize_legacy_language_codes.py
+++ b/modoboa/core/migrations/0031_normalize_legacy_language_codes.py
@@ -1,0 +1,46 @@
+"""Normalize legacy language codes stored on user profiles.
+
+Migration 0027 changed the language *choices* (e.g. ``pt_BR`` -> ``pt-br``)
+but never migrated the values already stored in the database. Those stale
+codes don't match Django's locale names, so the ``Accept-Language`` header
+the frontend forwards is ignored and the UI/API falls back to English.
+
+This data migration maps every legacy code to its current equivalent.
+"""
+
+from django.db import migrations
+
+# Old (stored) code -> current code in modoboa.core.constants.LANGUAGES.
+LEGACY_LANGUAGE_CODES = {
+    "el_GR": "el",
+    "ja_JP": "ja",
+    "pl_PL": "pl",
+    "pt_BR": "pt-br",
+    "pt_PT": "pt",
+    "ro_RO": "ro",
+    "tr_TR": "tr",
+    "zh_TW": "zh-hant",
+}
+
+
+def normalize_language_codes(apps, schema_editor):
+    User = apps.get_model("core", "User")
+    for old_code, new_code in LEGACY_LANGUAGE_CODES.items():
+        User.objects.filter(language=old_code).update(language=new_code)
+
+
+def revert_language_codes(apps, schema_editor):
+    User = apps.get_model("core", "User")
+    for old_code, new_code in LEGACY_LANGUAGE_CODES.items():
+        User.objects.filter(language=new_code).update(language=old_code)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0030_alter_user_managers"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_language_codes, revert_language_codes),
+    ]

--- a/modoboa/webmail/serializers.py
+++ b/modoboa/webmail/serializers.py
@@ -91,7 +91,9 @@ class UserMailboxesSerializer(serializers.Serializer):
 class UserMailboxInputSerializer(serializers.Serializer):
 
     name = serializers.CharField()
-    parent_mailbox = serializers.CharField(required=False)
+    # Top-level folders send an empty parent: accept it (treated as "no
+    # parent" by the viewsets) instead of rejecting it as blank.
+    parent_mailbox = serializers.CharField(required=False, allow_blank=True)
 
 
 class UserMailboxUpdateSerializer(UserMailboxInputSerializer):

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -128,6 +128,12 @@ class UserMailboxViewSetTestCase(WebmailTestCase):
         response = self.client.post(url, body, format="json")
         self.assertEqual(response.status_code, 200)
 
+        # Top-level folders send an empty parent_mailbox: it must not be
+        # rejected as blank.
+        body = {"name": "Test renamed", "oldname": "Test", "parent_mailbox": ""}
+        response = self.client.post(url, body, format="json")
+        self.assertEqual(response.status_code, 200)
+
     def test_compress(self):
         self.authenticate()
         url = reverse("v2:webmail-mailbox-compress")

--- a/modoboa/webmail/viewsets.py
+++ b/modoboa/webmail/viewsets.py
@@ -91,7 +91,7 @@ class UserMailboxViewSet(viewsets.GenericViewSet):
         with lib.get_imapconnector(request) as imapc:
             imapc.create_folder(
                 serializer.validated_data["name"],
-                serializer.validated_data.get("parent_mailbox"),
+                serializer.validated_data.get("parent_mailbox") or None,
             )
         return response.Response(serializer.validated_data, status=201)
 
@@ -104,7 +104,7 @@ class UserMailboxViewSet(viewsets.GenericViewSet):
                 serializer.validated_data["oldname"], sep=imapc.hdelimiter
             )
             name = serializer.validated_data["name"]
-            parent = serializer.validated_data.get("parent_mailbox")
+            parent = serializer.validated_data.get("parent_mailbox") or None
             if name != oldname or parent != oldparent:
                 newname = (
                     name if parent is None else imapc.hdelimiter.join([parent, name])


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR batches multiple bug fixes and enhancements related to the internationalization (i18n) core of Modoboa, fixing crashes, missing mappings, and improving the language selector UI.

**Current behavior before PR:**
1. The Brazilian Portuguese translation contained rendering breaks due to unescaped characters in the locale files.
2. Traditional Chinese (`zh-hant`) failed to map correctly to its Vue/Django locale counterpart, causing translation files to not load.
3. The frontend `translations.json` dictionary was out of sync with the actual `.po` source files, displaying stale or missing strings.
4. Legacy language codes left over in user database profiles (or an empty `parent_mailbox` during folder renaming) caused HTTP 500 crashes.
5. The login language selector displayed dozens of empty/untranslated languages (0% coverage), confusing users.

**Desired behavior after PR is merged:**
1. PT-BR renders correctly without breaking the Vue layout.
2. The Chinese mapping (`zh-hant`) works perfectly across both the backend and frontend components.
3. `translations.json` is perfectly resynced with the official `.po` sources.
4. Legacy user languages trigger a graceful fallback and `parent_mailbox` operations are handled safely.
5. Languages with 0% translation coverage are hidden from the UI selector, presenting a cleaner and more professional list of supported languages to the end-users.

---

*removed: yarn-error.log