### PR TITLE
feat(admin): add bulk delete action to domain list

### DIFF
--- a/frontend/src/api/domains.js
+++ b/frontend/src/api/domains.js
@@ -53,6 +53,9 @@ export default {
   deleteDomain(domainId, data) {
     return repository.post(`/${domainResource}/${domainId}/delete/`, data)
   },
+  bulkDeleteDomains(data) {
+    return repository.post(`/${domainResource}/bulk_delete/`, data)
+  },
   createDomainAlias(data) {
     return repository.post(`/${domainAliasResource}/`, data)
   },

--- a/frontend/src/components/admin/domains/DomainList.vue
+++ b/frontend/src/components/admin/domains/DomainList.vue
@@ -29,7 +29,10 @@
             class="flex-grow-0 w-33 mr-4"
           ></v-text-field>
           <slot name="extraActions" />
-          <v-menu location="bottom">
+          <v-menu
+            v-if="canDeleteDomain && selected.length > 1"
+            location="bottom"
+          >
             <template #activator="{ props }">
               <v-btn
                 variant="flat"
@@ -40,7 +43,9 @@
                 {{ $gettext('Actions') }}
               </v-btn>
             </template>
-            <v-list density="compact"> </v-list>
+            <v-list density="compact">
+              <MenuItems :items="getActionMenuItems()" />
+            </v-list>
           </v-menu>
           <v-btn
             variant="text"
@@ -204,7 +209,7 @@ import { ref, onMounted } from 'vue'
 const { $gettext } = useGettext()
 const router = useRouter()
 
-const { canSetRole } = usePermissions()
+const { canSetRole, canDeleteDomain } = usePermissions()
 const busStore = useBusStore()
 
 const domainHeaders = [
@@ -320,6 +325,45 @@ async function deleteDomain(domain) {
   } finally {
     loading.value = false
   }
+}
+
+async function deleteDomains() {
+  const result = await confirm.value.open(
+    $gettext('Warning'),
+    $gettext('Do you really want to delete the selected domains?'),
+    {
+      color: 'error',
+      cancelLabel: $gettext('No'),
+      agreeLabel: $gettext('Yes'),
+    }
+  )
+  if (!result) {
+    return
+  }
+  loading.value = true
+  try {
+    await domainsApi.bulkDeleteDomains({
+      ids: selected.value,
+      keep_folder: keepDomainFolder.value,
+    })
+    selected.value = []
+    keepDomainFolder.value = false
+    reloadDomains()
+    busStore.displayNotification({ msg: $gettext('Domains deleted') })
+  } finally {
+    loading.value = false
+  }
+}
+
+function getActionMenuItems() {
+  return [
+    {
+      label: $gettext('Delete'),
+      icon: 'mdi-delete-outline',
+      onClick: deleteDomains,
+      color: 'red',
+    },
+  ]
 }
 
 function editDomain(domain) {

--- a/frontend/src/composables/permissions.js
+++ b/frontend/src/composables/permissions.js
@@ -17,6 +17,12 @@ export function usePermissions() {
     )
   })
 
+  const canDeleteDomain = computed(() => {
+    return [constants.RESELLER, constants.SUPER_ADMIN].includes(
+      authStore.authUser.role
+    )
+  })
+
   const canViewDomain = computed(() => {
     return [
       constants.DOMAIN_ADMIN,
@@ -28,6 +34,7 @@ export function usePermissions() {
   return {
     canSetRole,
     canAddDomain,
+    canDeleteDomain,
     canViewDomain,
   }
 }

--- a/modoboa/admin/api/v2/serializers.py
+++ b/modoboa/admin/api/v2/serializers.py
@@ -268,6 +268,13 @@ class DeleteDomainSerializer(serializers.Serializer):
     keep_folder = serializers.BooleanField(default=False)
 
 
+class DomainBulkDeleteSerializer(serializers.Serializer):
+    """Serializer used with bulk delete operation."""
+
+    ids = serializers.ListField(child=serializers.IntegerField(), allow_empty=False)
+    keep_folder = serializers.BooleanField(default=False)
+
+
 class AdminGlobalParametersSerializer(serializers.Serializer):
     """A serializer for global parameters."""
 
@@ -882,7 +889,6 @@ class AlarmSerializer(serializers.ModelSerializer):
 
 
 class AlarmBulkDeleteSerializer(serializers.Serializer):
-
     ids = serializers.ListField(child=serializers.IntegerField())
 
 

--- a/modoboa/admin/api/v2/tests.py
+++ b/modoboa/admin/api/v2/tests.py
@@ -188,6 +188,103 @@ class DomainViewSetTestCase(ModoAPITestCase):
             core_models.User.objects.filter(username="admin@test2.com").exists()
         )
 
+    def test_bulk_delete(self):
+        url = reverse("v2:domain-bulk-delete")
+
+        # Invalid input
+        resp = self.client.post(url, {}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.post(url, {"ids": []}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.post(url, {"ids": ["toto"]}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+        # Unknown domain
+        resp = self.client.post(url, {"ids": [9999]}, format="json")
+        self.assertEqual(resp.status_code, 404)
+
+        # Valid request
+        domains = models.Domain.objects.filter(name__in=["test.com", "test2.com"])
+        ids = list(domains.values_list("pk", flat=True))
+        resp = self.client.post(url, {"ids": ids}, format="json")
+        self.assertEqual(resp.status_code, 204)
+        self.assertFalse(models.Domain.objects.filter(pk__in=ids).exists())
+        # Related mailboxes must have been removed too
+        self.assertFalse(models.Mailbox.objects.filter(domain__pk__in=ids).exists())
+
+    def test_bulk_delete_auto_account_removal(self):
+        self.set_global_parameter("auto_account_removal", True)
+        domain = models.Domain.objects.get(name="test2.com")
+        url = reverse("v2:domain-bulk-delete")
+        resp = self.client.post(url, {"ids": [domain.pk]}, format="json")
+        self.assertEqual(resp.status_code, 204)
+        with self.assertRaises(models.Domain.DoesNotExist):
+            domain.refresh_from_db()
+        self.assertFalse(
+            core_models.User.objects.filter(username="admin@test2.com").exists()
+        )
+
+    def test_bulk_delete_denied_for_domain_admin(self):
+        """A domain administrator has no delete_domain permission."""
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.da_token.key)
+        domain = models.Domain.objects.get(name="test.com")
+        url = reverse("v2:domain-bulk-delete")
+        resp = self.client.post(url, {"ids": [domain.pk]}, format="json")
+        self.assertEqual(resp.status_code, 403)
+        self.assertTrue(models.Domain.objects.filter(pk=domain.pk).exists())
+
+    def test_bulk_delete_permissions(self):
+        """A reseller can only delete the domains it owns."""
+        self.set_global_parameter("enable_admin_limits", False, app="limits")
+        reseller = core_factories.UserFactory(
+            username="reseller", groups=("Resellers",)
+        )
+        owned = models.Domain.objects.get(name="test.com")
+        forbidden = models.Domain.objects.get(name="test2.com")
+        grant_access_to_object(reseller, owned, is_owner=True)
+        self.authenticate_user(reseller)
+        url = reverse("v2:domain-bulk-delete")
+
+        resp = self.client.post(url, {"ids": [owned.pk, forbidden.pk]}, format="json")
+        self.assertEqual(resp.status_code, 404)
+        # No domain must have been deleted
+        self.assertEqual(
+            models.Domain.objects.filter(pk__in=[owned.pk, forbidden.pk]).count(), 2
+        )
+
+        resp = self.client.post(url, {"ids": [owned.pk]}, format="json")
+        self.assertEqual(resp.status_code, 204)
+        self.assertFalse(models.Domain.objects.filter(pk=owned.pk).exists())
+
+    def test_bulk_delete_own_domain(self):
+        """A user must not delete the domain its own mailbox belongs to."""
+        self.set_global_parameter("enable_admin_limits", False, app="limits")
+        admin = core_models.User.objects.get(username="admin@test.com")
+        admin.role = "Resellers"
+        own_domain = admin.mailbox.domain
+        other = models.Domain.objects.get(name="test2.com")
+        grant_access_to_object(admin, other, is_owner=True)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.da_token.key)
+        url = reverse("v2:domain-bulk-delete")
+
+        resp = self.client.post(url, {"ids": [own_domain.pk, other.pk]}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        # No domain must have been deleted
+        self.assertEqual(
+            models.Domain.objects.filter(pk__in=[own_domain.pk, other.pk]).count(), 2
+        )
+
+    def test_bulk_delete_keep_folder(self):
+        domain = models.Domain.objects.get(name="test2.com")
+        url = reverse("v2:domain-bulk-delete")
+        with mock.patch("modoboa.admin.models.domain.Domain.delete") as delete_mock:
+            resp = self.client.post(
+                url, {"ids": [domain.pk], "keep_folder": True}, format="json"
+            )
+        self.assertEqual(resp.status_code, 204)
+        delete_mock.assert_called_once()
+        self.assertTrue(delete_mock.call_args[0][1])
+
     def test_administrators(self):
         domain = models.Domain.objects.get(name="test.com")
         url = reverse("v2:domain-administrators", args=[domain.pk])

--- a/modoboa/admin/api/v2/viewsets.py
+++ b/modoboa/admin/api/v2/viewsets.py
@@ -31,6 +31,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from modoboa.admin.api.v1 import viewsets as v1_viewsets
 from modoboa.core import constants as core_constants, models as core_models
+from modoboa.lib import permissions as lib_permissions
 from modoboa.lib import pagination
 from modoboa.lib import renderers as lib_renderers
 from modoboa.lib import signals as lib_signals
@@ -90,9 +91,21 @@ class DomainViewSet(
             return models.Domain.objects.get_for_admin(self.request.user)
         return models.Domain.objects.none()
 
+    def get_permissions(self):
+        if self.action == "bulk_delete":
+            # DjangoModelPermissions maps POST to the "add" permission, which
+            # is not what a deletion endpoint must require.
+            return [
+                permissions.IsAuthenticated(),
+                lib_permissions.CanDeleteDomain(),
+            ]
+        return super().get_permissions()
+
     def get_serializer_class(self, *args, **kwargs):
         if self.action == "delete":
             return serializers.DeleteDomainSerializer
+        if self.action == "bulk_delete":
+            return serializers.DomainBulkDeleteSerializer
         if self.action == "administrators":
             return serializers.DomainAdminSerializer
         if self.action in ["add_administrator", "remove_administrator"]:
@@ -111,6 +124,26 @@ class DomainViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         domain.delete(request.user, serializer.validated_data["keep_folder"])
+        return response.Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(methods=["post"], detail=False)
+    def bulk_delete(self, request, **kwargs):
+        """Delete multiple domains at the same time."""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        ids = serializer.validated_data["ids"]
+        domains = self.get_queryset().filter(pk__in=ids)
+        if domains.count() != len(set(ids)):
+            return response.Response(status=status.HTTP_404_NOT_FOUND)
+        mb = getattr(request.user, "mailbox", None)
+        if mb and mb.domain_id in ids:
+            return response.Response(
+                {"ids": [_("You can't delete your own domain")]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        keep_folder = serializer.validated_data["keep_folder"]
+        for domain in domains:
+            domain.delete(request.user, keep_folder)
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=["get"], detail=True)
@@ -349,7 +382,6 @@ class IdentityViewSet(GetThrottleViewsetMixin, viewsets.ViewSet):
 
 
 class AliasFilter(dj_filters.FilterSet):
-
     domain = dj_filters.ModelChoiceFilter(
         queryset=lambda request: models.Domain.objects.get_for_admin(request.user),
         to_field_name="name",

--- a/modoboa/lib/permissions.py
+++ b/modoboa/lib/permissions.py
@@ -194,3 +194,10 @@ class CanViewDomain(permissions.BasePermission):
 
     def has_permission(self, request, view):
         return request.user.has_perm("admin.view_domain")
+
+
+class CanDeleteDomain(permissions.BasePermission):
+    """Permissions class to allow users with delete_domain right."""
+
+    def has_permission(self, request, view):
+        return request.user.has_perm("admin.delete_domain")


### PR DESCRIPTION
Add a dedicated POST /api/v2/domains/bulk_delete/ endpoint, mirroring what already exists for accounts.

The queryset is filtered by get_for_admin() so any id the user can't access returns a 404 without deleting anything, and deleting the domain owning one's own mailbox is refused. Deletion goes through Domain.delete() to keep the business logic (access revocation, quotas, auto_account_removal).

DjangoModelPermissions maps POST to the "add" permission, which is wrong for a deletion endpoint, so a CanDeleteDomain permission class is used for this action only: super admins and resellers can call it, domain admins get a 403.

On the frontend side, the (so far empty) "Actions" menu of the domain list now offers a Delete entry when several domains are selected.

fix #3974 