### PR TITLE
Add ability to specify post-task command-line to execute after finishing mail log parsing and allow passing `call_command` arguments through RQ job handlers

### DIFF
--- a/doc-ng/installation/modoboa.md
+++ b/doc-ng/installation/modoboa.md
@@ -309,6 +309,46 @@ numprocs=1
 stopsignal=TERM
 ```
 
+The cron scheduler is *configurable*: During [deployment](#deployment) the file
+`<path to Modoboa instance>/instance/cron_config.py`
+is created containing all currently configured jobs in the form
+`register(<job name>, queue_name="<worker name>", cron="<interval spec>")`.
+
+Editing `cron_config.py` is an advanced feature but may be useful in some
+special cases:
+
+  * Jobs can be disabled by adding a `#` to the start of the line  
+    Generally, you should *never* disable a job – do not open issues about
+    some tasks not working unless you have verified the problem is not related
+    to having disabled the responsible job.
+  * `<worker name>` is the name of one of the workers created in the steps below  
+    On an LSB-compatible Linux distribution it should never be required to
+    change a job’s worker queue – like with disabling jobs, you must ensure
+    any encountered problems are not due to permission issues when running the
+    given job before opening an issue.
+  * `<interval spec>` is a Cron-compatible
+    [interval specification](https://en.wikipedia.org/wiki/Cron#Overview)
+    (only standard 4.4BSD/POSIX syntax is supported)  
+    In some setups it may be benifical to adjust scheduled jobs to manage
+    system load as long you ensure that jobs run “often enough” to not cause
+    issues.
+
+Some jobs may also accept arguments to adjust their operation, arguments may be
+specififed by adding keyword arguments of the form
+`, kwargs={"<name1>": <value1>, "<name2>": <value2>, <…>}` to the given job.  
+Currently the following arguments are supported:
+
+  * `maillog_jobs.logparser`:
+    * `post_cmd`: A Python command argument list containing an command to
+       execute after parsing Postfix log files  
+       This can be used to automatically rotate and remove the Postfix maillog
+       file after it has been parsed on systems where it is not used otherwise:
+       `kwargs={"post_cmd": ["/bin/sh", "-c", "\"$1\" logrotate && rm /var/log/mail.log.*", "-", "/usr/sbin/postfix"]}`
+
+Other arguments may exist, but unless they are documented they may disappear
+or completely change behaviour at any time. Please open an issue if you require
+another argument in your setup.
+
 ## Privileged worker
 ``` ini
 [program:modoboa-privileged-worker]

--- a/doc-ng/installation/modoboa.md
+++ b/doc-ng/installation/modoboa.md
@@ -231,17 +231,6 @@ INSTANCE=<path to Modoboa instance>
 0     0  *  *  *  root  $PYTHON $INSTANCE/manage.py clearsessions
 ```
 
-::: tip TIPS
-
-**🥵 potential high load configuration**
-Please note that above crontab might not be ideal on high load systems.
-If you receive a fairly high amount of emails per day, you may want to
-run modoboas logparser tasks *once per night*.
-
-This has the down side that the statistic graph and message log within
-the UI are updated once per day only.
-:::
-
 ## Policy daemon {#policy_daemon}
 
 Modoboa comes with a built-in
@@ -348,6 +337,18 @@ Currently the following arguments are supported:
 Other arguments may exist, but unless they are documented they may disappear
 or completely change behaviour at any time. Please open an issue if you require
 another argument in your setup.
+
+::: tip TIPS
+
+**🥵 potential high load configuration**
+Please note that default `cron_config.py` might not be ideal on high load
+systems. If you receive a fairly high amount of emails per day, you may want
+to run modoboas logparser tasks *once per night*
+(ie: interval spec `30 3 * * *` to run at 03:30 in the morning).
+
+This has the down side that the statistic graph and message log within
+the UI are updated once per day only.
+:::
 
 ## Privileged worker
 ``` ini

--- a/modoboa/amavis/jobs.py
+++ b/modoboa/amavis/jobs.py
@@ -3,9 +3,9 @@
 from django.core.management import call_command
 
 
-def amnotify():
-    call_command("amnotify")
+def amnotify(*args, **options):
+    call_command("amnotify", *args, **options)
 
 
-def qcleanup():
-    call_command("qcleanup")
+def qcleanup(*args, **options):
+    call_command("qcleanup", *args, **options)

--- a/modoboa/calendars/jobs.py
+++ b/modoboa/calendars/jobs.py
@@ -3,5 +3,5 @@
 from django.core.management import call_command
 
 
-def generate_rights():
-    call_command("generate_rights")
+def generate_rights(*args, **options):
+    call_command("generate_rights", *args, **options)

--- a/modoboa/core/jobs.py
+++ b/modoboa/core/jobs.py
@@ -30,5 +30,5 @@ def clean_logs():
     Maillog.objects.filter(date__lt=limit).delete()
 
 
-def communicate_with_public_api():
-    call_command("communicate_with_public_api")
+def communicate_with_public_api(*args, **options):
+    call_command("communicate_with_public_api", *args, **options)

--- a/modoboa/maillog/jobs.py
+++ b/modoboa/maillog/jobs.py
@@ -3,9 +3,9 @@
 from django.core.management import call_command
 
 
-def logparser():
-    call_command("logparser")
+def logparser(*args, **options):
+    call_command("logparser", *args, **options)
 
 
-def update_statistics():
-    call_command("update_statistics")
+def update_statistics(*args, **options):
+    call_command("update_statistics", *args, **options)

--- a/modoboa/maillog/management/commands/logparser.py
+++ b/modoboa/maillog/management/commands/logparser.py
@@ -31,6 +31,7 @@ from django.utils import timezone
 
 from modoboa.admin.models import Domain
 from modoboa.parameters import tools as param_tools
+from modoboa.lib import sysutils
 from modoboa.lib.email_utils import split_mailbox
 
 from ... import lib
@@ -599,6 +600,13 @@ class Command(BaseCommand):
             metavar="FILE",
         )
         parser.add_argument(
+            "--post-cmd",
+            default=None,
+            help="Argument list of command to execute after completing logfile parsing (for RQ usage)",
+            metavar="ARG",
+            nargs="+",
+        )
+        parser.add_argument(
             "--verbose",
             default=False,
             action="store_true",
@@ -639,3 +647,5 @@ class Command(BaseCommand):
             options, param_tools.get_global_parameter("rrd_rootdir"), None, greylist
         )
         p.process()
+        if options["post_cmd"] is not None:
+            sysutils.exec_cmd(options["post_cmd"])

--- a/modoboa/maillog/tests/test_views.py
+++ b/modoboa/maillog/tests/test_views.py
@@ -28,7 +28,7 @@ class RunCommandsMixin:
         if os.path.exists(pid_file):
             os.remove(pid_file)
 
-    def run_logparser(self):
+    def run_logparser(self, *args, **options):
         """Run logparser command."""
         path = os.path.join(os.path.dirname(__file__), "mail.log")
         with open(path) as fp:
@@ -37,7 +37,7 @@ class RunCommandsMixin:
         with open(path, "w") as fp:
             fp.write(content)
         self.set_global_parameter("logfile", path)
-        jobs.logparser()
+        jobs.logparser(*args, **options)
 
     def run_update_statistics(self, rebuild=False):
         """Run update_statistics command."""
@@ -86,3 +86,25 @@ class ManagementCommandsTestCase(RunCommandsMixin, SimpleModoTestCase):
         with self.assertRaises(SystemExit) as inst:
             self.run_logparser()
         self.assertEqual(inst.exception.code, 2)
+
+
+    def test_logparser_post_cmd(self):
+        """Test logparser command."""
+        path = os.path.join(os.path.dirname(__file__), ".post-cmd-has-run")
+
+        try:
+            # Structured options style
+            self.run_logparser(post_cmd=["touch", path])
+            self.assertTrue(os.path.exists(path))
+            os.remove(path)
+            os.remove(f"{settings.PID_FILE_STORAGE_PATH}/modoboa_logparser.pid")
+
+            # Command-line options style
+            self.run_logparser("--post-cmd", "touch", path)
+            self.assertTrue(os.path.exists(path))
+        finally:
+            os.remove(path)
+
+        for d in ["global", "test.com"]:
+            path = os.path.join(self.workdir, f"{d}.rrd")
+            self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Primarily, this adds ability to specify post-task command-line to execute after finishing mail log parsing.

On `modoboa-nixos` this is used to rotate and delete the Postfix log file after parsing. NixOS defaults to having no log file, so we also consider it a transient institution as well.

To make this useful all the RQ job handler functions are updated to forward their arguments to `call_command` so that you can customize their command invocations in `cron_config.py`.