### PR TITLE
fix(core): harden SMS password recovery on the Django side

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -4,15 +4,6 @@ export default {
   requestToken(data) {
     return repository.post('/token/', data)
   },
-  recoverPassword(data) {
-    return repository.post('/password_reset/', data)
-  },
-  checkSmsTotp(data) {
-    return repository.post('/sms_totp/', data)
-  },
-  changePassword(data) {
-    return repository.post('/reset_confirm/', data)
-  },
   beginFidoRegistration() {
     return repository.post('/fido/registration/begin/')
   },

--- a/modoboa/core/api/v2/serializers.py
+++ b/modoboa/core/api/v2/serializers.py
@@ -1,27 +1,16 @@
 """Core API v2 serializers."""
 
 import django_otp
-import oath
 
 from django.conf import settings
-from django.db.models import Q
 
 from django.contrib.auth import authenticate, password_validation
-from django.contrib.sites.shortcuts import get_current_site
-from django.contrib.auth.tokens import default_token_generator
-from django.core.mail import send_mail
-from django.core.exceptions import ValidationError as djangoValidationError
 
-from django.template import loader
 
 from django.utils import formats
-from django.utils.encoding import force_str
-from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
-from django.utils.encoding import force_bytes
 from django.utils.translation import gettext_lazy, gettext as _
 
-from rest_framework import serializers, status
-from rest_framework.exceptions import APIException
+from rest_framework import serializers
 
 from modoboa.core import (
     constants,
@@ -29,36 +18,8 @@ from modoboa.core import (
     sms_backends,
     app_settings,
 )
-from modoboa.core.models import User
-from modoboa.lib import fields as lib_fields, cryptutils
+from modoboa.lib import fields as lib_fields
 from modoboa.parameters import tools as param_tools
-
-
-class CustomValidationError(APIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    default_detail = "A server error occurred."
-
-    def __init__(self, detail, status_code):
-        if status_code is not None:
-            self.status_code = status_code
-        if detail is not None:
-            self.detail = detail
-        else:
-            self.detail = {"detail": force_str(self.default_detail)}
-
-
-class NoSMSAvailable(Exception):
-    """Raised when no sms totp is available for password reset (to try email)."""
-
-    pass
-
-
-class PasswordRequirementsFailure(Exception):
-    """Raised when django is not happy with password provided."""
-
-    def __init__(self, message_list, *args: object) -> None:
-        super().__init__(*args)
-        self.message_list = message_list
 
 
 class CoreGlobalParametersSerializer(serializers.Serializer):
@@ -454,203 +415,6 @@ class UserAPITokenSerializer(serializers.Serializer):
     token = serializers.CharField()
 
 
-class PasswordRecoveryEmailSerializer(serializers.Serializer):
-    """Serializer used by password recovery route."""
-
-    email = serializers.EmailField()
-
-    def validate(self, data):
-        clean_email = data["email"]
-        self.context["user"] = (
-            User.objects.filter(email__iexact=clean_email, is_active=True).exclude(
-                Q(secondary_email__isnull=True) | Q(secondary_email="")
-            )
-        ).first()
-        # Do not disclose whether an account exists: always return a success
-        # response. When no matching user is found, sending is simply skipped
-        # in save().
-        return data
-
-    def save(self):
-        user = self.context["user"]
-        if user is None:
-            return
-        to_email = user.secondary_email
-        current_site = get_current_site(self.context["request"])
-        site_name = current_site.name
-        domain = current_site.domain
-        context = {
-            "email": to_email,
-            "domain": domain,
-            "site_name": site_name,
-            "uid": urlsafe_base64_encode(force_bytes(user.pk)),
-            "user": user,
-            "token": default_token_generator.make_token(user),
-            "protocol": "https",
-        }
-        subject = loader.render_to_string(
-            "registration/password_reset_subject.txt", context
-        )
-        # Email subject *must not* contain newlines
-        subject = "".join(subject.splitlines())
-        body = loader.render_to_string(
-            "registration/password_reset_email.html", context
-        )
-        send_mail(subject, body, None, [to_email], fail_silently=False)
-
-
-def send_sms_code(secret, backend, user):
-    """Send a sms containing a TOTP code for password reset."""
-    code = oath.totp(secret)
-    text = _(
-        "Please use the following code to recover your Modoboa password: {}".format(
-            code
-        )
-    )
-    if not backend.send(text, [str(user.phone_number)]):
-        raise NoSMSAvailable()
-
-
-class PasswordRecoverySmsSerializer(serializers.Serializer):
-    email = serializers.EmailField()
-
-    def validate(self, data, *args, **kwargs):
-        request = self.context["request"]
-        clean_email = data["email"]
-
-        user = User.objects.filter(email__iexact=clean_email, is_active=True).first()
-        if user is None:
-            # Fall back to the generic email response instead of revealing
-            # that no account matches this address.
-            raise NoSMSAvailable()
-
-        self.context["user"] = (
-            User.objects.filter(email__iexact=clean_email, is_active=True).exclude(
-                Q(phone_number__isnull=True) | Q(phone_number="")
-            )
-        ).first()
-        if self.context["user"] is None:
-            raise NoSMSAvailable()
-
-        if not request.localconfig.parameters.get_value("sms_password_recovery"):
-            raise NoSMSAvailable()
-
-        user = self.context["user"]
-        if not user:
-            raise NoSMSAvailable()
-        backend = sms_backends.get_active_backend(request.localconfig.parameters)
-        secret = cryptutils.random_hex_key(20)
-        send_sms_code(secret, backend, user)
-        request.session["totp_secret"] = secret
-        request.session["user_pk"] = user.pk
-        return data
-
-
-class PasswordRecoverySmsConfirmSerializer(serializers.Serializer):
-    sms_totp = serializers.CharField(min_length=6, max_length=6)
-
-    def validate(self, data):
-        try:
-            self.context["totp_secret"] = self.context["request"].session["totp_secret"]
-        except KeyError:
-            raise CustomValidationError(
-                {"reason": "totp secret not set in session"}, 403
-            ) from None
-        if not oath.accept_totp(self.context["totp_secret"], data["sms_totp"])[0]:
-            raise CustomValidationError({"reason": "Wrong totp"}, 400)
-
-        # Attempt to get user, will raise an error if pk is not valid
-        self.context["user"] = User.objects.filter(
-            pk=self.context["request"].session["user_pk"]
-        ).first()
-        if self.context["user"] is None:
-            raise CustomValidationError({"reason": "Invalid user"}, 400)
-
-        return data
-
-    def save(self):
-        self.context["request"].session.pop("totp_secret")
-        user_pk = self.context["request"].session.pop("user_pk")
-        token = default_token_generator.make_token(self.context["user"])
-        uid = urlsafe_base64_encode(force_bytes(user_pk))
-        self.context["response"] = (token, uid)
-        return True
-
-
-class PasswordRecoverySmsResendSerializer(serializers.Serializer):
-    def validate(self, data):
-        try:
-            self.context["totp_secret"] = self.context["request"].session["totp_secret"]
-        except KeyError:
-            raise CustomValidationError(
-                {"reason": "totp secret not set in session"}, status.HTTP_403_FORBIDDEN
-            ) from None
-
-        # Attempt to get user, will raise an error if pk is not valid
-        self.context["user"] = User.objects.filter(
-            pk=self.context["request"].session["user_pk"]
-        ).first()
-        if self.context["user"] is None:
-            raise CustomValidationError({"reason": "Invalid user"}, 400)
-
-        return data
-
-    def save(self):
-        backend = sms_backends.get_active_backend(
-            self.context["request"].localconfig.parameters
-        )
-        send_sms_code(self.context["totp_secret"], backend, self.context["user"])
-        return True
-
-
-class PasswordRecoveryConfirmSerializer(serializers.Serializer):
-    new_password1 = serializers.CharField()
-    new_password2 = serializers.CharField()
-
-    token = serializers.CharField()
-
-    id = serializers.CharField()
-
-    def get_user(self, user_id):
-        try:
-            # urlsafe_base64_decode() decodes to bytestring
-            uid = urlsafe_base64_decode(user_id).decode()
-            user = User.objects.get(pk=uid)
-        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
-            user = None
-        return user
-
-    def validate(self, data):
-        # Validate password
-        if (
-            data["new_password1"] == ""
-            or data["new_password1"] != data["new_password2"]
-        ):
-            raise serializers.ValidationError("Password is empty or does not match")
-
-        user = self.get_user(data["id"])
-
-        if user is None:
-            raise CustomValidationError({"reason": "User not found."}, 404)
-
-        if not default_token_generator.check_token(user, data["token"]):
-            raise CustomValidationError({"reason": "Wrong reset token"}, 403)
-
-        # Check that the password works with set conditions
-        try:
-            password_validation.validate_password(data["new_password1"], user)
-        except djangoValidationError as e:
-            raise PasswordRequirementsFailure(e.messages) from None
-        self.context["user"] = user
-        return super().validate(data)
-
-    def save(self):
-        user = self.context["user"]
-        user.set_password(self.validated_data["new_password1"])
-        user.save()
-        return True
-
-
 class ModoboaComponentSerializer(serializers.Serializer):
     """Serializer used for information endpoint."""
 
@@ -675,7 +439,6 @@ class NotificationSerializer(serializers.Serializer):
 
 
 class ModoboaApplicationSerializer(serializers.Serializer):
-
     label = serializers.CharField()
     name = serializers.CharField()
     icon = serializers.CharField()
@@ -684,14 +447,12 @@ class ModoboaApplicationSerializer(serializers.Serializer):
 
 
 class NewsFeedEntrySerializer(serializers.Serializer):
-
     title = serializers.CharField()
     link = serializers.CharField()
     published = serializers.DateTimeField()
 
 
 class ThemeSerializer(serializers.Serializer):
-
     theme_primary_color = serializers.CharField(default="#046BF8")
     theme_primary_color_dark = serializers.CharField(default="#0350BA")
     theme_primary_color_light = serializers.CharField(default="#3688F9")
@@ -703,7 +464,6 @@ class ThemeSerializer(serializers.Serializer):
 
 
 class ThemeLogoUploadSerializer(serializers.Serializer):
-
     LOGO_TYPES = ("login", "menu", "creation_form")
 
     logo_type = serializers.ChoiceField(choices=LOGO_TYPES)
@@ -711,7 +471,6 @@ class ThemeLogoUploadSerializer(serializers.Serializer):
 
 
 class StatisticsSerializer(serializers.Serializer):
-
     domain_count = serializers.IntegerField()
     domain_alias_count = serializers.IntegerField()
     account_count = serializers.IntegerField()

--- a/modoboa/core/api/v2/tests.py
+++ b/modoboa/core/api/v2/tests.py
@@ -5,18 +5,14 @@ import getpass
 import io
 import shutil
 import tempfile
-import oath
 from unittest import mock
 
 from PIL import Image
 
-from django.core import mail
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.urls import reverse
-from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
 
 from modoboa.admin import (
     factories,
@@ -190,7 +186,6 @@ class ParametersAPITestCase(ModoAPITestCase):
 
 
 class AccountViewSetTestCase(ModoAPITestCase):
-
     @classmethod
     def setUpTestData(cls):  # NOQA:N802
         """Create test data."""
@@ -339,329 +334,6 @@ class AccountViewSetTestCase(ModoAPITestCase):
         self.assertEqual(len(resp.json()), 1)
 
 
-class PasswordResetTestCase(AccountViewSetTestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.id = 0
-        self.sms_token = 0
-
-    @mock.patch("ovh.Client.get")
-    @mock.patch("ovh.Client.post")
-    def test_reset_password(self, client_post, client_get):
-        url = reverse("v2:password_reset")
-        # No payload provided
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, 400)
-
-        # Unknown account: the response must not disclose that no user
-        # exists. It looks exactly like a successful email request and no
-        # message is actually sent.
-        data = {"email": "doesntexist@whoami.com"}
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["type"], "email")
-        self.assertEqual(len(mail.outbox), 0)
-
-        account = models.User.objects.get(username="user@test.com")
-
-        # Email reset test
-        # Known account without a recovery email: same generic response,
-        # still nothing sent.
-        data = {"email": account.email}
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["type"], "email")
-        self.assertEqual(len(mail.outbox), 0)
-        # With secondary email
-        account.secondary_email = "toto@test.com"
-        account.is_active = True
-        account.save()
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["type"], "email")
-
-        # The email must contain a valid confirmation link (regression
-        # guard: an unset template variable previously produced a stray
-        # double slash that broke the link).
-        self.assertEqual(len(mail.outbox), 1)
-        uid = urlsafe_base64_encode(force_bytes(account.pk))
-        email_body = mail.outbox[0].body
-        self.assertIn(f"/reset/{uid}/", email_body)
-        self.assertNotIn("//reset/", email_body)
-
-        # SMS reset test
-        self.set_global_parameters(
-            {
-                "sms_password_recovery": True,
-                "sms_provider": "ovh",
-                "sms_ovh_application_key": "key",
-                "sms_ovh_application_secret": "secret",
-                "sms_ovh_consumer_key": "consumer",
-            },
-            app="core",
-        )
-
-        # Phone number
-        account.phone_number = "+33612345678"
-        account.save()
-        client_get.return_value = ["service"]
-        client_post.return_value = {"totalCreditsRemoved": 1}
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["type"], "sms")
-
-    def test_password_reset_does_not_disclose_account_existence(self):
-        """Unknown and existing accounts must yield identical responses.
-
-        Regression test: the endpoint used to return a 404 for unknown
-        addresses (and different payloads depending on the account state),
-        turning it into an account-enumeration oracle.
-        """
-        url = reverse("v2:password_reset")
-
-        # Existing, active account with a working recovery email.
-        account = models.User.objects.get(username="user@test.com")
-        account.secondary_email = "toto@test.com"
-        account.is_active = True
-        account.save()
-
-        known = self.client.post(url, {"email": account.email}, format="json")
-        unknown = self.client.post(
-            url, {"email": "doesntexist@whoami.com"}, format="json"
-        )
-        # Same status code and body: the two cases are indistinguishable.
-        self.assertEqual(known.status_code, 200)
-        self.assertEqual(unknown.status_code, known.status_code)
-        self.assertEqual(unknown.json(), known.json())
-
-    @mock.patch("ovh.Client.get")
-    @mock.patch("ovh.Client.post")
-    def test_password_reset_sms_totp(self, client_post, client_get):
-        """Test reset password by SMS."""
-        url_create_sms = reverse("v2:password_reset")
-        url_sms_totp = reverse("v2:sms_totp")
-
-        # Prepare account
-        account = models.User.objects.get(username="user@test.com")
-        account.phone_number = "+33612345678"
-        account.secondary_email = "toto@test.com"
-        account.is_active = True
-        account.save()
-
-        # Send sms
-        client_get.return_value = ["service"]
-        client_post.return_value = {"totalCreditsRemoved": 1}
-        self.set_global_parameters(
-            {
-                "sms_password_recovery": True,
-                "sms_provider": "ovh",
-                "sms_ovh_application_key": "key",
-                "sms_ovh_application_secret": "secret",
-                "sms_ovh_consumer_key": "consumer",
-            }
-        )
-        self.client.logout()
-        self.create_session()
-        data = {"email": account.email}
-        response = self.client.post(url_create_sms, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["type"], "sms")
-        self.assertIn("totp_secret", self.client.session)
-
-        # Get the secret
-        session = self.client.session
-        secret = session["totp_secret"]
-
-        # Fail to provide type
-        data = {"sms_totp": "123456"}
-        response = self.client.post(url_sms_totp, data, format="json")
-        self.assertEqual(response.status_code, 400)
-
-        # Resend sms
-        data = {"type": "resend"}
-        response = self.client.post(url_sms_totp, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["type"], "resend")
-
-        # False totp code
-        data = {"sms_totp": "123456", "type": "confirm"}
-        response = self.client.post(url_sms_totp, data, format="json")
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["reason"], "Wrong totp")
-
-        # Good totp code
-        data = {"sms_totp": oath.totp(secret), "type": "confirm"}
-        response = self.client.post(url_sms_totp, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("token", response.json())
-        self.assertIn("id", response.json())
-
-    @mock.patch("ovh.Client.get")
-    @mock.patch("ovh.Client.post")
-    def test_sms_totp_resend_does_not_reset_throttle(self, client_post, client_get):
-        """Ensure "resend" cannot be used to bypass the TOTP brute-force limit.
-
-        Regression test: the throttle counter used to be cleared on every
-        request, including "resend". An attacker could interleave resends
-        between wrong "confirm" guesses to reset the limit and brute-force
-        the 6-digit code indefinitely. The counter must now only be cleared
-        on a successful confirmation.
-        """
-        url_create_sms = reverse("v2:password_reset")
-        url_sms_totp = reverse("v2:sms_totp")
-
-        # Prepare account
-        account = models.User.objects.get(username="user@test.com")
-        account.phone_number = "+33612345678"
-        account.secondary_email = "toto@test.com"
-        account.is_active = True
-        account.save()
-
-        client_get.return_value = ["service"]
-        client_post.return_value = {"totalCreditsRemoved": 1}
-        self.set_global_parameters(
-            {
-                "sms_password_recovery": True,
-                "sms_provider": "ovh",
-                "sms_ovh_application_key": "key",
-                "sms_ovh_application_secret": "secret",
-                "sms_ovh_consumer_key": "consumer",
-            }
-        )
-        self.client.logout()
-        self.create_session()
-
-        # Start the SMS recovery flow to populate the session.
-        response = self.client.post(
-            url_create_sms, {"email": account.email}, format="json"
-        )
-        self.assertEqual(response.status_code, 200)
-
-        # The throttle counter is IP-based and shared across confirm/resend;
-        # start from a clean slate (the request above uses a different scope).
-        cache.clear()
-        # password_recovery_totp_check is rate-limited to 25/hour, so more than
-        # that many requests must eventually be throttled. Interleave wrong
-        # "confirm" guesses with "resend" requests: if resend reset the counter
-        # (the bug), no request would ever be throttled and we would loop
-        # unbounded; with the fix the shared counter keeps growing and a 429
-        # must be returned.
-        throttled = False
-        for _ in range(30):
-            response = self.client.post(
-                url_sms_totp,
-                {"sms_totp": "000000", "type": "confirm"},
-                format="json",
-            )
-            if response.status_code == 429:
-                throttled = True
-                break
-            self.assertEqual(response.status_code, 400)
-            response = self.client.post(url_sms_totp, {"type": "resend"}, format="json")
-            if response.status_code == 429:
-                throttled = True
-                break
-            self.assertEqual(response.status_code, 200)
-        cache.clear()
-        self.assertTrue(
-            throttled,
-            "TOTP confirm attempts were not throttled; resend reset the counter.",
-        )
-
-    @mock.patch("ovh.Client.get")
-    @mock.patch("ovh.Client.post")
-    def test_password_change(self, client_post, client_get):
-        url = reverse("v2:password_reset_confirm_v2")
-        url_create_sms = reverse("v2:password_reset")
-        url_sms_totp = reverse("v2:sms_totp")
-
-        client_get.return_value = ["service"]
-        client_post.return_value = {"totalCreditsRemoved": 1}
-        self.set_global_parameters(
-            {
-                "sms_password_recovery": True,
-                "sms_provider": "ovh",
-                "sms_ovh_application_key": "key",
-                "sms_ovh_application_secret": "secret",
-                "sms_ovh_consumer_key": "consumer",
-            }
-        )
-
-        # Prepare account
-        account = models.User.objects.get(username="user@test.com")
-        account.phone_number = "+33612345678"
-        account.secondary_email = "toto@test.com"
-        account.is_active = True
-        account.save()
-
-        # Send SMS
-        self.create_session()
-        data = {"email": account.email}
-        response = self.client.post(url_create_sms, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        session = self.client.session
-        secret = session["totp_secret"]
-        # Get token and ID
-        data = {"sms_totp": oath.totp(secret), "type": "confirm"}
-        response = self.client.post(url_sms_totp, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        id_ok = response.json()["id"]
-        token_ok = response.json()["token"]
-
-        # Password differs
-        data = {
-            "new_password1": "123456",
-            "new_password2": "123457",
-            "token": token_ok,
-            "id": id_ok,
-        }
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 400)
-
-        # Wrong ID
-        id_ko = urlsafe_base64_encode(force_bytes(-1))
-        data = {
-            "new_password1": "123456",
-            "new_password2": "123456",
-            "token": token_ok,
-            "id": id_ko,
-        }
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 404)
-
-        # Wrong Token
-        token_ko = "123456"
-        data = {
-            "new_password1": "123456",
-            "new_password2": "123456",
-            "token": token_ko,
-            "id": id_ok,
-        }
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 403)
-
-        # Failed password requirements
-        data = {
-            "new_password1": "123456",
-            "new_password2": "123456",
-            "token": token_ok,
-            "id": id_ok,
-        }
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.json()["type"], "password_requirement")
-
-        # All good
-        data = {
-            "new_password1": "MyHardenedPass1!",
-            "new_password2": "MyHardenedPass1!",
-            "token": token_ok,
-            "id": id_ok,
-        }
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, 200)
-        # TODO: See why user doesn't update it's password --> self.test_me_password(password_ok="MyHardenedPass1!")
-
-
 class LanguageViewSetTestCase(ModoAPITestCase):
     def test_list(self):
         url = reverse("v2:language-list")
@@ -677,7 +349,6 @@ class ComponentAPITestCase(ModoAPITestCase):
 
 
 class NotificationAPITestCase(ModoAPITestCase):
-
     def test_get_notifications(self):
         url = reverse("v2:notifications")
         resp = self.client.get(url)
@@ -687,12 +358,10 @@ class NotificationAPITestCase(ModoAPITestCase):
 
 
 class AuthenticatorData(bytes):
-
     credential_data = b"RESPONSE"
 
 
 class FIDOViewSetTestCase(ModoAPITestCase):
-
     @mock.patch("fido2.server.Fido2Server.register_complete")
     def test_registration(self, register_complete_mock):
         url = reverse("v2:fido-registration-begin")
@@ -715,7 +384,6 @@ class FIDOViewSetTestCase(ModoAPITestCase):
 
 
 class ThemeAPITestCase(ModoAPITestCase):
-
     def test_get(self):
         url = reverse("v2:theme")
         response = self.client.get(url)
@@ -869,7 +537,6 @@ class ThemeLogoUploadAPITestCase(ModoAPITestCase):
 
 
 class NewsFeedAPIViewTestCase(ModoAPITestCase):
-
     @classmethod
     def setUpTestData(cls):
         """Create test data."""
@@ -920,7 +587,6 @@ class NewsFeedAPIViewTestCase(ModoAPITestCase):
 
 
 class StatisticsAPIViewTestCase(ModoAPITestCase):
-
     @classmethod
     def setUpTestData(cls):
         """Create test data."""

--- a/modoboa/core/api/v2/urls.py
+++ b/modoboa/core/api/v2/urls.py
@@ -17,17 +17,6 @@ router.register(r"fido", viewsets.FIDOViewSet, basename="fido")
 urlpatterns = router.urls
 urlpatterns += [
     path(
-        "password_reset/",
-        views.DefaultPasswordResetView.as_view(),
-        name="password_reset",
-    ),
-    path(
-        "reset_confirm/",
-        views.PasswordResetConfirmView.as_view(),
-        name="password_reset_confirm_v2",
-    ),
-    path("sms_totp/", views.PasswordResetSmsTOTP.as_view(), name="sms_totp"),
-    path(
         "admin/components/",
         views.ComponentsInformationAPIView.as_view(),
         name="components_information",

--- a/modoboa/core/api/v2/views.py
+++ b/modoboa/core/api/v2/views.py
@@ -2,13 +2,11 @@
 
 from functools import reduce
 import logging
-from smtplib import SMTPException
 
 from dateutil import parser
 import feedparser
 
 from django.conf import settings
-from django.utils.datastructures import MultiValueDictKeyError
 
 from django.core.files.storage import default_storage
 
@@ -21,128 +19,13 @@ from modoboa.core import models, signals
 from modoboa.core.extensions import exts_pool
 from modoboa.core.utils import check_for_updates, get_capabilities
 from modoboa.lib.permissions import IsSuperUser, IsPrivilegedUser
-from modoboa.lib.throttle import (
-    UserLesserDdosUser,
-    PasswordResetApplyThrottle,
-    PasswordResetRequestThrottle,
-    PasswordResetTotpThrottle,
-)
+from modoboa.lib.throttle import UserLesserDdosUser
 
 from . import serializers
 
 logger = logging.getLogger("modoboa.auth")
 
 MODOBOA_WEBSITE_URL = "https://modoboa.org/"
-
-
-def delete_cache_key(class_target, throttles: list, request) -> None:
-    """Attempt to delete cache key from throttling on login/password reset success."""
-
-    for throttle in throttles:
-        if isinstance(throttle, class_target):
-            throttle.reset_cache(request)
-            return
-
-
-class EmailPasswordResetView(APIView):
-    """
-    An Api View which provides a method to request a password reset token based on an e-mail address.
-    """
-
-    throttle_classes = [PasswordResetRequestThrottle]
-
-    def post(self, request, *args, **kwargs):
-        serializer = serializers.PasswordRecoveryEmailSerializer(
-            data=request.data, context={"request": request}
-        )
-        serializer.is_valid(raise_exception=True)
-        try:
-            serializer.save()
-        except SMTPException:
-            return response.Response(
-                {
-                    "type": "email",
-                    "reason": "Error while sending the email. Please contact an administrator.",
-                },
-                503,
-            )
-
-        # Email response
-        return response.Response({"type": "email"}, 200)
-
-
-class DefaultPasswordResetView(EmailPasswordResetView):
-    """
-    Works with PasswordRecoveryForm.vue.
-    First checks if SMS recovery is available, else switch to super (Email recovery [with secondary email]).
-    """
-
-    def post(self, request, *args, **kwargs):
-        """Recover password."""
-        serializer = serializers.PasswordRecoverySmsSerializer(
-            data=request.data, context={"request": request}
-        )
-        try:
-            serializer.is_valid(raise_exception=True)
-        except serializers.NoSMSAvailable:
-            return super().post(request, *args, **kwargs)
-
-        # SMS response
-        return response.Response({"type": "sms"}, 200)
-
-
-class PasswordResetSmsTOTP(APIView):
-    """Check SMS Totp code."""
-
-    throttle_classes = [PasswordResetTotpThrottle]
-
-    def post(self, request, *args, **kwargs):
-        try:
-            if request.data["type"] == "confirm":
-                klass = serializers.PasswordRecoverySmsConfirmSerializer
-            elif request.data["type"] == "resend":
-                klass = serializers.PasswordRecoverySmsResendSerializer
-            serializer = klass(data=request.data, context={"request": request})
-        except (MultiValueDictKeyError, KeyError):
-            return response.Response({"reason": "No type provided."}, 400)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-        payload = {"type": "resend"}
-        if request.data["type"] == "confirm":
-            serializer_response = serializer.context["response"]
-            payload.update(
-                {
-                    "token": serializer_response[0],
-                    "id": serializer_response[1],
-                    "type": "confirm",
-                }
-            )
-            # Only clear the throttle counter after a genuinely successful
-            # confirmation. Resetting it on "resend" would let an attacker wipe
-            # the counter between guesses and brute-force the TOTP code.
-            delete_cache_key(PasswordResetTotpThrottle, self.get_throttles(), request)
-        return response.Response(payload, 200)
-
-
-class PasswordResetConfirmView(APIView):
-    """Get and set new user password."""
-
-    throttle_classes = [PasswordResetApplyThrottle]
-
-    def post(self, request, *args, **kwargs):
-        serializer = serializers.PasswordRecoveryConfirmSerializer(data=request.data)
-        try:
-            serializer.is_valid(raise_exception=True)
-        except serializers.PasswordRequirementsFailure as e:
-            data = {"type": "password_requirement"}
-            errors = []
-            for element in e.message_list:
-                errors.append(element)
-            data.update({"errors": errors})
-            return response.Response(data, 400)
-        serializer.save()
-        delete_cache_key(PasswordResetApplyThrottle, self.get_throttles(), request)
-        return response.Response(status=200)
 
 
 class ComponentsInformationAPIView(APIView):

--- a/modoboa/core/constants.py
+++ b/modoboa/core/constants.py
@@ -113,6 +113,13 @@ SMS_BACKENDS = [
 if settings.DEBUG:
     SMS_BACKENDS.insert(1, ("dummy", gettext_lazy("Dummy")))
 
+# A password recovery code is sent by SMS: the message needs time to reach its
+# recipient and to be typed back, so the accepted window is widened instead of
+# relying on the default one (about 90 seconds). A code stays valid for at
+# least SMS_CODE_PERIOD * SMS_CODE_BACKWARD_DRIFT seconds.
+SMS_CODE_PERIOD = 30
+SMS_CODE_BACKWARD_DRIFT = 20
+
 TFA_DEVICE_TOKEN_KEY = "otp_device_id"
 TFA_PRE_VERIFY_USER_PK = "tfa_pre_verify_user_pk"
 TFA_PRE_VERIFY_USER_BACKEND = "tfa_pre_verify_user_backend"

--- a/modoboa/core/forms.py
+++ b/modoboa/core/forms.py
@@ -1,7 +1,5 @@
 """Core forms."""
 
-import oath
-
 from django import forms
 from django.contrib.auth import forms as auth_forms, get_user_model
 from django.db.models import Q
@@ -9,12 +7,11 @@ from django.utils.translation import gettext as _, gettext_lazy
 
 import django_otp
 
-from modoboa.core import signals
+from modoboa.core import signals, sms_backends
 from modoboa.lib.form_utils import UserKwargModelFormMixin
 
 
 class AuthenticationForm(auth_forms.AuthenticationForm):
-
     rememberme = forms.BooleanField(initial=False, required=False)
 
     def confirm_login_allowed(self, user):
@@ -69,7 +66,7 @@ class VerifySMSCodeForm(forms.Form):
 
     def clean_code(self):
         code = self.cleaned_data["code"]
-        if not oath.accept_totp(self.totp_secret, code)[0]:
+        if not sms_backends.check_recovery_code(self.totp_secret, code):
             raise forms.ValidationError(_("Invalid code"))
         return code
 

--- a/modoboa/core/sms_backends/__init__.py
+++ b/modoboa/core/sms_backends/__init__.py
@@ -2,7 +2,24 @@
 
 from importlib import import_module
 
+import oath
+
 from .. import constants
+
+
+def generate_recovery_code(secret) -> str:
+    """Return the password recovery code to send for given secret."""
+    return oath.totp(secret, period=constants.SMS_CODE_PERIOD)
+
+
+def check_recovery_code(secret, code) -> bool:
+    """Tell if given password recovery code is still valid."""
+    return oath.accept_totp(
+        secret,
+        code,
+        period=constants.SMS_CODE_PERIOD,
+        backward_drift=constants.SMS_CODE_BACKWARD_DRIFT,
+    )[0]
 
 
 class SMSBackend:

--- a/modoboa/core/tests/test_authentication.py
+++ b/modoboa/core/tests/test_authentication.py
@@ -2,9 +2,11 @@
 
 import os
 import smtplib
+import time
 from unittest import mock, skipIf, skipUnless
 
 from django.core import mail
+from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
 
@@ -15,10 +17,13 @@ except ImportError:
 
 from django.template import Context, Template
 
-from modoboa.core import constants, signals as core_signals
+import oath
+
+from modoboa.core import constants, signals as core_signals, sms_backends
 from modoboa.core.context_processors import theme
 from modoboa.core.password_hashers import get_password_hasher
 from modoboa.core.password_hashers.utils import get_dovecot_schemes
+from modoboa.lib import cryptutils
 from modoboa.lib.tests import NO_SMTP, ModoTestCase
 from .. import factories, models
 
@@ -26,7 +31,6 @@ DOVEADM_TEST_PATH = f"{os.path.dirname(__file__)}/doveadm"
 
 
 class MockedAttestedCredentialData:
-
     def __init__(self, _):
         pass
 
@@ -306,6 +310,12 @@ class PasswordResetTestCase(ModoTestCase):
             username="user2@test.com", groups=("SimpleUsers",)
         )
 
+    def setUp(self):
+        super().setUp()
+        # Throttle counters live in a persistent cache and are shared with the
+        # API v2 tests, so they must not leak from one test to the next.
+        cache.clear()
+
     def test_reset_password(self):
         """Validate simple case."""
         self.client.logout()
@@ -400,6 +410,170 @@ class PasswordResetTestCase(ModoTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("totp_secret", self.client.session)
+
+    def test_reset_password_is_rate_limited(self):
+        """Requests are capped, to protect the SMS budget."""
+        self.client.logout()
+        url = reverse("password_reset")
+        data = {"email": self.account_ok.email}
+        # password_recovery_request is rate limited to 12/hour
+        for _ in range(12):
+            response = self.client.post(url, data)
+            self.assertEqual(response.status_code, 302)
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 429)
+        self.assertIn("Retry-After", response)
+
+    @mock.patch("oath.accept_totp")
+    def test_verify_sms_code_is_rate_limited(self, accept_totp):
+        """Wrong codes are capped and a good one clears the counter."""
+        accept_totp.return_value = (False, "")
+        self.client.logout()
+        session = self.client.session
+        session["user_pk"] = self.account_ok.pk
+        session["totp_secret"] = "secret"
+        session.save()
+        url = reverse("password_reset_confirm_code")
+        data = {"code": "123456"}
+        # password_recovery_totp_check is rate limited to 25/hour
+        for _ in range(25):
+            response = self.client.post(url, data)
+            self.assertEqual(response.status_code, 200)
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 429)
+
+        # A successful verification clears the counter
+        cache.clear()
+        accept_totp.return_value = (True, "")
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        session = self.client.session
+        session["user_pk"] = self.account_ok.pk
+        session["totp_secret"] = "secret"
+        session.save()
+        accept_totp.return_value = (False, "")
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch("ovh.Client.get")
+    @mock.patch("ovh.Client.post")
+    def test_resend_reset_code_is_rate_limited(self, client_post, client_get):
+        """A resend consumes the same budget as an initial request."""
+        self.set_global_parameters(
+            {
+                "sms_password_recovery": True,
+                "sms_provider": "ovh",
+                "sms_ovh_application_key": "key",
+                "sms_ovh_application_secret": "secret",
+                "sms_ovh_consumer_key": "consumer",
+            },
+            app="core",
+        )
+        client_get.return_value = ["service"]
+        client_post.return_value = {"totalCreditsRemoved": 1}
+        session = self.client.session
+        session["user_pk"] = self.account_ok.pk
+        session.save()
+        url = reverse("password_reset_resend_code")
+        for _ in range(12):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.json()["status"], "ko")
+
+    def test_reset_confirm_is_rate_limited(self):
+        """Applying a new password is capped too."""
+        self.client.logout()
+        url = reverse("password_reset_confirm", args=["invalid", "set-password"])
+        data = {"new_password1": "Toto1234", "new_password2": "Toto1234"}
+        # password_recovery_apply is rate limited to 25/hour
+        for _ in range(25):
+            response = self.client.post(url, data)
+            self.assertEqual(response.status_code, 200)
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 429)
+
+    SMS_PARAMETERS = {
+        "sms_password_recovery": True,
+        "sms_provider": "ovh",
+        "sms_ovh_application_key": "key",
+        "sms_ovh_application_secret": "secret",
+        "sms_ovh_consumer_key": "consumer",
+    }
+
+    def test_recovery_code_validity_window(self):
+        """A code must survive the SMS delivery and typing delay."""
+        secret = cryptutils.random_hex_key(20)
+        self.assertTrue(
+            sms_backends.check_recovery_code(
+                secret, sms_backends.generate_recovery_code(secret)
+            )
+        )
+        now = int(time.time())
+        # Still valid after a bit more than 9 minutes...
+        code = oath.totp(secret, period=constants.SMS_CODE_PERIOD, t=now - 570)
+        self.assertTrue(sms_backends.check_recovery_code(secret, code))
+        # ... but not after 20
+        code = oath.totp(secret, period=constants.SMS_CODE_PERIOD, t=now - 1200)
+        self.assertFalse(sms_backends.check_recovery_code(secret, code))
+
+    @mock.patch("ovh.Client.get")
+    @mock.patch("ovh.Client.post")
+    def test_reset_password_sms_email_is_case_insensitive(
+        self, client_post, client_get
+    ):
+        """The SMS branch must match the email like the email one does."""
+        client_get.return_value = ["service"]
+        client_post.return_value = {"totalCreditsRemoved": 1}
+        self.set_global_parameters(self.SMS_PARAMETERS)
+        self.client.logout()
+        response = self.client.post(
+            reverse("password_reset"), {"email": self.account_ok.email.upper()}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("password_reset_confirm_code"))
+
+    @mock.patch("ovh.Client.get")
+    @mock.patch("ovh.Client.post")
+    def test_reset_password_sms_empty_phone_number(self, client_post, client_get):
+        """An empty phone number must fall back to the email branch."""
+        client_get.return_value = ["service"]
+        client_post.return_value = {"totalCreditsRemoved": 1}
+        self.set_global_parameters(self.SMS_PARAMETERS)
+        account = factories.UserFactory(
+            username="empty@test.com",
+            secondary_email="empty@ext.com",
+            phone_number="",
+            groups=("SimpleUsers",),
+        )
+        self.client.logout()
+        response = self.client.post(reverse("password_reset"), {"email": account.email})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("password_reset_done"))
+        client_post.assert_not_called()
+
+    @mock.patch("ovh.Client.get")
+    @mock.patch("ovh.Client.post")
+    def test_reset_password_sms_inactive_account(self, client_post, client_get):
+        """A disabled account must not receive a recovery SMS."""
+        client_get.return_value = ["service"]
+        client_post.return_value = {"totalCreditsRemoved": 1}
+        self.set_global_parameters(self.SMS_PARAMETERS)
+        self.account_ok.is_active = False
+        self.account_ok.save(update_fields=["is_active"])
+        self.addCleanup(
+            lambda: models.User.objects.filter(pk=self.account_ok.pk).update(
+                is_active=True
+            )
+        )
+        self.client.logout()
+        response = self.client.post(
+            reverse("password_reset"), {"email": self.account_ok.email}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("password_reset_done"))
+        client_post.assert_not_called()
 
 
 class ThemeContextProcessorTestCase(ModoTestCase):

--- a/modoboa/core/views/__init__.py
+++ b/modoboa/core/views/__init__.py
@@ -1,6 +1,7 @@
 """Core views."""
 
 from .auth import (
+    PasswordResetConfirmView,
     PasswordResetView,
     LoginView,
     VerifySMSCodeView,
@@ -12,6 +13,7 @@ from .auth import (
 
 __all__ = [
     "LoginView",
+    "PasswordResetConfirmView",
     "PasswordResetView",
     "ResendSMSCodeView",
     "VerifySMSCodeView",

--- a/modoboa/core/views/auth.py
+++ b/modoboa/core/views/auth.py
@@ -4,10 +4,9 @@ from functools import cached_property
 import logging
 import urllib.parse
 
-import oath
-
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db.models import Q
 from django.http import HttpResponseRedirect, Http404, JsonResponse
 from django.urls import reverse
 from django.utils import translation
@@ -28,6 +27,12 @@ from modoboa.core import constants, fido2_auth, forms, models
 from modoboa.core.api.v2 import serializers
 from modoboa.core.password_hashers import get_password_hasher
 from modoboa.lib import cryptutils
+from modoboa.lib.throttle import (
+    PasswordResetApplyThrottle,
+    PasswordResetRequestThrottle,
+    PasswordResetTotpThrottle,
+    ThrottleViewMixin,
+)
 from modoboa.parameters import tools as param_tools
 
 from .. import sms_backends
@@ -117,7 +122,7 @@ class LoginView(LoginViewMixin, auth_views.LoginView):
             user.save()
         if pwhash.needs_rehash(user.password):
             logging.info(
-                _("Password hash parameter missmatch. " "Updating %s password"),
+                _("Password hash parameter missmatch. Updating %s password"),
                 user.username,
             )
             user.set_password(form.cleaned_data["password"])
@@ -148,10 +153,11 @@ class LoginView(LoginViewMixin, auth_views.LoginView):
         return self.render_to_response(self.get_context_data(form=form), status=401)
 
 
-class PasswordResetView(auth_views.PasswordResetView):
+class PasswordResetView(ThrottleViewMixin, auth_views.PasswordResetView):
     """Custom view to override form."""
 
     form_class = forms.PasswordResetForm
+    throttle_classes = [PasswordResetRequestThrottle]
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
@@ -172,15 +178,19 @@ class PasswordResetView(auth_views.PasswordResetView):
         )
         if not sms_password_recovery:
             return super().form_valid(form)
-        user = models.User._default_manager.filter(
-            email=form.cleaned_data["email"], phone_number__isnull=False
-        ).first()
+        user = (
+            models.User._default_manager.filter(
+                email__iexact=form.cleaned_data["email"], is_active=True
+            )
+            .exclude(Q(phone_number__isnull=True) | Q(phone_number=""))
+            .first()
+        )
         if not user:
             # Fallback to email
             return super().form_valid(form)
         backend = sms_backends.get_active_backend(self.request.localconfig.parameters)
         secret = cryptutils.random_hex_key(20)
-        code = oath.totp(secret)
+        code = sms_backends.generate_recovery_code(secret)
         text = _(
             "Please use the following code to recover your Modoboa password: {}".format(
                 code
@@ -193,11 +203,12 @@ class PasswordResetView(auth_views.PasswordResetView):
         return HttpResponseRedirect(reverse("password_reset_confirm_code"))
 
 
-class VerifySMSCodeView(generic.FormView):
+class VerifySMSCodeView(ThrottleViewMixin, generic.FormView):
     """View to verify a code received by SMS."""
 
     form_class = forms.VerifySMSCodeForm
     template_name = "registration/password_reset_confirm_code.html"
+    throttle_classes = [PasswordResetTotpThrottle]
 
     def get_form_kwargs(self):
         """Include totp secret in kwargs."""
@@ -210,6 +221,9 @@ class VerifySMSCodeView(generic.FormView):
 
     def form_valid(self, form):
         """Redirect to reset password form."""
+        # Only clear the counter once a code has genuinely been verified,
+        # otherwise wrong attempts would cost nothing to an attacker.
+        self.reset_throttles(self.request)
         user = models.User.objects.get(pk=self.request.session.pop("user_pk"))
         self.request.session.pop("totp_secret")
         token = default_token_generator.make_token(user)
@@ -218,8 +232,21 @@ class VerifySMSCodeView(generic.FormView):
         return HttpResponseRedirect(url)
 
 
-class ResendSMSCodeView(generic.View):
+class ResendSMSCodeView(ThrottleViewMixin, generic.View):
     """A view to resend validation code."""
+
+    # A resend sends a new SMS, so it must consume the same budget as an
+    # initial request instead of the (larger) code verification one.
+    throttle_classes = [PasswordResetRequestThrottle]
+    throttled_methods = ("GET",)
+
+    def throttled_response(self, request, throttle):
+        """Answer with JSON, as expected by the caller."""
+        response = JsonResponse({"status": "ko"}, status=429)
+        wait = throttle.wait()
+        if wait:
+            response["Retry-After"] = str(int(wait))
+        return response
 
     def get(self, request, *args, **kwargs):
         sms_password_recovery = self.request.localconfig.parameters.get_value(
@@ -233,16 +260,22 @@ class ResendSMSCodeView(generic.View):
             raise Http404 from None
         backend = sms_backends.get_active_backend(self.request.localconfig.parameters)
         secret = cryptutils.random_hex_key(20)
-        code = oath.totp(secret)
+        code = sms_backends.generate_recovery_code(secret)
         text = _(
             "Please use the following code to recover your Modoboa password: {}".format(
                 code
             )
         )
-        if not backend.send(text, [user.phone_number]):
+        if not backend.send(text, [str(user.phone_number)]):
             raise Http404 from None
         self.request.session["totp_secret"] = secret
         return JsonResponse({"status": "ok"})
+
+
+class PasswordResetConfirmView(ThrottleViewMixin, auth_views.PasswordResetConfirmView):
+    """Rate limited version of the builtin view."""
+
+    throttle_classes = [PasswordResetApplyThrottle]
 
 
 class TwoFactorCodeVerifyView(LoginViewMixin, generic.FormView):

--- a/modoboa/lib/throttle.py
+++ b/modoboa/lib/throttle.py
@@ -1,5 +1,8 @@
-from rest_framework.throttling import SimpleRateThrottle, UserRateThrottle
+from django.shortcuts import render
 from django.urls import resolve
+from django.utils.translation import gettext as _
+
+from rest_framework.throttling import SimpleRateThrottle, UserRateThrottle
 
 
 class UserDdosPerView(SimpleRateThrottle):
@@ -47,18 +50,60 @@ class LoginThrottle(SimpleRateThrottle):
 
 
 class PasswordResetRequestThrottle(LoginThrottle):
-
     scope = "password_recovery_request"
 
 
 class PasswordResetTotpThrottle(LoginThrottle):
-
     scope = "password_recovery_totp_check"
 
 
 class PasswordResetApplyThrottle(LoginThrottle):
-
     scope = "password_recovery_apply"
+
+
+class ThrottleViewMixin:
+    """Apply DRF throttle classes to a plain Django class based view.
+
+    The throttle classes defined above only need ``request.META`` and the
+    cache, so they work as is with a regular ``HttpRequest``. Reusing them
+    here means the Django views and their API v2 counterparts share the same
+    scopes, rates and counters.
+    """
+
+    throttle_classes: list = []
+    throttled_methods: tuple = ("POST",)
+
+    def get_throttles(self):
+        """Instantiate throttles once per request."""
+        if not hasattr(self, "_throttles"):
+            self._throttles = [klass() for klass in self.throttle_classes]
+        return self._throttles
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.method in self.throttled_methods:
+            for throttle in self.get_throttles():
+                if not throttle.allow_request(request, self):
+                    return self.throttled_response(request, throttle)
+        return super().dispatch(request, *args, **kwargs)
+
+    def throttled_response(self, request, throttle):
+        """Return the response sent once the rate limit is reached."""
+        response = render(
+            request,
+            "common/error.html",
+            {"error": _("Too many attempts, please try again later.")},
+            status=429,
+        )
+        wait = throttle.wait()
+        if wait:
+            response["Retry-After"] = str(int(wait))
+        return response
+
+    def reset_throttles(self, request):
+        """Clear counters, to call once a request legitimately succeeded."""
+        for throttle in self.get_throttles():
+            if hasattr(throttle, "reset_cache"):
+                throttle.reset_cache(request)
 
 
 class GetThrottleViewsetMixin:

--- a/modoboa/urls.py
+++ b/modoboa/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
     ),
     path(
         "reset/<uidb64>/<token>/",
-        auth_views.PasswordResetConfirmView.as_view(),
+        core_views.PasswordResetConfirmView.as_view(),
         name="password_reset_confirm",
     ),
     path(


### PR DESCRIPTION
Password recovery is served by the Django views: the Vue3 frontend delegates authentication to OIDC and its recovery screens were removed with the OIDC migration. The rate limiting, however, only existed on the unused API v2 endpoints.

Rate limit the Django views. `ThrottleViewMixin` applies the existing DRF throttle classes to plain class based views: they only need `request.META` and the cache, so both sides share the same scopes, rates and counters and an attacker cannot double a quota by alternating between them. `PasswordResetConfirmView` is subclassed to get the same treatment. A resend consumes the request budget rather than the larger verification one, since it sends a billable SMS, and the verification counter is only cleared on a genuine success so wrong attempts keep costing something.

Remove the API v2 recovery endpoints, which had no consumer left, along with their serializers, exceptions, tests and the orphan frontend calls.

Fix three defects in the remaining views:
- an empty phone number passed the `isnull=False` filter and an SMS was sent to an empty recipient; disabled accounts were eligible too, unlike in the email branch of the same form
- the SMS branch matched the address case sensitively while the email branch used `iexact`
- a code was only accepted for about 90 seconds, which an SMS delivery plus typing can easily exceed. Generation and verification now go through shared helpers and the accepted window is widened to at least 10 minutes
- as a side effect, the resend path passed a `PhoneNumber` object where the provider payload expects a string
