### PR TITLE
fix(admin): dedupe alias recipients on resolved target

### DIFF
--- a/modoboa/admin/models/alias.py
+++ b/modoboa/admin/models/alias.py
@@ -230,6 +230,19 @@ class Alias(AdminObject):
                     kwargs["r_alias"] = rcpt
                 else:
                     kwargs["r_mailbox"] = rcpt
+            # An alias can only reference a given local target once
+            # (unique constraint on (alias, r_mailbox) / (alias, r_alias)).
+            # Address extensions (foo+bar) are stripped during resolution, so
+            # foo@dom and foo+bar@dom resolve to the same target: skip it here
+            # instead of hitting an IntegrityError.
+            if kwargs.get("r_mailbox") is not None and (
+                self.aliasrecipient_set.filter(r_mailbox=kwargs["r_mailbox"]).exists()
+            ):
+                continue
+            if kwargs.get("r_alias") is not None and (
+                self.aliasrecipient_set.filter(r_alias=kwargs["r_alias"]).exists()
+            ):
+                continue
             AliasRecipient(**kwargs).save()
 
     def remove_recipient_or_delete(self, recipient_to_delete: str):

--- a/modoboa/admin/tests/test_alias.py
+++ b/modoboa/admin/tests/test_alias.py
@@ -28,6 +28,22 @@ class AliasTestCase(ModoAPITestCase):
         alias = Alias.objects.get(address="badalias@test.com")
         self.assertEqual(alias.recipients_count, 1)
 
+    def test_alias_with_base_and_extension_recipient(self):
+        """A base address and its +extension resolve to the same mailbox.
+
+        They must be deduplicated instead of raising an IntegrityError on the
+        (alias, r_mailbox) unique constraint.
+        """
+        from ..models import Domain
+
+        alias = factories.AliasFactory.create(
+            address="plusalias@test.com", domain=Domain.objects.get(name="test.com")
+        )
+        alias.add_recipients(["user@test.com", "user+ext@test.com"])
+        self.assertEqual(alias.recipients_count, 1)
+        recipient = AliasRecipient.objects.get(alias=alias)
+        self.assertEqual(recipient.r_mailbox.full_address, "user@test.com")
+
     def test_upper_case_alias(self):
         """Try to create an upper case alias."""
         user = User.objects.get(username="user@test.com")


### PR DESCRIPTION
An alias recipient using an address extension (foo+bar@dom) is stripped of its extension during resolution, so foo@dom and foo+bar@dom resolve to the same mailbox. add_recipients deduplicated on the raw address only, letting both be inserted and violating the (alias, r_mailbox) unique constraint with an IntegrityError -- notably when saving the pointed account re-syncs its aliases.

Deduplicate on the resolved r_mailbox/r_alias target before inserting. External recipients keep their address-based dedup.