### PR TITLE
security(imap_migration): Fix race condition between time of file creation and restricting file permission bits

### DIFF
--- a/modoboa/imap_migration/management/commands/generate_offlineimap_config.py
+++ b/modoboa/imap_migration/management/commands/generate_offlineimap_config.py
@@ -24,6 +24,12 @@ class Command(BaseCommand):
             default="/tmp/offlineimap.conf",
             help="Path of the generated file",
         )
+        parser.add_argument(
+            "--no-restrict",
+            dest="restrict",
+            action="store_false",
+            help="Do not restrict file permissions on generated OfflineIMAP configuration file",
+        )
 
     def handle(self, *args, **options):
         """Entry point."""
@@ -39,8 +45,10 @@ class Command(BaseCommand):
                 "provider", "mailbox__domain"
             ),
         }
-        opener = lambda path, flags: \
-            os.open(path, flags, mode=(stat.S_IRUSR | stat.S_IWUSR))
+        opener = None  # Default creates files using mode 0o666 (umask’d)
+        if options["restrict"]:
+            opener = lambda path, flags: \
+                os.open(path, flags, mode=(stat.S_IRUSR | stat.S_IWUSR))
         with open(options["output"], "w", opener=opener) as fpo:
             content = render_to_string("imap_migration/offlineimap.conf", context)
             fpo.write(content)

--- a/modoboa/imap_migration/management/commands/generate_offlineimap_config.py
+++ b/modoboa/imap_migration/management/commands/generate_offlineimap_config.py
@@ -39,7 +39,8 @@ class Command(BaseCommand):
                 "provider", "mailbox__domain"
             ),
         }
-        with open(options["output"], "w") as fpo:
+        opener = lambda path, flags: \
+            os.open(path, flags, mode=(stat.S_IRUSR | stat.S_IWUSR))
+        with open(options["output"], "w", opener=opener) as fpo:
             content = render_to_string("imap_migration/offlineimap.conf", context)
             fpo.write(content)
-        os.chmod(options["output"], stat.S_IRUSR | stat.S_IWUSR)

--- a/modoboa/imap_migration/tests.py
+++ b/modoboa/imap_migration/tests.py
@@ -134,6 +134,19 @@ class ManagementCommandTestCase(DataMixin, ModoTestCase):
         conf.read(path)
         self.assertTrue(conf.has_section("Account user@test.com"))
 
+
+    def test_generate_offlineimap_config_norestrict(self):
+        """Test generate_offlineimap_config command with --no-restrict."""
+        # Read umask (never do this in multi-threaded code!)
+        umask = os.umask(0)  # Reads current umask, replacing it with 0
+        os.umask(umask)  # Restores umask
+
+        # Test that generated file has default umask restrictions
+        path = os.path.join(self.workdir, "offlineimap.conf")
+        call_command("generate_offlineimap_config", "--output", path, "--no-restrict")
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), (0o666 & ~umask))
+
     def test_password_escaping(self):
         """Check that passwords are escaped when needed."""
         self.migration.password = "%Test1234"

--- a/modoboa/imap_migration/tests.py
+++ b/modoboa/imap_migration/tests.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import stat
 import tempfile
 from unittest import mock
 
@@ -128,6 +129,7 @@ class ManagementCommandTestCase(DataMixin, ModoTestCase):
         path = os.path.join(self.workdir, "offlineimap.conf")
         call_command("generate_offlineimap_config", "--output", path)
         self.assertTrue(os.path.exists(path))
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), stat.S_IRUSR | stat.S_IWUSR)
         conf = configparser.ConfigParser()
         conf.read(path)
         self.assertTrue(conf.has_section("Account user@test.com"))


### PR DESCRIPTION
Fixes race condition in between writing IMAP migration configuration file and restricting its permissions. Also adds ability to *not* restrict the file permissions. (Opt-in! I actually have a similar patch to do this for DKIM keys, but didn’t finish/submit it yet.)

Adds tests for both modes, but no regression test as it is very hard to test race conditions reliably without adding a lot of overhead and wasting a lot of dev time.

Please check the remaining Modoboa codebase for similar issues, I’m sure there are some.