### PR TITLE
fix: allow rq>=2.10.0 with django-rq>=4.1.1 (#4088)

### DIFF
--- a/modoboa/core/tests/test_cron_config.py
+++ b/modoboa/core/tests/test_cron_config.py
@@ -1,0 +1,48 @@
+"""Tests for cron configuration and rq version compatibility."""
+
+import importlib
+import sys
+
+from django.test import override_settings
+
+from modoboa.lib.tests import SimpleModoTestCase
+
+
+class CronConfigTestCase(SimpleModoTestCase):
+    """Verify that cron_config.py loads without errors across rq versions."""
+
+    def test_cron_config_imports(self):
+        """cron_config.py must import without TypeError on rq>=2.10.
+
+        Regression test for issue #4088: rq>=2.10.0 added a `webhooks`
+        kwarg to ``rq.cron.register()``. The previous django-rq==4.0.1
+        ``DjangoCronScheduler.register()`` override did not accept this
+        kwarg, causing a ``TypeError`` when ``cron_config.py`` called
+        ``register()`` at import time. django-rq>=4.1.1 fixes this by
+        accepting and forwarding ``webhooks``.
+        """
+        # Force re-import to catch import-time errors
+        if "test_project.cron_config" in sys.modules:
+            importlib.reload(sys.modules["test_project.cron_config"])
+        else:
+            importlib.import_module("test_project.cron_config")
+
+    def test_rq_version_not_pinned_below_2_10(self):
+        """The rq dependency must not be pinned below 2.10.0."""
+        import rq
+
+        # We allow rq >= 2.7.0 (including >= 2.10.0)
+        major, minor = int(rq.__version__.split(".")[0]), int(
+            rq.__version__.split(".")[1]
+        )
+        # If rq is 2.10+, django-rq must be >= 4.1.1 to accept webhooks
+        if major == 2 and minor >= 10:
+            import django_rq
+
+            dj_rq_parts = django_rq.__version__.split(".")
+            dj_rq_major, dj_rq_minor = int(dj_rq_parts[0]), int(dj_rq_parts[1])
+            self.assertGreaterEqual(
+                (dj_rq_major, dj_rq_minor),
+                (4, 1),
+                "django-rq>=4.1.1 is required when rq>=2.10.0 (issue #4088)",
+            )

--- a/modoboa/core/tests/test_cron_config.py
+++ b/modoboa/core/tests/test_cron_config.py
@@ -3,8 +3,6 @@
 import importlib
 import sys
 
-from django.test import override_settings
-
 from modoboa.lib.tests import SimpleModoTestCase
 
 
@@ -29,20 +27,18 @@ class CronConfigTestCase(SimpleModoTestCase):
 
     def test_rq_version_not_pinned_below_2_10(self):
         """The rq dependency must not be pinned below 2.10.0."""
+        from packaging.version import parse
+
         import rq
 
-        # We allow rq >= 2.7.0 (including >= 2.10.0)
-        major, minor = int(rq.__version__.split(".")[0]), int(
-            rq.__version__.split(".")[1]
-        )
+        rq_ver = parse(rq.__version__)
         # If rq is 2.10+, django-rq must be >= 4.1.1 to accept webhooks
-        if major == 2 and minor >= 10:
+        if rq_ver >= parse("2.10.0"):
             import django_rq
 
-            dj_rq_parts = django_rq.__version__.split(".")
-            dj_rq_major, dj_rq_minor = int(dj_rq_parts[0]), int(dj_rq_parts[1])
+            dj_rq_ver = parse(django_rq.__version__)
             self.assertGreaterEqual(
-                (dj_rq_major, dj_rq_minor),
-                (4, 1),
+                dj_rq_ver,
+                parse("4.1.1"),
                 "django-rq>=4.1.1 is required when rq>=2.10.0 (issue #4088)",
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,8 @@ dependencies = [
 	"defusedxml>=0.6.0",
 	"python-magic>=0.4.24",
 	# RQ
-	# rq>=2.10.0 added a `webhooks` kwarg to cron.register() that
-	# django-rq==4.1.0's DjangoCronScheduler.register() override doesn't
-	# accept yet, breaking `rqcron` (TypeError, 0 jobs registered).
-	"rq>=2.7.0,<2.10.0",
-	"django-rq>=4.0.1",
+	"rq>=2.7.0",
+	"django-rq>=4.1.1",
 	# Sieve
 	"sievelib>=1.4.1",
 	# User


### PR DESCRIPTION
## Summary

Fixes #4088

rq>=2.10.0 added a `webhooks` kwarg to `cron.register()`. The previous `django-rq==4.0.1` `DjangoCronScheduler.register()` override did not accept this kwarg, causing a `TypeError` when `cron_config.py` called `register()` at import time (0 jobs registered, `rqcron` crashes immediately).

## The Fix

`django-rq>=4.1.1` already accepts and forwards the `webhooks` kwarg, so the version cap is no longer needed.

Changes:
- Remove `<2.10.0` upper bound on rq dependency in `pyproject.toml`
- Raise django-rq minimum from `>=4.0.1` to `>=4.1.1`
- Remove the workaround comment
- Add `test_cron_config.py` with:
  - Import test verifying `cron_config.py` loads without `TypeError`
  - Version guard asserting django-rq>=4.1.1 when rq>=2.10.0

## Testing

Verified locally with `rq==2.10.0` + `django-rq==4.1.1`:
- `rq.cron.register` signature includes `webhooks` param ✅
- `DjangoCronScheduler.register` accepts `webhooks` param ✅
- `cron_config.py` imports without error ✅