### PR TITLE
fix: pass request.auth directly to IMAPconnector instead of str()

### DIFF
--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -933,4 +933,4 @@ def get_imapconnector(request, **kwargs) -> IMAPconnector:
 
     :param request: a ``Request`` object
     """
-    return IMAPconnector(request.user.username, str(request.auth), **kwargs)
+    return IMAPconnector(request.user.username, request.auth, **kwargs)


### PR DESCRIPTION
## Summary

`get_imapconnector()` was passing `str(request.auth)` as the password to `IMAPconnector`, which caused OAUTHBEARER authentication to hang for 180 seconds before disconnecting.

The `str()` call converted the auth token object to its string representation instead of passing the actual token value.

## Change

```diff
- return IMAPconnector(request.user.username, str(request.auth), **kwargs)
+ return IMAPconnector(request.user.username, request.auth, **kwargs)
```

## Why

In Django REST Framework, `request.auth` contains the actual token value. Calling `str()` on it produces the string representation of the token object (e.g., `<Token: abc123>`), not the token itself. This caused Dovecot to receive an invalid token and hang during OAUTHBEARER authentication.

Fixes #4131