### PR TITLE
fix(api): expose identity quota usage

### DIFF
--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -424,7 +424,17 @@ class IdentitySerializer(serializers.Serializer):
     name_or_rcpt = serializers.CharField()
     tags = TagSerializer(many=True)
     enabled = serializers.BooleanField()
+    quota_usage = serializers.SerializerMethodField()
     possible_actions = serializers.SerializerMethodField()
+
+    def get_quota_usage(self, identity) -> int:
+        """Return mailbox quota usage for accounts, or zero for aliases."""
+        if not isinstance(identity, core_models.User):
+            return 0
+        mailbox = getattr(identity, "mailbox", None)
+        if mailbox is None:
+            return 0
+        return mailbox.get_quota_in_percent()
 
     def get_possible_actions(self, identity) -> list[IdPossibleActionsSerializer]:
         if not isinstance(identity, core_models.User):

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -908,6 +908,17 @@ class IdentityViewSetTestCase(ModoAPITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json()), 8)
 
+    def test_list_quota_usage(self):
+        """Include account quota usage and a stable zero for aliases."""
+        models.Quota.objects.filter(username="user@test.com").update(
+            bytes=5 * 1048576
+        )
+        response = self.client.get(reverse("v2:identities-list"))
+        self.assertEqual(response.status_code, 200)
+        identities = {identity["identity"]: identity for identity in response.json()}
+        self.assertEqual(identities["user@test.com"]["quota_usage"], 50)
+        self.assertEqual(identities["alias@test.com"]["quota_usage"], 0)
+
     def test_import(self):
         f = ContentFile(
             """


### PR DESCRIPTION
﻿## Summary

Expose mailbox quota usage in the v2 identities API so the Identities page can sort accounts by quota usage.

## Problem

/api/v2/identities/ did not include quota_usage, so the frontend Quota column had no value to sort. Aliases do not have mailbox quotas.

## Implementation

- Add quota_usage to IdentitySerializer.
- Return the mailbox usage percentage for account identities.
- Return 0 for aliases and accounts without a mailbox.
- Add API regression coverage for an account at 50% usage and an alias at 0%.

## Testing

- .\.venv\Scripts\python.exe -m py_compile modoboa\admin\api\v2\serializers.py modoboa\admin\api\v2\tests.py — passed.
- Ad-hoc serializer branch verification — passed.
- .\.venv\Scripts\python.exe tests.py modoboa.admin.api.v2.tests.IdentityViewSetTestCase — blocked on Windows because Modoboa imports the POSIX-only pwd module.
- Full dependency setup was blocked by rrdtool-bindings requiring Microsoft Visual C++ 14+.

Closes #4085
