### PR TITLE
feat(core,admin,webmail): add doveadm HTTP API support

### DIFF
--- a/doc-ng/configuration.md
+++ b/doc-ng/configuration.md
@@ -48,10 +48,14 @@ If Dovecot is not running on the same host than Modoboa, you will have
 to define which password schemes are supported.
 
 To do so, open the `settings.py` file and add a `DOVECOT_SUPPORTED_SCHEMES`
-variable with the output of the command:
+variable with the output of the command (run on the Dovecot host):
 ```shell
 $ doveadm pw -l
 ```
+
+In this situation, you can also tell Modoboa to communicate with the
+remote Dovecot server through the
+[doveadm HTTP API](/installation/dovecot#doveadm_http_api).
 :::
 
 ::: info
@@ -123,7 +127,10 @@ Then, edit the `config.json` file located in this very same directory and add th
 ::: tip
 This section is only relevant when Modoboa handles mailboxes renaming
 and removal from the filesystem,
-which requires that Dovecot is installed and running on this host.
+which requires that Dovecot is installed and running on this host
+(ie. `DOVECOT_OPERATION_MODE` is not set or set to `'cmd'`). These
+operations are not available when the
+[doveadm HTTP API](/installation/dovecot#doveadm_http_api) is used.
 
 If it is installed at a non-standard directory,
 paths to its binaries can be set in the `settings.py` file

--- a/doc-ng/installation/dovecot.md
+++ b/doc-ng/installation/dovecot.md
@@ -87,6 +87,13 @@ For dovecot 2.0 and older, use the [autocreate](http://wiki2.dovecot.org/Plugins
 ### Operations on the file system {#fs_operations}
 
 ::: warning
+This section only applies when Dovecot runs on the same host than
+Modoboa (ie. `DOVECOT_OPERATION_MODE` is not set or set to `'cmd'`). If
+Dovecot runs on a different host, see the
+[doveadm HTTP API](#doveadm_http_api) section.
+:::
+
+::: warning
 Modoboa needs to access the `dovecot` binary to check its version. To
 find the binary path, we use the `which` command first and then try
 known locations (`/usr/sbin/dovecot`  and
@@ -140,6 +147,74 @@ instance.
 The result of each order is recorded into Modoboa's log. 
 
 Go to *Modoboa > Logs* to consult them.
+
+## Remote Dovecot: doveadm HTTP API {#doveadm_http_api}
+
+By default, Modoboa uses the `doveadm` command line tool for some
+operations (mailbox location retrieval, scheduled messages handling,
+supported password schemes discovery), which requires Dovecot to be
+installed on the same host.
+
+If Dovecot runs on a different host, Modoboa can use the
+[doveadm HTTP API](https://doc.dovecot.org/admin_manual/doveadm_http_api/)
+instead.
+
+### Dovecot configuration
+
+Enable the HTTP listener of the doveadm service and define an API key:
+
+```txt
+service doveadm {
+  inet_listener http {
+    port = 8080
+    # ssl = yes  # uncomment to enable TLS (recommended)
+  }
+}
+
+doveadm_api_key = <a strong random key>
+```
+
+::: warning
+The API key is sent with every request. Restrict access to the listener
+(firewall) and enable TLS if requests transit over an untrusted network.
+:::
+
+### Modoboa configuration
+
+Add the following variables to `settings.py`:
+
+``` python
+DOVECOT_OPERATION_MODE = 'rest'
+DOVEADM_API_URL = 'https://<dovecot_host>:8080/doveadm/v1'
+DOVEADM_API_KEY = '<same key than doveadm_api_key>'
+# Optional, request timeout in seconds (defaults to 10)
+DOVEADM_API_TIMEOUT = 10
+```
+
+Since `doveadm pw` is not available through the HTTP API, you must also
+define the list of supported password schemes manually. Run the
+following command on the Dovecot host:
+
+```shell
+$ doveadm pw -l
+```
+
+and copy its output into the `DOVECOT_SUPPORTED_SCHEMES` variable:
+
+``` python
+DOVECOT_SUPPORTED_SCHEMES = 'SHA512-CRYPT SHA256-CRYPT BLF-CRYPT ARGON2ID'
+```
+
+### Limitations
+
+* [Operations on the file system](#fs_operations) (mailbox renaming and
+  deletion) are not available in this mode since Modoboa can't access
+  the file system where the mailboxes are stored: renaming or removing
+  a mailbox within Modoboa won't modify the corresponding directories,
+  even if the *Handle mailboxes on filesystem* parameter is enabled.
+  The `handle_mailbox_operations` cron script is not needed.
+* Supported password schemes can't be discovered automatically, see
+  above.
 
 ## Authentication
 

--- a/doc-ng/installation/upgrade.md
+++ b/doc-ng/installation/upgrade.md
@@ -167,6 +167,30 @@ credential document or IMAP migration is created: data encrypted with
 the previous key cannot be decrypted anymore once the key changes.
 :::
 
+### Optional: use the doveadm HTTP API instead of the doveadm binary
+
+Until now, Modoboa used the `doveadm` command line tool for some
+operations (mailbox location retrieval, scheduled messages handling),
+which required Dovecot to be installed on the same host.
+
+If Dovecot runs on a different host, you can now tell Modoboa to use
+the [doveadm HTTP API](https://doc.dovecot.org/admin_manual/doveadm_http_api/)
+instead by adding the following variables to `settings.py`:
+
+``` python
+DOVECOT_OPERATION_MODE = 'rest'
+DOVEADM_API_URL = 'https://<dovecot_host>:8080/doveadm/v1'
+DOVEADM_API_KEY = '<value of the doveadm_api_key Dovecot setting>'
+# Optional, request timeout in seconds (defaults to 10)
+DOVEADM_API_TIMEOUT = 10
+```
+
+The default mode (`'cmd'`, the local `doveadm` binary) remains unchanged:
+if you don't add anything, your installation will keep working as before.
+
+See the [Dovecot documentation page](/installation/dovecot#doveadm_http_api)
+for the required Dovecot configuration and the limitations of this mode.
+
 ## 2.9.0
 
 ### Required changes to `settings.py`

--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy
 
+from modoboa.lib import dovecot
 from modoboa.lib.sysutils import exec_cmd
 
 
@@ -298,6 +299,10 @@ GLOBAL_PARAMETERS_STRUCT = collections.OrderedDict(
 
 def init_structure() -> dict:
     structure = copy.deepcopy(GLOBAL_PARAMETERS_STRUCT)
+    if dovecot.get_dovecot_operation_mode() != dovecot.DOVECOT_OPERATION_MODE_CMD:
+        # Dovecot is reached through its HTTP API: it doesn't need to be
+        # installed locally.
+        return structure
     hide_fields = False
     dpath = None
     code, output = exec_cmd(["which", "dovecot"])

--- a/modoboa/admin/models/mailbox.py
+++ b/modoboa/admin/models/mailbox.py
@@ -6,13 +6,13 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import Q
 from django.db.models.manager import Manager
-from django.utils.encoding import smart_str, force_str
+from django.utils.encoding import smart_str
 from django.utils.translation import gettext as _, gettext_lazy
 
 from modoboa.core.models import User
 from modoboa.lib import exceptions as lib_exceptions
+from modoboa.lib import dovecot
 from modoboa.lib.email_utils import split_mailbox
-from modoboa.lib.sysutils import doveadm_cmd
 from modoboa.parameters import tools as param_tools
 
 from .base import AdminObject
@@ -147,12 +147,14 @@ class Mailbox(mixins.MessageLimitMixin, AdminObject):
         if not admin_params.get("handle_mailboxes"):
             return None
         if self.__mail_home is None:
-            code, output = doveadm_cmd(["user", "-f", "home", self.full_address])
-            if code:
-                raise lib_exceptions.InternalError(
-                    _("Failed to retrieve mailbox location (%s)") % output
+            try:
+                self.__mail_home = dovecot.get_dovecot_backend().get_user_home(
+                    self.full_address
                 )
-            self.__mail_home = force_str(output.strip())
+            except dovecot.DoveadmError as err:
+                raise lib_exceptions.InternalError(
+                    _("Failed to retrieve mailbox location (%s)") % err
+                ) from err
         return self.__mail_home
 
     @property
@@ -192,6 +194,9 @@ class Mailbox(mixins.MessageLimitMixin, AdminObject):
         hm = param_tools.get_global_parameter("handle_mailboxes", raise_exception=False)
         if not hm:
             return
+        if dovecot.get_dovecot_operation_mode() != dovecot.DOVECOT_OPERATION_MODE_CMD:
+            # Dovecot lives on another host, we can't touch the filesystem
+            return
         MailboxOperation.objects.create(
             mailbox=self, type="rename", argument=old_mail_home
         )
@@ -222,6 +227,9 @@ class Mailbox(mixins.MessageLimitMixin, AdminObject):
     def delete_dir(self):
         hm = param_tools.get_global_parameter("handle_mailboxes", raise_exception=False)
         if not hm:
+            return
+        if dovecot.get_dovecot_operation_mode() != dovecot.DOVECOT_OPERATION_MODE_CMD:
+            # Dovecot lives on another host, we can't touch the filesystem
             return
         MailboxOperation.objects.create(type="delete", argument=self.mail_home)
 

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -277,6 +277,16 @@ SPECTACULAR_SETTINGS = {
 
 # DOVECOT_USER = 'vmail'
 
+# Dovecot access mode: 'cmd' (local doveadm binary, default) or 'rest'
+# (doveadm HTTP API, allows Dovecot to run on a different host).
+# When using 'rest', DOVEADM_API_URL and DOVEADM_API_KEY are required and
+# DOVECOT_SUPPORTED_SCHEMES should be defined ('doveadm pw' is not
+# available through the HTTP API).
+#DOVECOT_OPERATION_MODE = 'rest'
+#DOVEADM_API_URL = 'https://imap.example.com:8080/doveadm/v1'
+#DOVEADM_API_KEY = 'secret'
+#DOVEADM_API_TIMEOUT = 10
+
 MODOBOA_API_URL = 'https://api.modoboa.org/1/'
 
 DISABLE_DASHBOARD_EXTERNAL_QUERIES = False

--- a/modoboa/core/password_hashers/utils.py
+++ b/modoboa/core/password_hashers/utils.py
@@ -9,7 +9,7 @@ from modoboa.admin.constants import ALARM_CLOSED, ALARM_OPENED
 
 from modoboa.core.constants import DOVEADM_PASS_SCHEME_ALARM
 
-from modoboa.lib.sysutils import doveadm_cmd
+from modoboa.lib import dovecot
 
 from .base import PasswordHasher
 
@@ -21,6 +21,11 @@ def get_dovecot_schemes():
     doveadm output, and fallback to {MD5-CRYPT} and {PLAIN} if the command
     is not found.
 
+    When the doveadm HTTP API is used (DOVECOT_OPERATION_MODE = "rest"),
+    schemes can't be retrieved remotely ('doveadm pw' is a local command)
+    so the DOVECOT_SUPPORTED_SCHEMES setting should be defined. Otherwise,
+    default schemes are used (without opening an alarm).
+
     :return: A tuple with [0] : a list of supported '{SCHEME}'
     [1] : the status (0=actual schemes, 1=settings schemes, 2=default schemes)
     """
@@ -29,13 +34,14 @@ def get_dovecot_schemes():
     status = 1
 
     if not schemes:
-        try:
-            retcode, schemes = doveadm_cmd(["pw", "-l"])
-        except OSError:
+        if dovecot.get_dovecot_operation_mode() != dovecot.DOVECOT_OPERATION_MODE_CMD:
+            # Not available through the HTTP API: fallback to default
+            # schemes without raising an alarm.
             schemes = default_schemes
-            status = 2
         else:
-            if retcode:
+            try:
+                schemes = dovecot.get_dovecot_backend().list_password_schemes()
+            except dovecot.DoveadmError:
                 schemes = default_schemes
                 status = 2
             else:

--- a/modoboa/lib/dovecot.py
+++ b/modoboa/lib/dovecot.py
@@ -1,0 +1,214 @@
+"""Dovecot access layer.
+
+This module provides a small abstraction over the different ways to
+communicate with Dovecot:
+
+* ``cmd``: through the ``doveadm`` command line tool (default). It
+  requires Dovecot to be installed on the same host than Modoboa.
+* ``rest``: through the doveadm HTTP API. It allows Modoboa to manage a
+  Dovecot server running on a different host.
+
+The mode is controlled by the ``DOVECOT_OPERATION_MODE`` Django setting
+(``"cmd"`` or ``"rest"``). The ``rest`` mode requires the following
+additional settings:
+
+* ``DOVEADM_API_URL``: url of the doveadm HTTP endpoint
+  (eg. ``https://imap.example.com:8080/doveadm/v1``)
+* ``DOVEADM_API_KEY``: value of the ``doveadm_api_key`` setting defined
+  in the Dovecot configuration
+* ``DOVEADM_API_TIMEOUT``: optional, request timeout in seconds
+  (defaults to 10)
+"""
+
+import base64
+
+from django.conf import settings
+from django.utils.encoding import force_str
+
+import requests
+
+from modoboa.lib.sysutils import doveadm_cmd
+
+DOVECOT_OPERATION_MODE_CMD = "cmd"
+DOVECOT_OPERATION_MODE_REST = "rest"
+
+
+class DoveadmError(Exception):
+    """Raised when a doveadm operation fails, whatever the backend."""
+
+
+class DoveadmCmdBackend:
+    """Talk to Dovecot using the doveadm command line tool."""
+
+    def get_user_home(self, address: str) -> str:
+        """Return the home directory of the given user."""
+        try:
+            code, output = doveadm_cmd(["user", "-f", "home", address])
+        except OSError as err:
+            raise DoveadmError(str(err)) from err
+        if code:
+            raise DoveadmError(force_str(output))
+        return force_str(output).strip()
+
+    def move_message(
+        self,
+        user: str,
+        destination: str,
+        source_mailbox: str,
+        header_name: str,
+        header_value: str,
+    ) -> None:
+        """Move message(s) matching the given header to destination."""
+        try:
+            code, output = doveadm_cmd(
+                [
+                    "move",
+                    "-u",
+                    user,
+                    destination,
+                    "mailbox",
+                    source_mailbox,
+                    "header",
+                    header_name,
+                    header_value,
+                ]
+            )
+        except OSError as err:
+            raise DoveadmError(str(err)) from err
+        if code:
+            raise DoveadmError(force_str(output))
+
+    def delete_mailbox_if_empty(self, user: str, mailbox: str) -> None:
+        """Delete the given mailbox if it is empty. Best effort."""
+        try:
+            doveadm_cmd(["mailbox", "delete", "-u", user, "-s", "-e", mailbox])
+        except OSError as err:
+            raise DoveadmError(str(err)) from err
+
+    def list_password_schemes(self) -> str:
+        """Return password schemes supported by Dovecot."""
+        try:
+            code, output = doveadm_cmd(["pw", "-l"])
+        except OSError as err:
+            raise DoveadmError(str(err)) from err
+        if code:
+            raise DoveadmError(force_str(output))
+        return force_str(output)
+
+
+class DoveadmHTTPBackend:
+    """Talk to Dovecot using the doveadm HTTP API."""
+
+    def __init__(self):
+        self.url = getattr(settings, "DOVEADM_API_URL", None)
+        if not self.url:
+            raise DoveadmError(
+                "DOVEADM_API_URL setting is required when "
+                "DOVECOT_OPERATION_MODE is set to 'rest'"
+            )
+        self.api_key = getattr(settings, "DOVEADM_API_KEY", None)
+        if not self.api_key:
+            raise DoveadmError(
+                "DOVEADM_API_KEY setting is required when "
+                "DOVECOT_OPERATION_MODE is set to 'rest'"
+            )
+        self.timeout = getattr(settings, "DOVEADM_API_TIMEOUT", 10)
+
+    def _run_command(self, name: str, parameters: dict) -> list:
+        """Run a doveadm command through the HTTP API.
+
+        The API expects a list of commands ([name, parameters, tag]) and
+        returns a list of responses ([type, data, tag]).
+        """
+        token = base64.b64encode(self.api_key.encode()).decode()
+        headers = {
+            "Authorization": f"X-Dovecot-API {token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            response = requests.post(
+                self.url,
+                json=[[name, parameters, "c1"]],
+                headers=headers,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            content = response.json()
+        except (requests.RequestException, ValueError) as err:
+            raise DoveadmError(f"doveadm HTTP API request failed: {err}") from err
+        try:
+            rtype, data = content[0][0], content[0][1]
+        except (IndexError, TypeError) as err:
+            raise DoveadmError(
+                f"unexpected response from doveadm HTTP API: {content}"
+            ) from err
+        if rtype == "error":
+            raise DoveadmError(f"doveadm command {name} failed: {data}")
+        return data
+
+    def get_user_home(self, address: str) -> str:
+        data = self._run_command("user", {"userMask": [address]})
+        # Response is a list of userdb field dicts, possibly keyed by
+        # user name depending on the Dovecot version.
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            if "home" in entry:
+                return entry["home"]
+            for value in entry.values():
+                if isinstance(value, dict) and "home" in value:
+                    return value["home"]
+        raise DoveadmError(f"failed to retrieve home directory of {address}")
+
+    def move_message(
+        self,
+        user: str,
+        destination: str,
+        source_mailbox: str,
+        header_name: str,
+        header_value: str,
+    ) -> None:
+        self._run_command(
+            "move",
+            {
+                "user": user,
+                "destinationMailbox": destination,
+                "query": [
+                    "mailbox",
+                    source_mailbox,
+                    "header",
+                    header_name,
+                    header_value,
+                ],
+            },
+        )
+
+    def delete_mailbox_if_empty(self, user: str, mailbox: str) -> None:
+        self._run_command(
+            "mailboxDelete",
+            {
+                "user": user,
+                "mailbox": [mailbox],
+                "requireEmpty": True,
+                "subscriptions": True,
+            },
+        )
+
+    def list_password_schemes(self) -> str:
+        # 'doveadm pw' is a local command, not exposed through the HTTP
+        # API. Use the DOVECOT_SUPPORTED_SCHEMES setting instead.
+        raise DoveadmError(
+            "listing password schemes is not supported by the doveadm HTTP API"
+        )
+
+
+def get_dovecot_operation_mode() -> str:
+    """Return the configured operation mode."""
+    return getattr(settings, "DOVECOT_OPERATION_MODE", DOVECOT_OPERATION_MODE_CMD)
+
+
+def get_dovecot_backend():
+    """Return a backend instance according to DOVECOT_OPERATION_MODE."""
+    if get_dovecot_operation_mode() == DOVECOT_OPERATION_MODE_REST:
+        return DoveadmHTTPBackend()
+    return DoveadmCmdBackend()

--- a/modoboa/lib/tests/test_dovecot.py
+++ b/modoboa/lib/tests/test_dovecot.py
@@ -222,6 +222,10 @@ class RestModeSchemesTestCase(TestCase):
         from modoboa.core.constants import DOVEADM_PASS_SCHEME_ALARM
         from modoboa.core.password_hashers.utils import get_dovecot_schemes
 
+        # An alarm may have been opened before this test runs (ie. if
+        # doveadm is not installed): get rid of it since we want to
+        # check that the call below doesn't create one.
+        Alarm.objects.filter(internal_name=DOVEADM_PASS_SCHEME_ALARM).delete()
         schemes, status = get_dovecot_schemes()
         self.assertEqual(schemes, ["{MD5-CRYPT}", "{PLAIN}"])
         self.assertEqual(status, 1)

--- a/modoboa/lib/tests/test_dovecot.py
+++ b/modoboa/lib/tests/test_dovecot.py
@@ -1,0 +1,241 @@
+"""Tests for the dovecot access layer."""
+
+from unittest import mock
+
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from modoboa.lib import dovecot
+
+REST_SETTINGS = {
+    "DOVECOT_OPERATION_MODE": "rest",
+    "DOVEADM_API_URL": "https://imap.example.com:8080/doveadm/v1",
+    "DOVEADM_API_KEY": "secret",
+}
+
+
+def http_response(payload, status_code=200):
+    response = mock.Mock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+class FactoryTestCase(SimpleTestCase):
+    def test_default_mode(self):
+        self.assertEqual(dovecot.get_dovecot_operation_mode(), "cmd")
+        self.assertIsInstance(dovecot.get_dovecot_backend(), dovecot.DoveadmCmdBackend)
+
+    @override_settings(**REST_SETTINGS)
+    def test_rest_mode(self):
+        self.assertIsInstance(dovecot.get_dovecot_backend(), dovecot.DoveadmHTTPBackend)
+
+    @override_settings(DOVECOT_OPERATION_MODE="rest")
+    def test_rest_mode_missing_settings(self):
+        with self.assertRaises(dovecot.DoveadmError):
+            dovecot.get_dovecot_backend()
+
+    @override_settings(DOVECOT_OPERATION_MODE="rest", DOVEADM_API_URL="http://url")
+    def test_rest_mode_missing_api_key(self):
+        with self.assertRaises(dovecot.DoveadmError):
+            dovecot.get_dovecot_backend()
+
+
+class DoveadmCmdBackendTestCase(SimpleTestCase):
+    def setUp(self):
+        self.backend = dovecot.DoveadmCmdBackend()
+
+    @mock.patch("modoboa.lib.dovecot.doveadm_cmd")
+    def test_get_user_home(self, doveadm_cmd_mock):
+        doveadm_cmd_mock.return_value = (0, b"/srv/vmail/domain/user\n")
+        self.assertEqual(
+            self.backend.get_user_home("user@domain"), "/srv/vmail/domain/user"
+        )
+        doveadm_cmd_mock.assert_called_with(["user", "-f", "home", "user@domain"])
+
+    @mock.patch("modoboa.lib.dovecot.doveadm_cmd")
+    def test_get_user_home_failure(self, doveadm_cmd_mock):
+        doveadm_cmd_mock.return_value = (68, b"user not found")
+        with self.assertRaises(dovecot.DoveadmError):
+            self.backend.get_user_home("user@domain")
+        doveadm_cmd_mock.side_effect = OSError("doveadm command not found")
+        with self.assertRaises(dovecot.DoveadmError):
+            self.backend.get_user_home("user@domain")
+
+    @mock.patch("modoboa.lib.dovecot.doveadm_cmd")
+    def test_move_message(self, doveadm_cmd_mock):
+        doveadm_cmd_mock.return_value = (0, b"")
+        self.backend.move_message("user@domain", "Sent", "Scheduled", "X-Hdr", "12")
+        doveadm_cmd_mock.assert_called_with(
+            [
+                "move",
+                "-u",
+                "user@domain",
+                "Sent",
+                "mailbox",
+                "Scheduled",
+                "header",
+                "X-Hdr",
+                "12",
+            ]
+        )
+        doveadm_cmd_mock.return_value = (75, b"error")
+        with self.assertRaises(dovecot.DoveadmError):
+            self.backend.move_message("user@domain", "Sent", "Scheduled", "X-Hdr", "12")
+
+    @mock.patch("modoboa.lib.dovecot.doveadm_cmd")
+    def test_delete_mailbox_if_empty(self, doveadm_cmd_mock):
+        doveadm_cmd_mock.return_value = (0, b"")
+        self.backend.delete_mailbox_if_empty("user@domain", "Scheduled")
+        doveadm_cmd_mock.assert_called_with(
+            ["mailbox", "delete", "-u", "user@domain", "-s", "-e", "Scheduled"]
+        )
+
+    @mock.patch("modoboa.lib.dovecot.doveadm_cmd")
+    def test_list_password_schemes(self, doveadm_cmd_mock):
+        doveadm_cmd_mock.return_value = (0, b"SHA512-CRYPT PLAIN")
+        self.assertEqual(self.backend.list_password_schemes(), "SHA512-CRYPT PLAIN")
+        doveadm_cmd_mock.assert_called_with(["pw", "-l"])
+
+
+@override_settings(**REST_SETTINGS)
+class DoveadmHTTPBackendTestCase(SimpleTestCase):
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_get_user_home(self, post_mock):
+        post_mock.return_value = http_response(
+            [["doveadmResponse", [{"home": "/srv/vmail/domain/user"}], "c1"]]
+        )
+        backend = dovecot.DoveadmHTTPBackend()
+        self.assertEqual(backend.get_user_home("user@domain"), "/srv/vmail/domain/user")
+        args, kwargs = post_mock.call_args
+        self.assertEqual(args[0], REST_SETTINGS["DOVEADM_API_URL"])
+        self.assertEqual(
+            kwargs["json"], [["user", {"userMask": ["user@domain"]}, "c1"]]
+        )
+        self.assertTrue(kwargs["headers"]["Authorization"].startswith("X-Dovecot-API "))
+
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_get_user_home_nested_response(self, post_mock):
+        post_mock.return_value = http_response(
+            [
+                [
+                    "doveadmResponse",
+                    [{"user@domain": {"home": "/srv/vmail/domain/user"}}],
+                    "c1",
+                ]
+            ]
+        )
+        backend = dovecot.DoveadmHTTPBackend()
+        self.assertEqual(backend.get_user_home("user@domain"), "/srv/vmail/domain/user")
+
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_get_user_home_not_found(self, post_mock):
+        post_mock.return_value = http_response([["doveadmResponse", [], "c1"]])
+        backend = dovecot.DoveadmHTTPBackend()
+        with self.assertRaises(dovecot.DoveadmError):
+            backend.get_user_home("user@domain")
+
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_command_error(self, post_mock):
+        post_mock.return_value = http_response(
+            [["error", {"type": "exitCode", "exitCode": 68}, "c1"]]
+        )
+        backend = dovecot.DoveadmHTTPBackend()
+        with self.assertRaises(dovecot.DoveadmError):
+            backend.get_user_home("user@domain")
+
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_network_error(self, post_mock):
+        import requests
+
+        post_mock.side_effect = requests.ConnectionError("connection refused")
+        backend = dovecot.DoveadmHTTPBackend()
+        with self.assertRaises(dovecot.DoveadmError):
+            backend.get_user_home("user@domain")
+
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_move_message(self, post_mock):
+        post_mock.return_value = http_response([["doveadmResponse", [], "c1"]])
+        backend = dovecot.DoveadmHTTPBackend()
+        backend.move_message("user@domain", "Sent", "Scheduled", "X-Hdr", "12")
+        kwargs = post_mock.call_args[1]
+        self.assertEqual(
+            kwargs["json"],
+            [
+                [
+                    "move",
+                    {
+                        "user": "user@domain",
+                        "destinationMailbox": "Sent",
+                        "query": ["mailbox", "Scheduled", "header", "X-Hdr", "12"],
+                    },
+                    "c1",
+                ]
+            ],
+        )
+
+    @mock.patch("modoboa.lib.dovecot.requests.post")
+    def test_delete_mailbox_if_empty(self, post_mock):
+        post_mock.return_value = http_response([["doveadmResponse", [], "c1"]])
+        backend = dovecot.DoveadmHTTPBackend()
+        backend.delete_mailbox_if_empty("user@domain", "Scheduled")
+        kwargs = post_mock.call_args[1]
+        self.assertEqual(
+            kwargs["json"],
+            [
+                [
+                    "mailboxDelete",
+                    {
+                        "user": "user@domain",
+                        "mailbox": ["Scheduled"],
+                        "requireEmpty": True,
+                        "subscriptions": True,
+                    },
+                    "c1",
+                ]
+            ],
+        )
+
+    def test_list_password_schemes(self):
+        backend = dovecot.DoveadmHTTPBackend()
+        with self.assertRaises(dovecot.DoveadmError):
+            backend.list_password_schemes()
+
+
+class RestModeStructureTestCase(SimpleTestCase):
+    """Check admin global parameters structure in rest mode."""
+
+    @override_settings(**REST_SETTINGS)
+    def test_handle_mailboxes_visible(self):
+        from modoboa.admin.app_settings import init_structure
+
+        structure = init_structure()
+        self.assertIn("handle_mailboxes", structure["mailboxes"]["params"])
+
+
+class RestModeSchemesTestCase(TestCase):
+    """Check password schemes retrieval in rest mode."""
+
+    @override_settings(**REST_SETTINGS)
+    def test_get_dovecot_schemes_fallback(self):
+        from modoboa.admin.models.alarm import Alarm
+        from modoboa.core.constants import DOVEADM_PASS_SCHEME_ALARM
+        from modoboa.core.password_hashers.utils import get_dovecot_schemes
+
+        schemes, status = get_dovecot_schemes()
+        self.assertEqual(schemes, ["{MD5-CRYPT}", "{PLAIN}"])
+        self.assertEqual(status, 1)
+        # No alarm must be opened in this case
+        self.assertFalse(
+            Alarm.objects.filter(internal_name=DOVEADM_PASS_SCHEME_ALARM).exists()
+        )
+
+    @override_settings(
+        **REST_SETTINGS, DOVECOT_SUPPORTED_SCHEMES="SHA512-CRYPT ARGON2ID"
+    )
+    def test_get_dovecot_schemes_from_settings(self):
+        from modoboa.core.password_hashers.utils import get_dovecot_schemes
+
+        schemes, status = get_dovecot_schemes()
+        self.assertEqual(schemes, ["{SHA512-CRYPT}", "{ARGON2ID}"])
+        self.assertEqual(status, 1)

--- a/modoboa/webmail/models.py
+++ b/modoboa/webmail/models.py
@@ -5,7 +5,7 @@ Webmail related models.
 from django.core.mail import EmailMessage
 from django.db import models
 
-from modoboa.lib.sysutils import doveadm_cmd
+from modoboa.lib import dovecot
 from modoboa.webmail import constants
 from modoboa.webmail.lib.utils import create_message
 
@@ -53,39 +53,29 @@ class ScheduledMessage(models.Model):
 
     def delete_imap_copy(self) -> bool:
         """Move IMAP message to Sent folder using doveadm."""
-        # TODO: use doveadm HTTP API when dovecot is not local
         sent_folder = self.account.parameters.get_value("sent_folder")
-        code, output = doveadm_cmd(
-            [
-                "move",
-                "-u",
+        backend = dovecot.get_dovecot_backend()
+        try:
+            backend.move_message(
                 self.account.email,
                 sent_folder,
-                "mailbox",
                 constants.MAILBOX_NAME_SCHEDULED,
-                "header",
                 constants.CUSTOM_HEADER_SCHEDULED_ID,
                 str(self.id),
-            ]
-        )
-        if code:
+            )
+        except dovecot.DoveadmError as err:
             self.status = constants.SchedulingState.MOVE_ERROR.value
-            self.error = output
+            self.error = str(err)
             self.save()
             return False
 
         # Try to delete mailbox when empty
-        doveadm_cmd(
-            [
-                "mailbox",
-                "delete",
-                "-u",
-                self.account.email,
-                "-s",
-                "-e",
-                constants.MAILBOX_NAME_SCHEDULED,
-            ]
-        )
+        try:
+            backend.delete_mailbox_if_empty(
+                self.account.email, constants.MAILBOX_NAME_SCHEDULED
+            )
+        except dovecot.DoveadmError:
+            pass
 
         return True
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -285,6 +285,16 @@ SPECTACULAR_SETTINGS = {
 # DOVECOT_LOOKUP_PATH = ('/path/to/dovecot', )
 DOVECOT_USER = "root"
 
+# Dovecot access mode: "cmd" (local doveadm binary, default) or "rest"
+# (doveadm HTTP API, allows Dovecot to run on a different host).
+# DOVECOT_OPERATION_MODE = "rest"
+# DOVEADM_API_URL = "https://imap.example.com:8080/doveadm/v1"
+# DOVEADM_API_KEY = "secret"
+# DOVEADM_API_TIMEOUT = 10
+# In rest mode, 'doveadm pw -l' can't be used to list supported password
+# schemes so you should define them manually:
+# DOVECOT_SUPPORTED_SCHEMES = "SHA512-CRYPT ARGON2ID BLF-CRYPT"
+
 MODOBOA_API_URL = "https://api.modoboa.org/1/"
 
 PID_FILE_STORAGE_PATH = "/tmp"


### PR DESCRIPTION
Modoboa can now communicate with a remote Dovecot server through the doveadm HTTP API instead of the local doveadm binary. The mode is controlled by the new DOVECOT_OPERATION_MODE setting ('cmd' by default, 'rest' for the HTTP API) along with DOVEADM_API_URL, DOVEADM_API_KEY and DOVEADM_API_TIMEOUT.

A new access layer (modoboa.lib.dovecot) provides both backends behind a common interface and is now used for mailbox location retrieval, scheduled messages handling and password schemes discovery. In rest mode, filesystem operations (mailbox rename/delete) are disabled and password schemes fall back to DOVECOT_SUPPORTED_SCHEMES.