### PR TITLE
fix: Use calling hostname when performing FIDO2 authentication

### DIFF
--- a/modoboa/core/fido2_auth.py
+++ b/modoboa/core/fido2_auth.py
@@ -25,7 +25,7 @@ def get_creds_from_user(user_id: int) -> dict:
 
 
 def begin_registration(request):
-    server = create_fido2_server(request.localconfig.site.domain)
+    server = create_fido2_server(request.get_host())
     options, state = server.register_begin(
         PublicKeyCredentialUserEntity(
             id=request.user.pk,
@@ -40,7 +40,7 @@ def begin_registration(request):
 
 
 def end_registration(request):
-    server = create_fido2_server(request.localconfig.site.domain)
+    server = create_fido2_server(request.get_host())
     auth_data = server.register_complete(
         request.session.pop("fido2_state"), request.data
     )
@@ -48,7 +48,7 @@ def end_registration(request):
 
 
 def begin_authentication(request, user_id: int):
-    server = create_fido2_server(request.localconfig.site.domain)
+    server = create_fido2_server(request.get_host())
     return server.authenticate_begin(list(get_creds_from_user(user_id).values()))
 
 

--- a/modoboa/core/views/auth.py
+++ b/modoboa/core/views/auth.py
@@ -307,7 +307,7 @@ class FidoAuthenticationEndView(LoginViewMixin, APIView):
         serializer = serializers.FidoAuthenticationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         fido2_auth.end_authentication(
-            user, fido_state, serializer.validated_data, request.localconfig.site.domain
+            user, fido_state, serializer.validated_data, request.get_host()
         )
         response = self.login(user, self.request.session.pop("rememberme", False))
         return JsonResponse({"next": response.url})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Calling hostname is validated by Django using `ALLOWED_HOSTS`, so is safe for this operation and it avoids having RP end up being whatever hostname Modoboa happend when the instance was originally created, which may have since changed causing not-very-helpful “Origin and RP-ID do not match” error to be displayed.

Current behavior before PR:
RP-ID is taken from outdated `localconfig.site.domain`, I don’t even *know* to fix that value without database modding.

Desired behavior after PR is merged:
RP-ID is taken from request.
