### PR TITLE
fix(deps): restrict rq version to <2.10.0 to prevent crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 	"defusedxml>=0.6.0",
 	"python-magic>=0.4.24",
 	# RQ
-	"rq>=2.7.0",
+	"rq>=2.7.0,<2.10.0",
 	"django-rq>=4.1.1",
 	# Sieve
 	"sievelib>=1.4.1",


### PR DESCRIPTION
## Summary

Restricts the `rq` dependency version to `<2.10.0` to prevent a Django-RQ cron scheduler crash (closes #4088).

## Context

Recent `rq` version 2.10.0 added a mandatory `webhooks` argument to its job registration. This causes `django-rq` (django-rq 4.1.0/4.1.1)'s `rqcron` scheduler to crash immediately with:
```
TypeError: DjangoCronScheduler.register() got an unexpected keyword argument 'webhooks'
```

Restricting `rq` to `<2.10.0` ensures that Modoboa setup pulls a compatible version of rq and boots the background periodic task scheduler safely.

Signed-off-by: emreumar <emreumar@users.noreply.github.com>