### PR TITLE
fix(admin): enable ordering by quota_usage on accounts endpoint

### DIFF
--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -502,6 +502,15 @@ class AccountSerializer(v1_serializers.AccountSerializer):
             return
         self.fields["resources"] = serializers.SerializerMethodField()
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # Reuse the quota_usage annotation set by AccountViewSet.get_queryset()
+        # to avoid a per-row Quota query in the account listing. Falls back to
+        # the SerializerMethodField (get_quota_in_percent) when unannotated.
+        if data.get("mailbox") is not None and hasattr(instance, "quota_usage"):
+            data["mailbox"]["quota_usage"] = int(instance.quota_usage or 0)
+        return data
+
     def get_possible_actions(self, identity) -> list[IdPossibleActionsSerializer]:
         actions = admin_signals.extra_account_identities_actions.send(
             self.__class__, account=identity

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -291,6 +291,50 @@ class AccountViewSetTestCase(ModoAPITestCase):
         super().setUpTestData()
         factories.populate_database()
 
+    def _set_quota_usage(self, username, megabytes):
+        """Set the used bytes of an account's mailbox quota."""
+        mb = models.Mailbox.objects.get(user__username=username)
+        models.Quota.objects.filter(username=mb.full_address).update(
+            bytes=megabytes * 1048576
+        )
+
+    def test_list_quota_usage_value(self):
+        """quota_usage is computed from the Quota table (mailbox quota is MB)."""
+        self._set_quota_usage("user@test.com", 5)  # mailbox quota is 10MB -> 50%
+        url = reverse("v2:account-list")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        entry = next(
+            a for a in resp.json()["results"] if a["username"] == "user@test.com"
+        )
+        self.assertEqual(entry["mailbox"]["quota_usage"], 50)
+
+    def test_list_ordering_by_quota_usage(self):
+        """Results can be ordered by the computed quota_usage field."""
+        self._set_quota_usage("user@test.com", 5)  # 50%
+        self._set_quota_usage("admin@test.com", 1)  # 10%
+        self._set_quota_usage("user@test2.com", 8)  # 80%
+        url = reverse("v2:account-list")
+
+        resp = self.client.get(url, {"ordering": "quota_usage"})
+        self.assertEqual(resp.status_code, 200)
+        usages = [
+            a["mailbox"]["quota_usage"]
+            for a in resp.json()["results"]
+            if a["mailbox"] is not None
+        ]
+        self.assertEqual(usages, sorted(usages))
+
+        resp = self.client.get(url, {"ordering": "-quota_usage"})
+        self.assertEqual(resp.status_code, 200)
+        usages = [
+            a["mailbox"]["quota_usage"]
+            for a in resp.json()["results"]
+            if a["mailbox"] is not None
+        ]
+        self.assertEqual(usages, sorted(usages, reverse=True))
+        self.assertEqual(usages[0], 80)
+
     def test_create(self):
         url = reverse("v2:account-list")
         username = "toto@test.com"

--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -3,6 +3,17 @@
 from django.utils.translation import gettext as _
 
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import (
+    Case,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    OuterRef,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Concat
 
 from django_filters import rest_framework as dj_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -186,6 +197,13 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
         dj_filters.DjangoFilterBackend,
     )
     search_fields = ["^first_name", "^last_name", "^email", "username"]
+    ordering_fields = [
+        "username",
+        "first_name",
+        "last_name",
+        "is_active",
+        "quota_usage",
+    ]
     pagination_class = pagination.CustomPageNumberPagination
     filterset_class = AccountFilterSet
 
@@ -208,8 +226,34 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
         ids = user.objectaccess_set.filter(
             content_type=ContentType.objects.get_for_model(user)
         ).values_list("object_id", flat=True)
-        return core_models.User.objects.filter(pk__in=ids).prefetch_related(
-            "userobjectlimit_set"
+        # Quota has no FK to Mailbox: it is joined on
+        # Quota.username == Mailbox.full_address (local part + "@" + domain).
+        quota_bytes = Subquery(
+            models.Quota.objects.filter(
+                username=Concat(
+                    OuterRef("mailbox__address"),
+                    Value("@"),
+                    OuterRef("mailbox__domain__name"),
+                )
+            ).values("bytes")[:1]
+        )
+        # Mirror Mailbox.get_quota_in_percent() at the DB level so results can
+        # be ordered by quota usage and served without a per-row Quota query.
+        return (
+            core_models.User.objects.filter(pk__in=ids)
+            .select_related("mailbox", "mailbox__domain")
+            .prefetch_related("userobjectlimit_set")
+            .annotate(
+                quota_usage=Case(
+                    When(mailbox__quota=0, then=Value(0.0)),
+                    When(mailbox__quota__isnull=True, then=Value(0.0)),
+                    default=ExpressionWrapper(
+                        quota_bytes * 100.0 / (F("mailbox__quota") * 1048576),
+                        output_field=FloatField(),
+                    ),
+                    output_field=FloatField(),
+                )
+            )
         )
 
     @action(methods=["post"], detail=False)


### PR DESCRIPTION
quota_usage was a SerializerMethodField computed in Python from the Quota table, so DRF's OrderingFilter silently dropped it and each account triggered a per-row Quota query (N+1).

Annotate the account queryset with a DB-level quota usage percentage (correlated Subquery on Quota, joined by full_address since Quota has no FK to Mailbox), mirroring Mailbox.get_quota_in_percent(). The annotation now feeds both ordering and the serialized value, and select_related on mailbox/domain removes the related N+1 as well.

See #4085 