### PR TITLE
feat(admin): refine DNS checks gating and DMARC criticality

### DIFF
--- a/frontend/src/components/admin/domains/DNSDetail.vue
+++ b/frontend/src/components/admin/domains/DNSDetail.vue
@@ -63,26 +63,32 @@
       <template v-else>
         <v-row>
           <v-col>
-            <v-chip v-if="detail.autoconfig_record" color="success">
+            <v-chip
+              v-if="detail.autoconfig_record"
+              :color="statusColor(autoconfigEnabled, 'success')"
+            >
               {{
                 $gettext('autoconfig record (Mozilla): %{ value }', {
                   value: detail.autoconfig_record.value,
                 })
               }}
             </v-chip>
-            <v-chip v-else color="warning">
+            <v-chip v-else :color="statusColor(autoconfigEnabled, 'warning')">
               {{ $gettext('autoconfig record (Mozilla) not found') }}
             </v-chip>
           </v-col>
           <v-col>
-            <v-chip v-if="detail.autodiscover_record" color="success">
+            <v-chip
+              v-if="detail.autodiscover_record"
+              :color="statusColor(autoconfigEnabled, 'success')"
+            >
               {{
                 $gettext('autodiscover record (Microsoft): %{ value }', {
                   value: detail.autodiscover_record.value,
                 })
               }}
             </v-chip>
-            <v-chip v-else color="warning">
+            <v-chip v-else :color="statusColor(autoconfigEnabled, 'warning')">
               {{ $gettext('autodiscover record (Microsoft) not found') }}
             </v-chip>
           </v-col>
@@ -90,26 +96,35 @@
         <div class="mt-4 overline">{{ $gettext('Authentication') }}</div>
         <v-row>
           <v-col>
-            <v-chip v-if="detail.spf_record" color="success">
+            <v-chip
+              v-if="detail.spf_record"
+              :color="statusColor(spfEnabled, 'success')"
+            >
               {{ $gettext('SPF record found') }}
             </v-chip>
-            <v-chip v-else color="error">
+            <v-chip v-else :color="statusColor(spfEnabled, 'error')">
               {{ $gettext('SPF record not found') }}
             </v-chip>
           </v-col>
           <v-col>
-            <v-chip v-if="detail.dkim_record" color="success">
+            <v-chip
+              v-if="detail.dkim_record"
+              :color="statusColor(dkimEnabled, 'success')"
+            >
               {{ $gettext('DKIM record found') }}
             </v-chip>
-            <v-chip v-else color="error">
+            <v-chip v-else :color="statusColor(dkimEnabled, 'error')">
               {{ $gettext('DKIM record not found') }}
             </v-chip>
           </v-col>
           <v-col>
-            <v-chip v-if="detail.dmarc_record" color="success">
+            <v-chip
+              v-if="detail.dmarc_record"
+              :color="statusColor(dmarcEnabled, 'success')"
+            >
               {{ $gettext('DMARC record found') }}
             </v-chip>
-            <v-chip v-else color="error">
+            <v-chip v-else :color="statusColor(dmarcEnabled, 'error')">
               {{ $gettext('DMARC record not found') }}
             </v-chip>
           </v-col>
@@ -174,6 +189,7 @@
 import { useGettext } from 'vue3-gettext'
 import { useBusStore } from '@/stores'
 import domainsApi from '@/api/domains'
+import parametersApi from '@/api/parameters'
 import DomainDKIMKey from './DomainDKIMKey.vue'
 import DomainDNSConfig from './DomainDNSConfig.vue'
 import DNSBLSummary from './DNSBLSummary.vue'
@@ -187,8 +203,7 @@ const props = defineProps({
   modelValue: { type: Object, default: null },
 })
 
-const domain = computed(() => props.modelValue)
-
+const checksParams = ref({})
 const dialog = ref()
 const detail = ref({})
 const mxRecordHeaders = ref([
@@ -203,6 +218,24 @@ const selectedMXRecord = ref(null)
 const showConfigHelp = ref(false)
 const showDKIMKey = ref(false)
 const showDNSBLSummary = ref(false)
+
+const domain = computed(() => props.modelValue)
+const spfEnabled = computed(() => checksParams.value.enable_spf_checks)
+// DKIM is only checked when the global check is enabled AND signing is
+// activated for this domain (see backend DNSChecker).
+const dkimEnabled = computed(
+  () => checksParams.value.enable_dkim_checks && domain.value?.enable_dkim
+)
+const dmarcEnabled = computed(() => checksParams.value.enable_dmarc_checks)
+const autoconfigEnabled = computed(
+  () => checksParams.value.enable_autoconfig_checks
+)
+
+// Return the "normal" color when the related check is enabled, grey otherwise.
+function statusColor(enabled, normalColor) {
+  const DISABLED_COLOR = 'grey'
+  return enabled ? normalColor : DISABLED_COLOR
+}
 
 function copyPubKey() {
   navigator.clipboard.writeText(domain.value.dkim_public_key)
@@ -278,6 +311,10 @@ function openDNSBLSummary(mxrecord) {
   selectedMXRecord.value = mxrecord
   showDNSBLSummary.value = true
 }
+
+parametersApi.getGlobalApplication('admin').then((resp) => {
+  checksParams.value = resp.data.params
+})
 
 watch(
   domain,

--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -279,6 +279,7 @@ class AdminGlobalParametersSerializer(serializers.Serializer):
     enable_spf_checks = serializers.BooleanField(default=True)
     enable_dkim_checks = serializers.BooleanField(default=True)
     enable_dmarc_checks = serializers.BooleanField(default=True)
+    dmarc_check_is_critical = serializers.BooleanField(default=True)
     enable_autoconfig_checks = serializers.BooleanField(default=True)
     enable_dns_notifications = serializers.BooleanField(default=True)
     custom_dns_server = serializers.IPAddressField(allow_blank=True, allow_null=True)

--- a/modoboa/admin/app_settings.py
+++ b/modoboa/admin/app_settings.py
@@ -93,6 +93,17 @@ GLOBAL_PARAMETERS_STRUCT = collections.OrderedDict(
                             },
                         ),
                         (
+                            "dmarc_check_is_critical",
+                            {
+                                "label": gettext_lazy("DMARC check is critical"),
+                                "display": "enable_dmarc_checks=true",
+                                "help_text": gettext_lazy(
+                                    "Consider a missing or invalid DMARC record as "
+                                    "critical for the global DNS status of a domain"
+                                ),
+                            },
+                        ),
+                        (
                             "enable_autoconfig_checks",
                             {
                                 "label": gettext_lazy("Enable autoconfig checks"),

--- a/modoboa/admin/dns_checker.py
+++ b/modoboa/admin/dns_checker.py
@@ -189,7 +189,11 @@ class DNSChecker:
 
         if self.config["enable_spf_checks"]:
             dns_models.DNSRecord.objects.get_or_create_for_domain(domain, "spf", ttl)
-        condition = self.config["enable_dkim_checks"] and domain.dkim_public_key
+        condition = (
+            self.config["enable_dkim_checks"]
+            and domain.enable_dkim
+            and domain.dkim_public_key
+        )
         if condition:
             dns_models.DNSRecord.objects.get_or_create_for_domain(domain, "dkim", ttl)
         if self.config["enable_dmarc_checks"]:

--- a/modoboa/admin/models/domain.py
+++ b/modoboa/admin/models/domain.py
@@ -166,13 +166,19 @@ class Domain(mixins.MessageLimitMixin, AdminObject):
             and self.dnsblresult_set.blacklisted().exists()
         ):
             errors.append("dnsbl")
-        if config["enable_spf_checks"]:
-            if self.spf_record is None or not self.spf_record.is_valid:
-                errors.append("spf")
+        if config["enable_spf_checks"] and (
+            self.spf_record is None or not self.spf_record.is_valid
+        ):
+            errors.append("spf")
+        if config["enable_dkim_checks"] and self.enable_dkim and self.dkim_public_key:
             if self.dkim_record is None or not self.dkim_record.is_valid:
                 errors.append("dkim")
-            if self.dmarc_record is None or not self.dmarc_record.is_valid:
-                errors.append("dmarc")
+        if (
+            config["enable_dmarc_checks"]
+            and config["dmarc_check_is_critical"]
+            and (self.dmarc_record is None or not self.dmarc_record.is_valid)
+        ):
+            errors.append("dmarc")
         if config["enable_autoconfig_checks"]:
             if self.autoconfig_record is None:
                 errors.append("autoconfig")

--- a/modoboa/admin/tests/test_mx.py
+++ b/modoboa/admin/tests/test_mx.py
@@ -327,3 +327,25 @@ class DNSChecksTestCase(ModoTestCase):
         self.assertIsNot(self.domain.dmarc_record, None)
         self.assertIsNot(self.domain.autoconfig_record, None)
         self.assertIsNot(self.domain.autodiscover_record, None)
+
+    @mock.patch("socket.gethostbyname")
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch.object(dns.resolver.Resolver, "resolve")
+    def test_management_command_dkim_disabled(
+        self, mock_query, mock_getaddrinfo, mock_g_gethostbyname
+    ):
+        """Check that DKIM record is not checked when signing is disabled."""
+        mock_query.side_effect = utils.mock_dns_query_result
+        mock_getaddrinfo.side_effect = utils.mock_ip_query_result
+        mock_g_gethostbyname.return_value = "1.2.3.4"
+        self.set_global_parameter("enable_dnsbl_checks", False)
+
+        # A public key exists but DKIM signing is disabled.
+        self.domain.enable_dkim = False
+        self.domain.dkim_public_key = "XXXXX"
+        self.domain.save(update_fields=["enable_dkim", "dkim_public_key"])
+
+        with LogCapture("modoboa.dns"):
+            DNSChecker().run(self.domain, ttl=0)
+
+        self.assertIs(self.domain.dkim_record, None)

--- a/modoboa/dnstools/tests.py
+++ b/modoboa/dnstools/tests.py
@@ -159,3 +159,27 @@ class DomainTestCase(ModoTestCase):
             type="autodiscover", value="1.2.3.4", is_valid=True, domain__name="test.com"
         )
         self.assertEqual(domain.dns_global_status, "ok")
+
+    def test_dmarc_check_is_critical(self):
+        admin_factories.MXRecordFactory.create(
+            domain__name="test.com", name="mail.test.com", updated=timezone.now()
+        )
+        domain = admin_models.Domain.objects.get(name="test.com")
+        # Isolate the DMARC check from the other ones.
+        self.set_global_parameters(
+            {
+                "enable_mx_checks": False,
+                "enable_spf_checks": False,
+                "enable_dkim_checks": False,
+                "enable_autoconfig_checks": False,
+                "enable_dnsbl_checks": False,
+            },
+            app="admin",
+        )
+
+        # By default a missing DMARC record is considered critical.
+        self.assertEqual(domain.dns_global_status, "critical")
+
+        # When the check is not critical anymore, the domain is fine.
+        self.set_global_parameter("dmarc_check_is_critical", False, app="admin")
+        self.assertEqual(domain.dns_global_status, "ok")


### PR DESCRIPTION
- Skip DKIM DNS check unless signing is enabled (enable_dkim), not only when a public key exists.
- Gate the DKIM part of the global DNS status the same way.
- Add a global "dmarc_check_is_critical" parameter (shown only when DMARC checks are enabled) to control whether a missing/invalid DMARC record makes the domain DNS status critical.
- Grey out DNS record chips in the domain detail page when the related check is disabled.
