### PR TITLE
fix(core): resolve extension version from installed package metadata

### DIFF
--- a/modoboa/core/extensions.py
+++ b/modoboa/core/extensions.py
@@ -1,10 +1,30 @@
 """Extension management."""
 
+import functools
+from importlib.metadata import PackageNotFoundError, packages_distributions, version
+
 from django.conf import settings
 from django.templatetags.static import static
 from django.urls import include
 from django.urls import re_path
 from django.utils.encoding import smart_str
+
+
+@functools.cache
+def get_installed_version(module_name: str) -> str | None:
+    """Return the version of the distribution providing the given module.
+
+    ``None`` is returned when the module does not belong to an installed
+    distribution (local extension, source checkout, etc.).
+    """
+    top_level = module_name.split(".")[0]
+    candidates = packages_distributions().get(top_level) or [top_level]
+    for dist_name in candidates:
+        try:
+            return version(dist_name)
+        except PackageNotFoundError:
+            continue
+    return None
 
 
 class ModoExtension:
@@ -31,6 +51,16 @@ class ModoExtension:
     def get_available_apps(self) -> list:
         return []
 
+    def get_version(self) -> str:
+        """Return the version of this extension.
+
+        The ``version`` attribute is declared by the extension itself and
+        can easily become out of sync with the installed package. When the
+        extension is provided by an installed distribution, its metadata is
+        used as the source of truth.
+        """
+        return get_installed_version(self.name) or self.version
+
     def get_url(self):
         """Return extension base url."""
         if self.url is None:
@@ -42,7 +72,7 @@ class ModoExtension:
         return {
             "name": self.name,
             "label": self.label,
-            "version": self.version,
+            "version": self.get_version(),
             "description": self.description,
             "url": self.get_url(),
             "topredirection_url": self.topredirection_url,

--- a/modoboa/core/tests/test_extensions.py
+++ b/modoboa/core/tests/test_extensions.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from io import StringIO
+from unittest import mock
 
 from testfixtures import compare
 
@@ -72,6 +73,14 @@ class ExtensionTestCase(TestCase):
             },
         )
 
+    def test_get_extension_infos_uses_installed_version(self):
+        """Version must come from package metadata when available."""
+        with mock.patch.object(
+            extensions, "get_installed_version", return_value="1.1.0"
+        ):
+            infos = self.pool.get_extension_infos("stupid_extension_1")
+        self.assertEqual(infos["version"], "1.1.0")
+
     def test_list_all(self):
         """Check list_all method."""
         result = self.pool.list_all()
@@ -104,6 +113,58 @@ class ExtensionTestCase(TestCase):
 
         urls = self.pool.get_urls(category="api")
         self.assertEqual(len(urls), 0)
+
+
+class ModoExtensionVersionTests(TestCase):
+    """Version resolution related tests."""
+
+    def _ext(self, **attrs):
+        defaults = {"name": "ext", "label": "Ext", "version": "1.0.0"}
+        defaults.update(attrs)
+        return type("_Ext", (extensions.ModoExtension,), defaults)()
+
+    def setUp(self):
+        extensions.get_installed_version.cache_clear()
+        self.addCleanup(extensions.get_installed_version.cache_clear)
+
+    def test_installed_version_wins_over_declared_one(self):
+        """A stale hardcoded version must not shadow the installed package."""
+        ext = self._ext(name="modoboa_pro")
+        with (
+            mock.patch.object(
+                extensions,
+                "packages_distributions",
+                return_value={"modoboa_pro": ["modoboa-pro"]},
+            ),
+            mock.patch.object(extensions, "version", return_value="1.1.0") as vmock,
+        ):
+            self.assertEqual(ext.get_version(), "1.1.0")
+        vmock.assert_called_once_with("modoboa-pro")
+
+    def test_fallback_to_declared_version(self):
+        """Extensions not provided by a distribution keep their attribute."""
+        ext = self._ext(name="local_extension")
+        with (
+            mock.patch.object(extensions, "packages_distributions", return_value={}),
+            mock.patch.object(
+                extensions, "version", side_effect=extensions.PackageNotFoundError
+            ),
+        ):
+            self.assertEqual(ext.get_version(), "1.0.0")
+
+    def test_submodule_extension(self):
+        """Extensions shipped inside a package use the top-level distribution."""
+        ext = self._ext(name="modoboa.rspamd")
+        with (
+            mock.patch.object(
+                extensions,
+                "packages_distributions",
+                return_value={"modoboa": ["modoboa"]},
+            ),
+            mock.patch.object(extensions, "version", return_value="2.5.0") as vmock,
+        ):
+            self.assertEqual(ext.get_version(), "2.5.0")
+        vmock.assert_called_once_with("modoboa")
 
 
 class ModoExtensionFrontendManifestTests(TestCase):


### PR DESCRIPTION
The version displayed for an extension came from the `version` class attribute hardcoded in each plugin's modo_extension.py. When a plugin is released without bumping that attribute, Modoboa keeps advertising the old version (and the update check compares against a stale value).

Resolve the version from the installed distribution metadata, like the core already does, and fall back to the declared attribute for local extensions or source checkouts.