### PR TITLE
feat(admin): Allow generating DKIM keys without restricted permissions

### DIFF
--- a/modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py
+++ b/modoboa/admin/management/commands/subcommands/_manage_dkim_keys.py
@@ -17,7 +17,7 @@ from ....constants import DKIM_WRITE_ERROR, ALARM_OPENED, DKIM_ERROR
 class ManageDKIMKeys(BaseCommand):
     """Command class."""
 
-    def create_new_dkim_key(self, domain):
+    def create_new_dkim_key(self, domain: str, *, restrict: bool = True) -> None:
         """Create a new DKIM key."""
         storage_dir = param_tools.get_global_parameter("dkim_keys_storage_dir")
         pkey_path = os.path.join(storage_dir, f"{domain.name}.pem")
@@ -74,6 +74,14 @@ class ManageDKIMKeys(BaseCommand):
                 title=_("Failed to generate DKIM private key"), internal_name=DKIM_ERROR
             )
             return
+
+        # `openssl` generates keys to be only user read- and writable by default
+        #
+        # So `restrict=True` is the default and restoring default permissions
+        # to what they would be according to `umask` requires a seperate step.
+        if not restrict:
+            os.chmod(pkey_path, 0o666 & ~sysutils.UMASK)
+
         domain.dkim_private_key_path = pkey_path
         code, output = sysutils.exec_cmd(
             ["openssl", "rsa", "-in", pkey_path, "-pubout"]
@@ -103,6 +111,12 @@ class ManageDKIMKeys(BaseCommand):
             default="",
             help="Domain target for keys generation.",
         )
+        parser.add_argument(
+            "--no-restrict",
+            dest="restrict",
+            action="store_false",
+            help="Do not restrict file permissions on generated DKIM key files",
+        )
 
     def handle(self, *args, **options):
         """Entry point."""
@@ -116,13 +130,13 @@ class ManageDKIMKeys(BaseCommand):
                 name=options["domain"], enable_dkim=True, dkim_private_key_path=""
             ).first()
             if domain:
-                self.create_new_dkim_key(domain)
+                self.create_new_dkim_key(domain, restrict=options["restrict"])
                 domains.append(domain)
         else:
             qset = models.Domain.objects.filter(
                 enable_dkim=True, dkim_private_key_path=""
             )
             for domain in qset:
-                self.create_new_dkim_key(domain)
+                self.create_new_dkim_key(domain, restrict=options["restrict"])
                 domains.append(domain)
         signals.dkim_keys_created.send(self, domains=domains)

--- a/modoboa/admin/tests/test_domain.py
+++ b/modoboa/admin/tests/test_domain.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import stat
 import tempfile
 
 from rest_framework import serializers as drf_serializers
@@ -16,6 +17,7 @@ import django_rq
 from modoboa.admin import signals as admin_signals
 from modoboa.admin.api.v2 import serializers as admin_v2_serializers
 from modoboa.core.models import User
+from modoboa.lib import sysutils
 from modoboa.lib.tests import ModoAPITestCase, SETTINGS_SAMPLE
 
 from .. import constants
@@ -174,10 +176,31 @@ class DKIMTestCase(ModoAPITestCase):
         )
         key_path = os.path.join(self.workdir, "{}.pem".format(values["name"]))
         self.assertTrue(os.path.exists(key_path))
+        self.assertEqual(stat.S_IMODE(os.stat(key_path).st_mode), stat.S_IRUSR | stat.S_IWUSR)
+
+        domain.refresh_from_db()
+
+        # Generate with default process permissions
+        os.remove(key_path)
+        domain.dkim_private_key_path = ""
+        domain.save()
+
+        self.set_global_parameter("dkim_keys_storage_dir", self.workdir)
+        call_command("modo", "manage_dkim_keys", "--no-restrict")
+        self.assertEqual(
+            Alarm.objects.get(
+                domain=domain, internal_name=constants.DKIM_WRITE_ERROR
+            ).status,
+            constants.ALARM_CLOSED,
+        )
+        key_path = os.path.join(self.workdir, "{}.pem".format(values["name"]))
+        self.assertTrue(os.path.exists(key_path))
+        self.assertEqual(stat.S_IMODE(os.stat(key_path).st_mode), 0o666 & ~sysutils.UMASK)
 
         domain.refresh_from_db()
 
         # Try generating DKIM key for a targetted domain
+        os.remove(key_path)
         domain.dkim_private_key_path = ""
         domain.save()
 
@@ -198,6 +221,7 @@ class DKIMTestCase(ModoAPITestCase):
         )
         domain.refresh_from_db()
         self.assertEqual(domain.dkim_private_key_path, "")
+
 
     def test_dkim_key_path_traversal_refused(self):
         """A crafted domain name must not let the key escape storage_dir."""

--- a/modoboa/imap_migration/tests.py
+++ b/modoboa/imap_migration/tests.py
@@ -15,6 +15,7 @@ from modoboa.admin import factories as admin_factories
 from modoboa.admin import models as admin_models
 from modoboa.core import factories as core_factories
 from modoboa.core import models as core_models
+from modoboa.lib import sysutils
 from modoboa.lib.tests import ModoTestCase, ModoAPITestCase
 
 from . import checks
@@ -137,15 +138,11 @@ class ManagementCommandTestCase(DataMixin, ModoTestCase):
 
     def test_generate_offlineimap_config_norestrict(self):
         """Test generate_offlineimap_config command with --no-restrict."""
-        # Read umask (never do this in multi-threaded code!)
-        umask = os.umask(0)  # Reads current umask, replacing it with 0
-        os.umask(umask)  # Restores umask
-
         # Test that generated file has default umask restrictions
         path = os.path.join(self.workdir, "offlineimap.conf")
         call_command("generate_offlineimap_config", "--output", path, "--no-restrict")
         self.assertTrue(os.path.exists(path))
-        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), (0o666 & ~umask))
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), (0o666 & ~sysutils.UMASK))
 
     def test_password_escaping(self):
         """Check that passwords are escaped when needed."""

--- a/modoboa/lib/sysutils.py
+++ b/modoboa/lib/sysutils.py
@@ -13,6 +13,15 @@ from django.conf import settings
 from django.utils.encoding import force_str
 
 
+# Query `umask` at startup/import time BEFORE there are other threads
+#
+# Unfortunately, there is *no* way to query the kernel umask value without
+# also modifying it *process-wide*. So temporarily clearing it and then
+# restoring it is the best one can do.
+UMASK = os.umask(0)
+os.umask(UMASK)
+
+
 def exec_cmd(
     cmd: list[str],
     sudo_user: str | None = None,


### PR DESCRIPTION
Used on NixOS were permissions are instead restricted on the surrounding directory having only user and group path permissions and the directory’s owning group being that of `rspamd`.

Kinda the inverse of #4100 for DKIM keys.