### PR TITLE
security: use defusedxml to protect against XML attacks

### DIFF
--- a/modoboa/autoconfig/tests.py
+++ b/modoboa/autoconfig/tests.py
@@ -83,3 +83,17 @@ class ViewsTestCase(TestCase):
 
         resp = self.client.get(f"{url}?emailaddress=test@test.com")
         self.assertEqual(resp.status_code, 200)
+
+    def test_autodiscover_xxe_entity_not_resolved(self):
+        """Ensure XXE entity expansion is blocked by defusedxml (#1556)."""
+        url = reverse("autoconfig:autodiscover")
+        body = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE foo [<!ENTITY xxe "INJECTED">]>'
+            b"<Autodiscover><Request>"
+            b"<EMailAddress>&xxe;</EMailAddress>"
+            b"</Request></Autodiscover>"
+        )
+        resp = self.client.post(url, data=body, content_type="text/xml")
+        # Entity is not resolved, so EMailAddress is not a valid address → 404
+        self.assertEqual(resp.status_code, 404)

--- a/modoboa/autoconfig/views.py
+++ b/modoboa/autoconfig/views.py
@@ -1,6 +1,6 @@
 import plistlib
 import uuid
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import ParseError, fromstring as ET_fromstring
 
 from django.conf import settings
 from django.http import Http404, HttpResponse
@@ -20,8 +20,10 @@ def _email_address_from_xml_body(body: bytes) -> str | None:
     </Autodiscover>
     """
     try:
-        root = ET.fromstring(body)
-    except ET.ParseError:
+        root = ET_fromstring(body)
+    except (ParseError, ValueError):
+        # ParseError covers malformed XML; ValueError covers defusedxml
+        # security exceptions (EntitiesForbidden, DTDForbidden, etc.).
         return None
     for elem in root.iter():
         tag = elem.tag.rsplit("}", 1)[-1]  # strip XML namespace, if any

--- a/modoboa/contacts/lib/carddav.py
+++ b/modoboa/contacts/lib/carddav.py
@@ -33,6 +33,15 @@ from caldav.elements import base as elements_base, dav as elements_dav
 import lxml.etree as ET
 import requests
 
+# Secure parser to protect against XML-based attacks (billion laughs, XXE, etc.).
+# See https://pypi.org/project/defusedxml/ for rationale.
+_SECURE_PARSER = ET.XMLParser(resolve_entities=False, no_network=True)
+
+
+def _safe_xml(xml):
+    """Parse XML with a hardened parser that disables entity resolution."""
+    return ET.XML(xml, parser=_SECURE_PARSER)
+
 
 class UploadFailed(Exception):
     """uploading the card failed"""
@@ -338,7 +347,7 @@ class PyCardDAV:
         """Parse REPORT query result and return a dict."""
         result = {"cards": []}
         ns = "{DAV:}"
-        element = ET.XML(xml)
+        element = _safe_xml(xml)
         for item in element.iterchildren():
             if item.tag != ns + "response":
                 result["token"] = item.text
@@ -379,7 +388,7 @@ class PyCardDAV:
         """
         namespace = "{DAV:}"
 
-        element = ET.XML(xml)
+        element = _safe_xml(xml)
         abook = dict()
         for response in element.iterchildren():
             if response.tag != namespace + "response":

--- a/modoboa/contacts/tests.py
+++ b/modoboa/contacts/tests.py
@@ -6,6 +6,7 @@ import httmock
 from rq import SimpleWorker
 
 from django.core import management
+from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -18,6 +19,7 @@ from modoboa.lib.tests import ModoAPITestCase
 from . import factories
 from . import mocks
 from . import models
+from .lib.carddav import _safe_xml
 
 
 class TestDataMixin:
@@ -393,3 +395,25 @@ class ImportTestCase(TestDataMixin, ModoAPITestCase):
         self.assertEqual(address.contact.first_name, "Toto Tata")
         self.assertEqual(address.contact.addressbook.user.email, "user@test.com")
         self.assertEqual(address.contact.address, "Street 1 Street 2")
+
+
+class CardDavSecurityTestCase(TestCase):
+    """Verify that the CardDAV XML parser is hardened against XML attacks (#1556)."""
+
+    def test_safe_xml_rejects_entity_expansion(self):
+        """Entity definitions must not be resolved."""
+        payload = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE foo [<!ENTITY xxe "INJECTED">]>'
+            b"<root>&xxe;</root>"
+        )
+        element = _safe_xml(payload)
+        self.assertIsNone(element.text)
+
+    def test_safe_xml_parses_valid_document(self):
+        """Valid XML must still parse correctly."""
+        payload = b'<d:multistatus xmlns:d="DAV:"><d:response><d:href>/x</d:href></d:response></d:multistatus>'
+        element = _safe_xml(payload)
+        children = list(element.iterchildren())
+        self.assertEqual(len(children), 1)
+        self.assertEqual(children[0].tag, "{DAV:}response")


### PR DESCRIPTION
## Description

Closes #1556

This PR replaces unsafe XML parsing with hardened equivalents to protect against XXE (XML External Entity), billion laughs, and other XML decoding attacks.

### Changes

**`modoboa/autoconfig/views.py`**
- Replaced `import xml.etree.ElementTree as ET` with `from defusedxml.ElementTree import fromstring`
- The `_email_address_from_xml_body()` function parses Outlook Autodiscover XML from untrusted HTTP POST bodies — this is a direct attack surface
- Updated exception handling to catch both `ParseError` (malformed XML) and `ValueError` (defusedxml security exceptions like `EntitiesForbidden`, `DTDFForbidden`)

**`modoboa/contacts/lib/carddav.py`**
- Added a module-level `_SECURE_PARSER = ET.XMLParser(resolve_entities=False, no_network=True)` and a `_safe_xml()` wrapper
- Replaced both `ET.XML(xml)` calls (in `__process_report_result` and `_process_xml_props`) with `_safe_xml(xml)`
- Used lxml's built-in parser hardening rather than `defusedxml.lxml` (which is deprecated and will be removed in a future release)

### Why not defusedxml.lxml?

`defusedxml.lxml` is deprecated per its own documentation. The lxml-recommended approach is to configure `XMLParser` with `resolve_entities=False` and `no_network=True`, which provides the same protections while keeping full lxml API compatibility (the code relies on `iterchildren()`/`iterdescendants()` which are lxml-specific).

### No new dependencies

`defusedxml` is already listed in `pyproject.toml` (`defusedxml>=0.6.0`) and is already used in `modoboa/dmarc/lib.py`.

### Tests

**`modoboa/autoconfig/tests.py`**
- `test_autodiscover_xxe_entity_not_resolved`: POSTs an XML body with a `<!ENTITY>` declaration inside `EMailAddress` — verifies the entity is not resolved and the response is 404

**`modoboa/contacts/tests.py`**
- `CardDavSecurityTestCase.test_safe_xml_rejects_entity_expansion`: verifies `&xxe;` entity reference is not expanded (text is None)
- `CardDavSecurityTestCase.test_safe_xml_parses_valid_document`: verifies valid DAV XML still parses correctly with the secure parser