### PR TITLE
Expose quota usage in the identities API so the Quota column sorts

### DIFF
--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -424,7 +424,41 @@ class IdentitySerializer(serializers.Serializer):
     name_or_rcpt = serializers.CharField()
     tags = TagSerializer(many=True)
     enabled = serializers.BooleanField()
+    quota_usage = serializers.SerializerMethodField()
+    mailbox = serializers.SerializerMethodField()
     possible_actions = serializers.SerializerMethodField()
+
+    def _get_account_mailbox(self, identity):
+        """Return the account's mailbox, None for aliases or mailbox-less accounts."""
+        if not isinstance(identity, core_models.User):
+            return None
+        return getattr(identity, "mailbox", None)
+
+    def get_quota_usage(self, identity) -> int | None:
+        """Quota usage in percent, None for identities without a mailbox.
+
+        Exposed at the top level because the frontend Quota column sorts on
+        this key (aliases group together through the None value).
+        """
+        mailbox = self._get_account_mailbox(identity)
+        if mailbox is None:
+            return None
+        # Reuse the quota_usage annotation set by lib.get_identities() to
+        # avoid a per-row Quota query. Falls back to the model method when
+        # unannotated.
+        if hasattr(identity, "quota_usage"):
+            return int(identity.quota_usage or 0)
+        return mailbox.get_quota_in_percent()
+
+    def get_mailbox(self, identity) -> dict | None:
+        """Quota display data (types mirror MailboxSerializer: quota is a string)."""
+        mailbox = self._get_account_mailbox(identity)
+        if mailbox is None:
+            return None
+        return {
+            "quota": str(mailbox.quota),
+            "quota_usage": self.get_quota_usage(identity),
+        }
 
     def get_possible_actions(self, identity) -> list[IdPossibleActionsSerializer]:
         if not isinstance(identity, core_models.User):

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -908,6 +908,24 @@ class IdentityViewSetTestCase(ModoAPITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json()), 8)
 
+    def test_list_quota_fields(self):
+        """Accounts expose quota_usage and mailbox, aliases expose None."""
+        mb = models.Mailbox.objects.get(user__username="user@test.com")
+        models.Quota.objects.filter(username=mb.full_address).update(
+            bytes=5 * 1048576  # mailbox quota is 10MB -> 50%
+        )
+        url = reverse("v2:identities-list")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        identities = resp.json()
+        account = next(i for i in identities if i["identity"] == "user@test.com")
+        self.assertEqual(account["quota_usage"], 50)
+        self.assertEqual(account["mailbox"]["quota"], "10")
+        self.assertEqual(account["mailbox"]["quota_usage"], 50)
+        alias = next(i for i in identities if i["type"] != "account")
+        self.assertIsNone(alias["quota_usage"])
+        self.assertIsNone(alias["mailbox"])
+
     def test_import(self):
         f = ContentFile(
             """

--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -3,17 +3,6 @@
 from django.utils.translation import gettext as _
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import (
-    Case,
-    ExpressionWrapper,
-    F,
-    FloatField,
-    OuterRef,
-    Subquery,
-    Value,
-    When,
-)
-from django.db.models.functions import Concat
 
 from django_filters import rest_framework as dj_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -226,34 +215,10 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
         ids = user.objectaccess_set.filter(
             content_type=ContentType.objects.get_for_model(user)
         ).values_list("object_id", flat=True)
-        # Quota has no FK to Mailbox: it is joined on
-        # Quota.username == Mailbox.full_address (local part + "@" + domain).
-        quota_bytes = Subquery(
-            models.Quota.objects.filter(
-                username=Concat(
-                    OuterRef("mailbox__address"),
-                    Value("@"),
-                    OuterRef("mailbox__domain__name"),
-                )
-            ).values("bytes")[:1]
-        )
-        # Mirror Mailbox.get_quota_in_percent() at the DB level so results can
-        # be ordered by quota usage and served without a per-row Quota query.
-        return (
+        return lib.annotate_quota_usage(
             core_models.User.objects.filter(pk__in=ids)
             .select_related("mailbox", "mailbox__domain")
             .prefetch_related("userobjectlimit_set")
-            .annotate(
-                quota_usage=Case(
-                    When(mailbox__quota=0, then=Value(0.0)),
-                    When(mailbox__quota__isnull=True, then=Value(0.0)),
-                    default=ExpressionWrapper(
-                        quota_bytes * 100.0 / (F("mailbox__quota") * 1048576),
-                        output_field=FloatField(),
-                    ),
-                    output_field=FloatField(),
-                )
-            )
         )
 
     @action(methods=["post"], detail=False)

--- a/modoboa/admin/lib.py
+++ b/modoboa/admin/lib.py
@@ -13,7 +13,18 @@ from dns.name import IDNA_2008_UTS_46
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import (
+    Case,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Concat
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext as _
 
@@ -28,7 +39,37 @@ from modoboa.lib.exceptions import Conflict, ModoboaException, PermDeniedExcepti
 from modoboa.parameters import tools as param_tools
 
 from . import signals
-from .models import Alias, Domain, DomainAlias
+from .models import Alias, Domain, DomainAlias, Quota
+
+
+def annotate_quota_usage(accounts):
+    """Annotate an account queryset with its quota usage (percent).
+
+    Mirrors Mailbox.get_quota_in_percent() at the DB level so results can
+    be ordered by quota usage and served without a per-row Quota query.
+    Quota has no FK to Mailbox: it is joined on
+    Quota.username == Mailbox.full_address (local part + "@" + domain).
+    """
+    quota_bytes = Subquery(
+        Quota.objects.filter(
+            username=Concat(
+                OuterRef("mailbox__address"),
+                Value("@"),
+                OuterRef("mailbox__domain__name"),
+            )
+        ).values("bytes")[:1]
+    )
+    return accounts.annotate(
+        quota_usage=Case(
+            When(mailbox__quota=0, then=Value(0.0)),
+            When(mailbox__quota__isnull=True, then=Value(0.0)),
+            default=ExpressionWrapper(
+                quota_bytes * 100.0 / (F("mailbox__quota") * 1048576),
+                output_field=FloatField(),
+            ),
+            output_field=FloatField(),
+        )
+    )
 
 
 def get_identities(
@@ -58,7 +99,11 @@ def get_identities(
                 q &= Q(is_superuser=True)
             else:
                 q &= Q(groups__name=grpfilter)
-        accounts = User.objects.filter(q).prefetch_related("groups")
+        accounts = annotate_quota_usage(
+            User.objects.filter(q)
+            .select_related("mailbox", "mailbox__domain")
+            .prefetch_related("groups")
+        )
 
     aliases = []
     if (


### PR DESCRIPTION
Fixes #4085

On `/admin/identities` every column header sorted the list except **Quota** — the frontend keys that column on `quota_usage` (`IdentityList.vue`) and its cells read `item.mailbox.quota_usage`, but `IdentitySerializer` returned neither field, so the client-side comparator had nothing to order by and the click was a no-op.

### Changes

- **`lib.annotate_quota_usage()`** — extracted the quota-usage annotation (Quota-bytes subquery + percent `Case`) that lived in `AccountViewSet.get_queryset()` and reused it in `lib.get_identities()`, which now also `select_related("mailbox", "mailbox__domain")`. Identity rows get their percentage without per-row `Quota` queries. `AccountViewSet` calls the same helper, so accounts behavior is unchanged.
- **`IdentitySerializer`** now exposes:
  - `quota_usage` at the top level — the frontend's sort key;
  - `mailbox` as `{quota, quota_usage}` — what the Quota cells render (`quota` serialized as a string, same as `MailboxSerializer`, so the template's `quota !== '0'` unlimited check works).
  - Aliases and mailbox-less accounts serialize both as `None`, so they group together when sorting — the behavior the issue asks for.
- **Test**: `IdentityViewSetTestCase.test_list_quota_fields` — sets 5MB used of a 10MB quota, asserts the account row exposes `quota_usage == 50` and `mailbox == {"quota": "10", "quota_usage": 50}`, and that alias rows expose `None` for both.

The serializer falls back to `Mailbox.get_quota_in_percent()` when handed unannotated instances, mirroring the account serializer's fallback.