### PR TITLE
feat(webmail): Add IMAP folder subscriptions management

### DIFF
--- a/frontend/src/api/webmail.js
+++ b/frontend/src/api/webmail.js
@@ -28,6 +28,12 @@ export default {
   deleteUserMailbox(body) {
     return repository.post('/webmail/mailboxes/delete/', body)
   },
+  getSubscriptions() {
+    return repository.get('/webmail/mailboxes/subscriptions/')
+  },
+  updateSubscriptions(changes) {
+    return repository.post('/webmail/mailboxes/subscriptions/', { changes })
+  },
   emptyUserMailbox(mailbox) {
     const body = { name: mailbox }
     return repository.post('/webmail/mailboxes/empty/', body)

--- a/frontend/src/components/webmail/SubscriptionsDialog.vue
+++ b/frontend/src/components/webmail/SubscriptionsDialog.vue
@@ -1,0 +1,118 @@
+<template>
+  <v-card :title="$gettext('Subscriptions')">
+    <v-card-text>
+      <p class="text-body-2 text-medium-emphasis mb-4">
+        {{
+          $gettext(
+            'Check the folders you want to subscribe to. Only subscribed folders are displayed in the webmail.'
+          )
+        }}
+      </p>
+      <div v-if="loading" class="d-flex justify-center py-4">
+        <v-progress-circular indeterminate color="primary" />
+      </div>
+      <v-treeview
+        v-else
+        v-model:selected="selected"
+        :items="mailboxes"
+        item-value="name"
+        item-title="label"
+        item-children="sub"
+        select-strategy="independent"
+        selectable
+        open-all
+        density="compact"
+        fluid
+        class="subscription-tree"
+      />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn
+        :text="$gettext('Cancel')"
+        variant="flat"
+        :disabled="saving"
+        @click="emit('close')"
+      />
+      <v-btn
+        :text="$gettext('Apply')"
+        variant="tonal"
+        color="primary"
+        :loading="saving"
+        @click="apply"
+      />
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { useBusStore } from '@/stores'
+import api from '@/api/webmail'
+
+const emit = defineEmits(['close', 'updated'])
+
+const { $gettext } = useGettext()
+const { displayNotification } = useBusStore()
+
+const loading = ref(true)
+const saving = ref(false)
+const mailboxes = ref([])
+// Names of every folder, and the set initially subscribed, used to
+// compute the diff on apply.
+const allNames = ref([])
+const initial = ref(new Set())
+// Currently checked folders (bound to the treeview).
+const selected = ref([])
+
+function collect(nodes) {
+  for (const node of nodes) {
+    allNames.value.push(node.name)
+    if (node.subscribed) {
+      initial.value.add(node.name)
+      selected.value.push(node.name)
+    }
+    if (node.sub && node.sub.length) {
+      collect(node.sub)
+    }
+  }
+}
+
+async function apply() {
+  const current = new Set(selected.value)
+  const changes = allNames.value
+    .filter((name) => current.has(name) !== initial.value.has(name))
+    .map((name) => ({ name, subscribed: current.has(name) }))
+  if (changes.length === 0) {
+    emit('close')
+    return
+  }
+  saving.value = true
+  try {
+    await api.updateSubscriptions(changes)
+    displayNotification({ msg: $gettext('Subscriptions updated') })
+    emit('updated')
+    emit('close')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    const resp = await api.getSubscriptions()
+    mailboxes.value = resp.data.mailboxes
+    collect(mailboxes.value)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.subscription-tree {
+  max-height: 50vh;
+  overflow-y: auto;
+}
+</style>

--- a/frontend/src/layouts/webmail/WebmailLayout.vue
+++ b/frontend/src/layouts/webmail/WebmailLayout.vue
@@ -74,6 +74,11 @@
                     prepend-icon="mdi-folder-zip-outline"
                     @click="compressMailbox"
                   />
+                  <v-list-item
+                    :title="$gettext('Subscriptions')"
+                    prepend-icon="mdi-checkbox-multiple-marked-outline"
+                    @click="showSubscriptions = true"
+                  />
                 </v-list>
               </v-menu>
             </v-btn>
@@ -98,6 +103,12 @@
       @close="closeMailboxForm()"
     />
   </v-dialog>
+  <v-dialog v-model="showSubscriptions" max-width="600">
+    <SubscriptionsDialog
+      @close="showSubscriptions = false"
+      @updated="fetchUserMailboxes"
+    />
+  </v-dialog>
   <ConfirmDialog ref="confirm" />
 </template>
 
@@ -111,6 +122,7 @@ import ConfirmDialog from '@/components/tools/ConfirmDialog.vue'
 import ConnectedLayout from '@/layouts/connected/ConnectedLayout.vue'
 import MailboxForm from '@/components/webmail/MailboxForm.vue'
 import MailboxList from '@/components/webmail/MailboxList.vue'
+import SubscriptionsDialog from '@/components/webmail/SubscriptionsDialog.vue'
 import api from '@/api/webmail'
 
 const { $gettext } = useGettext()
@@ -145,6 +157,7 @@ const hdelimiter = ref(null)
 const mailboxQuota = ref(null)
 const selectedMailbox = ref(route.query.mailbox || 'INBOX')
 const showMailboxForm = ref(false)
+const showSubscriptions = ref(false)
 const userMailboxes = ref([])
 
 const readOnlyMailbox = computed(() => {

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -440,7 +440,36 @@ class IMAPconnector:
             sdescr["class"] = "subfolders"
         return True
 
-    def _listmboxes(self, topmailbox: str, mailboxes: list, until_mailbox=None) -> None:
+    def _parse_list_response(self, mb) -> tuple[list, str] | None:
+        """Parse a single ``LIST`` response line.
+
+        Handles both the literal form (name returned as a separate
+        ``{length}`` string, yielding a ``(header, name)`` tuple) and the
+        inline form. Returns the mailbox flags (as a list) and its decoded
+        name, or ``None`` for empty lines.
+        """
+        if not mb:
+            return None
+        if type(mb) in [list, tuple]:
+            flags, delimiter, namelen = self.list_response_pattern_literal.match(
+                mb[0].decode()
+            ).groups()
+            name = mb[1][0 : int(namelen)]
+        else:
+            flags, delimiter, name, childinfo = (
+                self.listextended_response_pattern.match(mb.decode()).groups()
+            )
+        flags = flags.split(" ")
+        name = bytearray(name, "utf-8").decode("imap4-utf-7")
+        return flags, name
+
+    def _listmboxes(
+        self,
+        topmailbox: str,
+        mailboxes: list,
+        until_mailbox=None,
+        subscribed_only: bool = False,
+    ) -> None:
         """Retrieve mailboxes list."""
         pattern = (
             f'"{topmailbox.encode("imap4-utf-7").decode()}{self.hdelimiter}%"'
@@ -448,24 +477,20 @@ class IMAPconnector:
             else "%"
         )
         resp = self._cmd(
-            "LIST", '""', pattern, "RETURN", "(CHILDREN STATUS (MESSAGES))"
+            "LIST", '""', pattern, "RETURN", "(SUBSCRIBED CHILDREN STATUS (MESSAGES))"
         )
         newmboxes = []
         for mb in resp:
-            if not mb:
+            parsed = self._parse_list_response(mb)
+            if parsed is None:
                 continue
-            if type(mb) in [list, tuple]:
-                flags, delimiter, namelen = self.list_response_pattern_literal.match(
-                    mb[0].decode()
-                ).groups()
-                name = mb[1][0 : int(namelen)]
-            else:
-                flags, delimiter, name, childinfo = (
-                    self.listextended_response_pattern.match(mb.decode()).groups()
-                )
-            flags = flags.split(" ")
-            name = bytearray(name, "utf-8")
-            name = name.decode("imap4-utf-7")
+            flags, name = parsed
+            has_children = "\\HasChildren" in flags
+            # When only subscribed mailboxes are requested, skip folders the
+            # user is not subscribed to. Unsubscribed folders that still have
+            # children are kept so subscribed descendants remain reachable.
+            if subscribed_only and "\\Subscribed" not in flags and not has_children:
+                continue
             mdm_found = False
             for idx, mdm in enumerate(mailboxes):
                 if mdm["name"] == name:
@@ -480,11 +505,11 @@ class IMAPconnector:
                 descr["send_status"] = True
             if r"\NonExistent" in flags:
                 descr["removed"] = True
-            if "\\HasChildren" in flags:
+            if has_children:
                 descr["path"] = name
                 descr["sub"] = []
                 if until_mailbox and until_mailbox.startswith(name):
-                    self._listmboxes(name, descr["sub"], until_mailbox)
+                    self._listmboxes(name, descr["sub"], until_mailbox, subscribed_only)
 
         from operator import itemgetter
 
@@ -496,6 +521,7 @@ class IMAPconnector:
         topmailbox: str = "",
         until_mailbox=None,
         unseen_messages: bool = True,
+        subscribed_only: bool = False,
     ) -> list:
         """Returns a list of mailboxes for a particular user.
 
@@ -507,6 +533,7 @@ class IMAPconnector:
         :param topmailbox: the mailbox where to start in the tree
         :param until_mailbox: the deepest needed mailbox
         :param unseen_messages: include unseen messages counters or not
+        :param subscribed_only: only return mailboxes the user is subscribed to
         :return: a list
         """
         if topmailbox:
@@ -549,7 +576,7 @@ class IMAPconnector:
             name, parent = separate_mailbox(until_mailbox, self.hdelimiter)
             if parent:
                 until_mailbox = parent
-        self._listmboxes(topmailbox, md_mailboxes, until_mailbox)
+        self._listmboxes(topmailbox, md_mailboxes, until_mailbox, subscribed_only)
 
         if unseen_messages:
             for mb in md_mailboxes:
@@ -694,6 +721,55 @@ class IMAPconnector:
         typ, data = self.m.delete(self._encode_mbox_name(name))
         if typ == "NO":
             raise WebmailInternalError(data[0])
+        return True
+
+    def get_subscription_tree(self) -> list:
+        """Return the full mailbox hierarchy with subscription status.
+
+        Contrary to :meth:`getmboxes`, every folder is returned (regardless
+        of subscription) as a nested tree. Each node is a dict with the
+        following keys: ``name`` (full path), ``label`` (last path
+        component), ``subscribed`` (bool) and ``sub`` (list of children).
+        """
+        resp = self._cmd("LIST", '""', '"*"', "RETURN", "(SUBSCRIBED)")
+        entries = []
+        for mb in resp or []:
+            parsed = self._parse_list_response(mb)
+            if parsed is None:
+                continue
+            flags, name = parsed
+            entries.append((name, "\\Subscribed" in flags))
+
+        tree: list = []
+        index: dict = {}
+        for name, subscribed in sorted(entries, key=lambda e: e[0]):
+            parts = name.split(self.hdelimiter)
+            label = parts[-1]
+            parent_path = self.hdelimiter.join(parts[:-1])
+            node = {
+                "name": name,
+                "label": label,
+                "subscribed": subscribed,
+                "sub": [],
+            }
+            index[name] = node
+            parent = index.get(parent_path)
+            if parent is not None:
+                parent["sub"].append(node)
+            else:
+                tree.append(node)
+        return tree
+
+    def subscribe_folder(self, name: str) -> bool:
+        typ, data = self.m.subscribe(self._encode_mbox_name(name))
+        if typ == "NO":
+            raise WebmailInternalError(str(data[0]))
+        return True
+
+    def unsubscribe_folder(self, name: str) -> bool:
+        typ, data = self.m.unsubscribe(self._encode_mbox_name(name))
+        if typ == "NO":
+            raise WebmailInternalError(str(data[0]))
         return True
 
     def getquota(self, mailbox: str) -> None:

--- a/modoboa/webmail/mocks.py
+++ b/modoboa/webmail/mocks.py
@@ -17,7 +17,16 @@ class IMAP4Mock:
         if name == "CAPABILITY":
             self.untagged_responses["CAPABILITY"] = [b"QUOTA"]
         elif name == "LIST":
-            self.untagged_responses["LIST"] = [b'() "." "INBOX"']
+            if '"*"' in [str(a) for a in args]:
+                # Full recursive listing used to build the subscription tree.
+                self.untagged_responses["LIST"] = [
+                    b'(\\Subscribed) "/" "INBOX"',
+                    b'(\\Subscribed \\HasChildren) "/" "Test"',
+                    b'() "/" "Test/Sub"',
+                ]
+            else:
+                # Sidebar listing (only subscribed folders are kept).
+                self.untagged_responses["LIST"] = [b'(\\Subscribed) "/" "INBOX"']
         elif name == "NAMESPACE":
             self.untagged_responses["NAMESPACE"] = [b'(("" "/")) NIL NIL']
         elif name == "STATUS":
@@ -37,6 +46,12 @@ class IMAP4Mock:
         return "OK", [b'() "." "INBOX"']
 
     def rename(self, oldname, newname):
+        return "OK", None
+
+    def subscribe(self, name):
+        return "OK", None
+
+    def unsubscribe(self, name):
         return "OK", None
 
     def uid(self, command, *args):

--- a/modoboa/webmail/serializers.py
+++ b/modoboa/webmail/serializers.py
@@ -70,6 +70,34 @@ class UserMailboxSerializer(serializers.Serializer):
         return None
 
 
+class SubscriptionNodeSerializer(serializers.Serializer):
+
+    name = serializers.CharField()
+    label = serializers.CharField()
+    subscribed = serializers.BooleanField()
+    sub = serializers.SerializerMethodField()
+
+    def get_sub(self, obj):
+        return SubscriptionNodeSerializer(obj.get("sub", []), many=True).data
+
+
+class SubscriptionsSerializer(serializers.Serializer):
+
+    mailboxes = SubscriptionNodeSerializer(many=True)
+    hdelimiter = serializers.CharField()
+
+
+class SubscriptionChangeSerializer(serializers.Serializer):
+
+    name = serializers.CharField()
+    subscribed = serializers.BooleanField()
+
+
+class SubscriptionUpdateSerializer(serializers.Serializer):
+
+    changes = SubscriptionChangeSerializer(many=True)
+
+
 class UserMailboxQuotaSerializer(serializers.Serializer):
 
     usage = serializers.IntegerField(source="quota_usage")

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -158,6 +158,40 @@ class UserMailboxViewSetTestCase(WebmailTestCase):
         response = self.client.post(url, body, format="json")
         self.assertEqual(response.status_code, 204)
 
+    def test_get_subscriptions(self):
+        self.authenticate()
+        url = reverse("v2:webmail-mailbox-subscriptions")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        names = {mb["name"]: mb for mb in content["mailboxes"]}
+        self.assertIn("INBOX", names)
+        self.assertTrue(names["INBOX"]["subscribed"])
+        self.assertIn("Test", names)
+        self.assertTrue(names["Test"]["subscribed"])
+        # Nested folders are exposed as a tree.
+        self.assertEqual(len(names["Test"]["sub"]), 1)
+        self.assertEqual(names["Test"]["sub"][0]["name"], "Test/Sub")
+        self.assertFalse(names["Test"]["sub"][0]["subscribed"])
+
+    def test_update_subscriptions(self):
+        self.authenticate()
+        url = reverse("v2:webmail-mailbox-subscriptions")
+        body = {
+            "changes": [
+                {"name": "Test/Sub", "subscribed": True},
+                {"name": "Test", "subscribed": False},
+            ]
+        }
+        response = self.client.post(url, body, format="json")
+        self.assertEqual(response.status_code, 204)
+
+    def test_update_subscriptions_invalid(self):
+        self.authenticate()
+        url = reverse("v2:webmail-mailbox-subscriptions")
+        response = self.client.post(url, {"changes": [{}]}, format="json")
+        self.assertEqual(response.status_code, 400)
+
 
 class UserEmailViewSetTestCase(WebmailTestCase):
 

--- a/modoboa/webmail/viewsets.py
+++ b/modoboa/webmail/viewsets.py
@@ -52,12 +52,16 @@ class UserMailboxViewSet(viewsets.GenericViewSet):
             return serializers.UserMailboxInputSerializer
         if self.action == "rename":
             return serializers.UserMailboxUpdateSerializer
+        if self.action == "subscriptions":
+            if self.request.method == "POST":
+                return serializers.SubscriptionUpdateSerializer
+            return serializers.SubscriptionsSerializer
         return serializers.UserMailboxesSerializer
 
     def list(self, request):
         parent_mailbox = request.GET.get("mailbox")
         with lib.get_imapconnector(request) as imapc:
-            mboxes = imapc.getmboxes(request.user, parent_mailbox)
+            mboxes = imapc.getmboxes(request.user, parent_mailbox, subscribed_only=True)
         serializer = self.get_serializer(
             {"mailboxes": mboxes, "hdelimiter": imapc.hdelimiter}
         )
@@ -137,6 +141,27 @@ class UserMailboxViewSet(viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         with lib.get_imapconnector(request) as imapc:
             imapc.delete_folder(serializer.validated_data["name"])
+        return response.Response(status=204)
+
+    @action(methods=["get", "post"], detail=False)
+    def subscriptions(self, request):
+        """List or update IMAP folder subscriptions for the current user."""
+        if request.method == "GET":
+            with lib.get_imapconnector(request) as imapc:
+                mboxes = imapc.get_subscription_tree()
+                serializer = self.get_serializer(
+                    {"mailboxes": mboxes, "hdelimiter": imapc.hdelimiter}
+                )
+            return response.Response(serializer.data)
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        with lib.get_imapconnector(request) as imapc:
+            for change in serializer.validated_data["changes"]:
+                if change["subscribed"]:
+                    imapc.subscribe_folder(change["name"])
+                else:
+                    imapc.unsubscribe_folder(change["name"])
         return response.Response(status=204)
 
 


### PR DESCRIPTION
Add a "Subscriptions" entry to the mailbox operations menu that opens a dialog listing the whole folder tree with a checkbox per folder to view and edit the current account's IMAP subscriptions.

The webmail sidebar now only displays subscribed folders (LIST with the SUBSCRIBED return option). Subscription toggling is applied as a batch on confirmation.
