### PR TITLE
fix(admin): don't re-validate domain quota when quota is unchanged

### DIFF
--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -585,6 +585,47 @@ class AccountViewSetTestCase(ModoAPITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(account.mailbox.quota, data["mailbox"]["quota"])
 
+    def test_update_unchanged_quota_when_domain_full(self):
+        """A domain admin must be able to edit an account (e.g. change the
+        password) even when the domain quota is fully allocated, as long as the
+        mailbox quota itself is not increased.
+        """
+        account = core_models.User.objects.get(username="user@test.com")
+        # Over-allocate the domain (cap is 50): user=50 + admin=10 -> 60.
+        account.mailbox.quota = 50
+        account.mailbox.save()
+        self.authenticate_user(core_models.User.objects.get(username="admin@test.com"))
+        url = reverse("v2:account-detail", args=[account.pk])
+        # The frontend resends every field, including the unchanged quota.
+        data = {
+            "username": "user@test.com",
+            "role": "SimpleUsers",
+            "password": "Toto12345",
+            "mailbox": {"quota": 50},
+        }
+        resp = self.client.patch(url, data, format="json")
+        self.assertEqual(resp.status_code, 200)
+        account.mailbox.refresh_from_db()
+        self.assertEqual(account.mailbox.quota, 50)
+
+    def test_update_quota_increase_rejected_when_domain_full(self):
+        """Increasing a mailbox quota beyond the domain cap must still fail."""
+        account = core_models.User.objects.get(username="user@test.com")
+        account.mailbox.quota = 50
+        account.mailbox.save()
+        self.authenticate_user(core_models.User.objects.get(username="admin@test.com"))
+        url = reverse("v2:account-detail", args=[account.pk])
+        data = {
+            "username": "user@test.com",
+            "role": "SimpleUsers",
+            "password": "Toto12345",
+            "mailbox": {"quota": 100},
+        }
+        resp = self.client.patch(url, data, format="json")
+        self.assertEqual(resp.status_code, 400)
+        account.mailbox.refresh_from_db()
+        self.assertEqual(account.mailbox.quota, 50)
+
     def test_user_updates_password(self):
         account = core_models.User.objects.get(username="user@test.com")
         self.authenticate_user(account)

--- a/modoboa/admin/models/mailbox.py
+++ b/modoboa/admin/models/mailbox.py
@@ -255,7 +255,7 @@ class Mailbox(mixins.MessageLimitMixin, AdminObject):
         if self.quota == 0:
             if self.domain.quota and not override_rules:
                 raise lib_exceptions.BadRequest(_("A quota is required"))
-        elif self.domain.quota:
+        elif self.domain.quota and self.quota > old_quota:
             quota_usage = self.domain.allocated_quota
             if old_quota:
                 quota_usage -= old_quota
@@ -318,9 +318,13 @@ class Mailbox(mixins.MessageLimitMixin, AdminObject):
                     raise lib_exceptions.NotFound(_("Domain does not exist"))
                 if not user.can_access(domain):
                     raise lib_exceptions.PermDeniedException
+        old_use_domain_quota = self.use_domain_quota
         if "use_domain_quota" in values:
             self.use_domain_quota = values["use_domain_quota"]
-        if "use_domain_quota" in values or "quota" in values:
+        quota_changed = (
+            "quota" in values and values["quota"] != self.quota
+        ) or self.use_domain_quota != old_use_domain_quota
+        if quota_changed:
             override_rules = (
                 not self.quota
                 or user.is_superuser


### PR DESCRIPTION
Domain admins resubmit every field when editing an account, including the unchanged mailbox quota. This re-ran the domain quota validation and failed with "domain quota exceeded" when the domain was fully allocated, preventing edits such as a password change.

Skip set_quota() when the submitted quota matches the stored value, and only reject genuine allocation increases in set_quota().
