### PR TITLE
feat(admin): add account bulk delete API endpoint

### DIFF
--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -32,4 +32,7 @@ export default {
   delete(accountId, data) {
     return repository.post(`${resource}/${accountId}/delete/`, data)
   },
+  bulkDelete(data) {
+    return repository.post(`${resource}/bulk_delete/`, data)
+  },
 }

--- a/frontend/src/components/admin/identities/IdentityList.vue
+++ b/frontend/src/components/admin/identities/IdentityList.vue
@@ -462,7 +462,7 @@ function getMenuItems(item) {
 
 function getActionMenuItems() {
   const result = []
-  if (selected.value.length > 0) {
+  if (selected.value.length > 0 && identityType.value === 'account') {
     result.push({
       label: $gettext('Delete'),
       icon: 'mdi-delete-outline',
@@ -515,7 +515,31 @@ function editAlias(alias) {
   router.push({ name: 'AliasEdit', params: { id: alias.pk } })
 }
 
-function deleteIdentities() {}
+async function deleteIdentities() {
+  const result = await confirmAccount.value.open(
+    $gettext('Warning'),
+    $gettext('Are you sure you want to delete the selected accounts?'),
+    {
+      color: 'error',
+      agreeLabel: $gettext('Yes'),
+      cancelLabel: $gettext('No'),
+    }
+  )
+  if (!result) {
+    return
+  }
+  loading.value = true
+  try {
+    await accountsApi.bulkDelete({
+      ids: selected.value,
+      keepdir: keepAccountFolder.value,
+    })
+    displayNotification({ msg: $gettext('Accounts deleted') })
+    fetchIdentities()
+  } finally {
+    loading.value = false
+  }
+}
 
 async function deleteAlias(alias) {
   const result = await confirmAlias.value.open(

--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -771,6 +771,13 @@ class DeleteAccountSerializer(serializers.Serializer):
     keepdir = serializers.BooleanField(default=False)
 
 
+class AccountBulkDeleteSerializer(serializers.Serializer):
+    """Serializer used with bulk delete operation."""
+
+    ids = serializers.ListField(child=serializers.IntegerField(), allow_empty=False)
+    keepdir = serializers.BooleanField(default=False)
+
+
 class AliasSerializer(v1_serializers.AliasSerializer):
     """Alias serializer for v2 API."""
 

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -374,6 +374,72 @@ class AccountViewSetTestCase(ModoAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_bulk_delete(self):
+        url = reverse("v2:account-bulk-delete")
+
+        # Invalid input
+        resp = self.client.post(url, {}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.post(url, {"ids": []}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.post(url, {"ids": ["toto"]}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+        # Valid request
+        accounts = core_models.User.objects.filter(
+            username__in=["user@test.com", "admin@test.com"]
+        )
+        ids = list(accounts.values_list("pk", flat=True))
+        resp = self.client.post(url, {"ids": ids}, format="json")
+        self.assertEqual(resp.status_code, 204)
+        self.assertFalse(core_models.User.objects.filter(pk__in=ids).exists())
+        # Check if self aliases have been deleted
+        self.assertFalse(
+            models.AliasRecipient.objects.select_related("alias")
+            .filter(
+                alias__address="user@test.com",
+                address="user@test.com",
+                alias__internal=True,
+            )
+            .exists()
+        )
+
+    def test_bulk_delete_own_account(self):
+        sadmin = core_models.User.objects.get(username="admin")
+        account = core_models.User.objects.get(username="user@test.com")
+        url = reverse("v2:account-bulk-delete")
+        resp = self.client.post(url, {"ids": [sadmin.pk, account.pk]}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        # No account must have been deleted
+        self.assertTrue(core_models.User.objects.filter(pk=account.pk).exists())
+
+    def test_bulk_delete_permissions(self):
+        admin = core_models.User.objects.get(username="admin@test.com")
+        self.authenticate_user(admin)
+        url = reverse("v2:account-bulk-delete")
+
+        # Try to delete an account not owned by the connected domain admin
+        forbidden_account = core_models.User.objects.get(username="user@test2.com")
+        owned_account = core_models.User.objects.get(username="user@test.com")
+        resp = self.client.post(
+            url,
+            {"ids": [owned_account.pk, forbidden_account.pk]},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 404)
+        # No account must have been deleted
+        self.assertTrue(
+            core_models.User.objects.filter(
+                pk__in=[owned_account.pk, forbidden_account.pk]
+            ).count()
+            == 2
+        )
+
+        # Now delete an owned account
+        resp = self.client.post(url, {"ids": [owned_account.pk]}, format="json")
+        self.assertEqual(resp.status_code, 204)
+        self.assertFalse(core_models.User.objects.filter(pk=owned_account.pk).exists())
+
     def test_update(self):
         account = core_models.User.objects.get(username="user@test.com")
         url = reverse("v2:account-detail", args=[account.pk])

--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -193,6 +193,8 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
             return serializers.WritableAccountSerializer
         if self.action == "delete":
             return serializers.DeleteAccountSerializer
+        if self.action == "bulk_delete":
+            return serializers.AccountBulkDeleteSerializer
         if self.action in ["list", "retrieve"]:
             return serializers.AccountSerializer
         return super().get_serializer_class()
@@ -231,6 +233,24 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         account.delete()
+        return response.Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(methods=["post"], detail=False)
+    def bulk_delete(self, request, **kwargs):
+        """Delete multiple accounts at the same time."""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        ids = serializer.validated_data["ids"]
+        if request.user.pk in ids:
+            return response.Response(
+                {"ids": [_("You can't delete your own account")]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        accounts = self.get_queryset().filter(pk__in=ids)
+        if accounts.count() != len(set(ids)):
+            return response.Response(status=status.HTTP_404_NOT_FOUND)
+        for account in accounts:
+            account.delete()
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
Add a bulk_delete action to the v2 AccountViewSet and wire the existing (empty) bulk delete action of the identities list to it. Requested ids are checked against the accounts the connected user can access: nothing is deleted if at least one account is out of scope. Self-deletion is rejected.
