### PR TITLE
fix(admin): allow editing username in account edit form

### DIFF
--- a/frontend/src/components/admin/identities/form_steps/AccountMailboxForm.vue
+++ b/frontend/src/components/admin/identities/form_steps/AccountMailboxForm.vue
@@ -45,55 +45,32 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { useDomainsStore } from '@/stores'
 import rules from '@/plugins/rules'
-import constants from '@/constants.json'
 
 const { $gettext } = useGettext()
-const emit = defineEmits(['update:modelValue'])
-const props = defineProps({ modelValue: { type: Object, default: null } })
+const form = defineModel({ type: Object })
 
 const domainsStore = useDomainsStore()
 
 const domains = computed(() => domainsStore.domains)
 
 const vFormRef = ref()
-const form = ref({
-  mailbox: {},
-})
 
-watch(
-  props.modelValue,
-  (value) => {
-    if (value) {
-      form.value = { ...value }
-      if (form.value.role === constants.USER) {
-        if (!form.value.mailbox) {
-          form.value.mailbox = {}
-        }
-        form.value.mailbox.full_address = form.value.username
-      }
-      if (form.value.mailbox.message_limit === '') {
-        form.value.mailbox.message_limit = null
-      }
-    } else {
-      form.value = {
-        mailbox: {},
-      }
-    }
-  },
-  { immediate: true }
-)
-
-watch(
-  form,
-  (value) => {
-    emit('update:modelValue', value)
-  },
-  { deep: true }
-)
+// Operate directly on the shared model (like the other sub-forms) instead of
+// keeping an internal copy synced through deep watchers. The previous approach
+// rebuilt a new object and re-emitted it on every change to the account,
+// including username edits, which churned the object identity bound to the
+// username field and made it impossible to type into it.
+if (!form.value.mailbox) {
+  form.value.mailbox = {}
+}
+form.value.mailbox.full_address = form.value.username
+if (form.value.mailbox.message_limit === '') {
+  form.value.mailbox.message_limit = null
+}
 
 const domainQuota = computed(() => {
   const email = form.value.mailbox.full_address


### PR DESCRIPTION
The account edit form mounts all panels eagerly, so AccountMailboxForm lived alongside the username field. Unlike the other sub-forms, it kept an internal copy synced through deep watchers, rebuilding a new object and re-emitting it on every account change (including username edits). This churned the identity of the object bound to the username field on each keystroke, making it impossible to type into it.

Switch AccountMailboxForm to the defineModel/in-place mutation pattern already used by the other sub-forms, removing the internal copy and the echoing watchers.