### PR TITLE
refactor(admin): use queryset delete in accounts bulk_delete

### DIFF
--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -256,8 +256,7 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
         accounts = self.get_queryset().filter(pk__in=ids)
         if accounts.count() != len(set(ids)):
             return response.Response(status=status.HTTP_404_NOT_FOUND)
-        for account in accounts:
-            account.delete()
+        accounts.delete()
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
Delete accounts in a single SQL query instead of iterating and calling delete() on each instance. The per-account cleanup (permissions, aliases, quotas, mailbox directory) is handled by pre_delete/post_delete signal receivers, which QuerySet.delete() still triggers because both User and Mailbox have registered receivers.
