### PR TITLE
fix: extract actual token from request.auth instead of str()

### DIFF
--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -933,4 +933,13 @@ def get_imapconnector(request, **kwargs) -> IMAPconnector:
 
     :param request: a ``Request`` object
     """
-    return IMAPconnector(request.user.username, str(request.auth), **kwargs)
+    # Extract the actual token string from the auth object
+    # instead of using str() which returns a useless repr
+    auth = request.auth
+    if hasattr(auth, "token"):
+        token = auth.token
+    elif hasattr(auth, "key"):
+        token = auth.key
+    else:
+        token = str(auth)
+    return IMAPconnector(request.user.username, token, **kwargs)


### PR DESCRIPTION
## Fix
Fixes #4131

 passes a string repr of the token object instead of the actual token value, causing OAUTHBEARER auth to hang for 180 seconds.

## Changes
- Extract actual token from  using  or  attributes
- Fall back to  for backward compatibility