### PR TITLE
fix(admin): avoid integer overflow in quota_usage annotation on PostgreSQL

### DIFF
--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -309,6 +309,20 @@ class AccountViewSetTestCase(ModoAPITestCase):
         )
         self.assertEqual(entry["mailbox"]["quota_usage"], 50)
 
+    def test_list_quota_usage_large_quota(self):
+        """Quotas above 2047MB must not overflow (quota * 1048576 > 2^31)."""
+        mb = models.Mailbox.objects.get(user__username="user@test.com")
+        mb.quota = 5000
+        mb.save(update_fields=["quota"])
+        self._set_quota_usage("user@test.com", 2500)  # 50%
+        url = reverse("v2:account-list")
+        resp = self.client.get(url, {"ordering": "quota_usage"})
+        self.assertEqual(resp.status_code, 200)
+        entry = next(
+            a for a in resp.json()["results"] if a["username"] == "user@test.com"
+        )
+        self.assertEqual(entry["mailbox"]["quota_usage"], 50)
+
     def test_list_ordering_by_quota_usage(self):
         """Results can be ordered by the computed quota_usage field."""
         self._set_quota_usage("user@test.com", 5)  # 50%

--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -247,8 +247,11 @@ class AccountViewSet(v1_viewsets.AccountViewSet):
                 quota_usage=Case(
                     When(mailbox__quota=0, then=Value(0.0)),
                     When(mailbox__quota__isnull=True, then=Value(0.0)),
+                    # Multiply by a float so PostgreSQL does not compute
+                    # quota * 1048576 as integer * integer, which overflows
+                    # for quotas above 2047MB.
                     default=ExpressionWrapper(
-                        quota_bytes * 100.0 / (F("mailbox__quota") * 1048576),
+                        quota_bytes * 100.0 / (F("mailbox__quota") * 1048576.0),
                         output_field=FloatField(),
                     ),
                     output_field=FloatField(),


### PR DESCRIPTION
The quota_usage annotation multiplied mailbox.quota by 1048576 using integer arithmetic. On PostgreSQL, integer * integer stays an integer, so any quota above 2047MB overflowed 2^31 and made the accounts listing fail with 'integer out of range'. Use a float literal so the whole expression is computed as double precision.
