### PR TITLE
fix: preserve already-decoded Unicode in Amavis text

### DIFF
--- a/modoboa/amavis/tests/test_utils.py
+++ b/modoboa/amavis/tests/test_utils.py
@@ -17,3 +17,14 @@ class FixUTF8EncodingTests(SimpleTestCase):
         expected_output = "\xf0\x9f\x99"
         output = fix_utf8_encoding(value)
         self.assertEqual(output, expected_output)
+
+    def test_valid_unicode_is_unchanged(self):
+        value = "Łukasz Jabłoński"
+        output = fix_utf8_encoding(value)
+        self.assertEqual(output, value)
+
+    def test_latin1_mojibake_is_repaired(self):
+        value = "Å\x81ukasz JabÅ\x82oÅ\x84ski"
+        expected_output = "Łukasz Jabłoński"
+        output = fix_utf8_encoding(value)
+        self.assertEqual(output, expected_output)

--- a/modoboa/amavis/utils.py
+++ b/modoboa/amavis/utils.py
@@ -53,6 +53,10 @@ def fix_utf8_encoding(value: str) -> str:
         # short circuit for empty strings
         return ""
 
+    if any(ord(char) > 0xFF for char in value):
+        # Already-decoded Unicode must not be converted to literal escapes.
+        return value
+
     bytes_value = value.encode("raw_unicode_escape")
     try:
         value = bytes_value.decode("utf-8")


### PR DESCRIPTION
## Problem
Fixes #4142.

`fix_utf8_encoding()` currently converts an already-correct Unicode string containing characters outside Latin-1 into literal `\\uXXXX` text. This affects quarantine sender names, subjects, and message bodies containing characters such as Polish, Greek, Cyrillic, or CJK text.

## Change
Return the input unchanged when it already contains a code point outside the Latin-1 range. Latin-1 mojibake continues through the existing repair path.

Added regression tests covering valid Unicode and Latin-1 mojibake.

## User impact
Correctly decoded non-Latin text is displayed as the original text instead of escaped sequences, without changing the existing mojibake repair behavior.

## Validation
- Direct assertions for valid Unicode, Latin-1 mojibake, empty input, valid four-byte UTF-8, and truncated UTF-8: 5 passed.
- Python compilation check passed.
- `git diff --check` passed.
- The repository Django test could not be run in this environment because installing the project's dependencies requires the system header `rrd.h` for `rrdtool-bindings`; no application test failure was observed.

This contribution was AI-assisted; the issue's reproduction and proposed guard were independently checked against the current implementation.
