### PR TITLE
fix(webmail): reliable unread counters in the mailbox sidebar

### DIFF
--- a/frontend/src/components/webmail/EmailList.vue
+++ b/frontend/src/components/webmail/EmailList.vue
@@ -369,6 +369,7 @@ const fetchEmails = () => {
 
 const autoRefreshContent = () => {
   fetchEmails()
+  reloadMailboxCounters()
 }
 
 const submitSearch = () => {

--- a/frontend/src/components/webmail/MailboxList.vue
+++ b/frontend/src/components/webmail/MailboxList.vue
@@ -19,24 +19,12 @@
       >
         <v-icon :icon="iconByMailboxType[mailbox.type]" class="mr-4" />
         <template v-if="!props.rail">
-          <template v-if="mailbox.name === route.query.mailbox">
-            <span v-if="currentMailboxUnseen > 0" class="font-weight-bold">
-              {{ getMailboxLabel(mailbox) }} ({{
-                getCurrentMailboxUnseen(mailbox)
-              }})
-            </span>
-            <span v-else>
-              {{ getMailboxLabel(mailbox) }}
-            </span>
-          </template>
-          <template v-else>
-            <span v-if="mailbox.unseen > 0" class="font-weight-bold">
-              {{ getMailboxLabel(mailbox) }} ({{ mailbox.unseen }})
-            </span>
-            <span v-else>
-              {{ getMailboxLabel(mailbox) }}
-            </span>
-          </template>
+          <span v-if="mailbox.unseen > 0" class="font-weight-bold">
+            {{ getMailboxLabel(mailbox) }} ({{ mailbox.unseen }})
+          </span>
+          <span v-else>
+            {{ getMailboxLabel(mailbox) }}
+          </span>
           <v-spacer />
           <v-btn
             v-if="mailbox.sub"
@@ -61,7 +49,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
 import { useBusStore, useWebmailStore } from '@/stores'
@@ -111,19 +99,11 @@ const iconByMailboxType = {
   normal: 'mdi-folder-outline',
 }
 
-const currentMailboxUnseen = ref(null)
 const hoverStates = ref({})
 const mailboxStates = ref({})
 
 function getMailboxLabel(mailbox) {
   return mailbox.label.split('/').pop()
-}
-
-function getCurrentMailboxUnseen(mailbox) {
-  if (currentMailboxUnseen.value === null) {
-    currentMailboxUnseen.value = mailbox.unseen
-  }
-  return currentMailboxUnseen.value
 }
 
 function setHover(mailbox, value) {
@@ -184,15 +164,6 @@ async function onDrop(mailbox) {
     busStore.hideNotification()
   }
 }
-
-watch(
-  () => busStore.mbCounterKey,
-  () => {
-    api.getUserMailboxUnseen(route.query.mailbox).then((resp) => {
-      currentMailboxUnseen.value = resp.data.counter
-    })
-  }
-)
 </script>
 
 <style scoped lang="scss">

--- a/frontend/src/layouts/webmail/WebmailLayout.vue
+++ b/frontend/src/layouts/webmail/WebmailLayout.vue
@@ -181,6 +181,29 @@ const mailboxQuotaTitle = computed(() => {
 
 const dataKey = computed(() => busStore.dataKey)
 
+function updateMailboxUnseen(mailboxes, name, counter) {
+  for (const mailbox of mailboxes) {
+    if (mailbox.name === name) {
+      mailbox.unseen = counter
+      return true
+    }
+    if (
+      mailbox.sub &&
+      mailbox.sub.length &&
+      updateMailboxUnseen(mailbox.sub, name, counter)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+function refreshMailboxUnseen(mailbox) {
+  api.getUserMailboxUnseen(mailbox).then((resp) => {
+    updateMailboxUnseen(userMailboxes.value, mailbox, resp.data.counter)
+  })
+}
+
 function openMailbox(mailbox) {
   router.push({
     name: 'MailboxView',
@@ -189,6 +212,9 @@ function openMailbox(mailbox) {
   api.getUserMailboxQuota(mailbox).then((resp) => {
     mailboxQuota.value = resp.data
   })
+  // A message may have arrived since the tree was loaded: refresh the
+  // selected mailbox counter so it reflects the current unseen count.
+  refreshMailboxUnseen(mailbox)
 }
 
 const fetchUserMailboxes = async () => {
@@ -250,6 +276,13 @@ const deleteMailbox = async () => {
 watch(dataKey, () => {
   fetchUserMailboxes()
 })
+
+watch(
+  () => busStore.mbCounterKey,
+  () => {
+    refreshMailboxUnseen(route.query.mailbox || 'INBOX')
+  }
+)
 
 await fetchUserMailboxes()
 const resp = await api.getUserMailboxQuota(route.query.mailbox || 'INBOX')

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -501,8 +501,12 @@ class IMAPconnector:
                 descr = {"name": name, "label": name, "type": "normal"}
                 newmboxes += [descr]
 
-            if "\\Marked" in flags or "\\UnMarked" not in flags:
-                descr["send_status"] = True
+            # A mailbox can hold unseen messages without being flagged
+            # \Marked (which only tracks messages *recently* added since the
+            # last SELECT). To display accurate counters we compute the unseen
+            # count for every selectable mailbox instead of relying on that
+            # heuristic. \Noselect mailboxes cannot be queried with STATUS.
+            descr["selectable"] = "\\Noselect" not in flags
             if r"\NonExistent" in flags:
                 descr["removed"] = True
             if has_children:
@@ -577,20 +581,25 @@ class IMAPconnector:
             if parent:
                 until_mailbox = parent
         self._listmboxes(topmailbox, md_mailboxes, until_mailbox, subscribed_only)
-
-        if unseen_messages:
-            for mb in md_mailboxes:
-                if "send_status" not in mb:
-                    continue
-                del mb["send_status"]
-                key = "path" if "path" in mb else "name"
-                if mb.get("removed", False):
-                    continue
-                count = self.unseen_messages(mb[key])
-                if count == 0:
-                    continue
-                mb["unseen"] = count
+        self._set_unseen_counters(md_mailboxes, unseen_messages)
         return md_mailboxes
+
+    def _set_unseen_counters(self, mailboxes: list, compute: bool = True) -> None:
+        """Compute the unseen messages counter of each selectable mailbox.
+
+        The ``selectable`` marker is an internal detail and is always
+        removed, whether or not the counters are actually computed.
+        """
+        for mb in mailboxes:
+            selectable = mb.pop("selectable", False)
+            if mb.get("sub"):
+                self._set_unseen_counters(mb["sub"], compute)
+            if not compute or not selectable or mb.get("removed", False):
+                continue
+            key = "path" if "path" in mb else "name"
+            count = self.unseen_messages(mb[key])
+            if count:
+                mb["unseen"] = count
 
     def _add_flag(self, mbox: str, msgset: list[str], flag: str) -> None:
         """Add flag to a messages set.

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -111,6 +111,50 @@ class UserMailboxViewSetTestCase(WebmailTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["counter"], 10)
 
+    def test_list_unseen_counters(self):
+        """Unseen counters must be computed for every selectable mailbox.
+
+        Even a mailbox flagged \\UnMarked (no *recent* activity since the
+        last SELECT) can hold unseen messages and must expose its counter.
+        \\Noselect mailboxes cannot be queried with STATUS and must be
+        skipped.
+        """
+
+        class IMAP4MockWithFolders(IMAP4Mock):
+            def _simple_command(self, name, *args, **kwargs):
+                if name == "LIST":
+                    self.untagged_responses["LIST"] = [
+                        b'(\\Subscribed \\HasNoChildren) "." "INBOX"',
+                        b'(\\Subscribed \\UnMarked \\HasNoChildren) "." "Archive"',
+                        # Unsubscribed but kept because it has children; its
+                        # \\Noselect flag means it must not be queried.
+                        b'(\\Noselect \\HasChildren) "." "Parent"',
+                    ]
+                    return "OK", None
+                if name == "STATUS":
+                    target = args[0]
+                    if isinstance(target, bytes):
+                        target = target.decode()
+                    count = 10 if "INBOX" in target else 3
+                    self.untagged_responses["STATUS"] = [
+                        f"STATUS x (UNSEEN {count})".encode()
+                    ]
+                    return "OK", None
+                return super()._simple_command(name, *args, **kwargs)
+
+        self.mock_imap4.return_value = IMAP4MockWithFolders()
+        self.authenticate()
+        url = reverse("v2:webmail-mailbox-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        mailboxes = {mb["name"]: mb for mb in response.json()["mailboxes"]}
+        # \\UnMarked mailbox with unseen messages: counter must be present
+        # (the previous heuristic skipped it).
+        self.assertEqual(mailboxes["Archive"]["unseen"], 3)
+        self.assertEqual(mailboxes["INBOX"]["unseen"], 10)
+        # \\Noselect mailbox: not queried, counter stays 0.
+        self.assertEqual(mailboxes["Parent"]["unseen"], 0)
+
     def test_create(self):
         self.authenticate()
         url = reverse("v2:webmail-mailbox-list")


### PR DESCRIPTION
Unread counters were computed with the \Marked/\UnMarked LIST heuristic, which only tracks *recent* activity since the last SELECT. A mailbox holding unseen messages but flagged \UnMarked (e.g. subfolders visited earlier) was skipped, so no counter was displayed.

Backend: compute the unseen count for every selectable mailbox actually returned by LIST (skipping \Noselect ones) instead of relying on that heuristic. The counting is now recursive to also cover deep-loaded trees.

Frontend: use mailbox.unseen as the single source of truth for all folders (current one included), refresh the current mailbox counter in place on mbCounterKey bumps, refresh a mailbox counter when it is selected (a message may have arrived meanwhile), and include the counter refresh in the junk actions and the 5-minute auto-refresh.

Add a regression test covering the \UnMarked and \Noselect cases.