### PR TITLE
feat(auth): patch fido registration name

### DIFF
--- a/modoboa/core/api/v2/tests.py
+++ b/modoboa/core/api/v2/tests.py
@@ -364,9 +364,37 @@ class AuthenticatorData(bytes):
 class FIDOViewSetTestCase(ModoAPITestCase):
     @mock.patch("fido2.server.Fido2Server.register_complete")
     def test_registration(self, register_complete_mock):
+        self.maxDiff = None
+
         url = reverse("v2:fido-registration-begin")
         resp = self.client.post(url)
         self.assertEqual(resp.status_code, 200)
+        self.assertIn("publicKey", resp.json())
+        self.assertIn("challenge", resp.json()["publicKey"])
+        self.assertIn("pubKeyCredParams", resp.json()["publicKey"])
+        self.assertIn("user", resp.json()["publicKey"])
+        self.assertIn("id", resp.json()["publicKey"]["user"])
+        self.assertEqual(resp.json(), {
+            "publicKey": {
+                "authenticatorSelection": {
+                    "requireResidentKey": False,
+                    "residentKey": "discouraged",
+                     "userVerification": "discouraged",
+                },
+                "excludeCredentials": [],
+                "challenge": resp.json()["publicKey"]["challenge"],  # Random value
+                "pubKeyCredParams": resp.json()["publicKey"]["pubKeyCredParams"],  # Complex and subject to change
+                "rp": {
+                    "id": "testserver",
+                    "name": "Modoboa",
+                },
+                "user": {
+                    "id": resp.json()["publicKey"]["user"]["id"],  # Random value
+                    "name": "admin",
+                    "displayName": "admin",
+                }
+            },
+        })
 
         register_complete_mock.side_effect = [AuthenticatorData()]
         data = {

--- a/modoboa/core/fido2_auth.py
+++ b/modoboa/core/fido2_auth.py
@@ -29,7 +29,7 @@ def begin_registration(request):
     options, state = server.register_begin(
         PublicKeyCredentialUserEntity(
             id=request.user.pk,
-            name=request.user.username.encode("utf-8"),
+            name=request.user.username,
             display_name=request.user.username,
         ),
         list(get_creds_from_user(request.user.pk).values()),

--- a/modoboa/core/views/auth.py
+++ b/modoboa/core/views/auth.py
@@ -343,4 +343,10 @@ class FidoAuthenticationEndView(LoginViewMixin, APIView):
             user, fido_state, serializer.validated_data, request.get_host()
         )
         response = self.login(user, self.request.session.pop("rememberme", False))
-        return JsonResponse({"next": response.url})
+        return JsonResponse({
+            "next": response.url,
+            "user": {
+                "name": user.username,
+                "displayName": user.get_full_name(),
+            },
+        })

--- a/modoboa/templates/registration/twofactor_code_verify.html
+++ b/modoboa/templates/registration/twofactor_code_verify.html
@@ -89,10 +89,9 @@
     if (!request.ok) {
       throw new Error('No credential available to authenticate!')
     }
-    let json = await request.json()
-    let options = parseRequestOptionsFromJSON(json)
+    let options = await request.json()
 
-    let response = await get(options);
+    let response = await get(parseRequestOptionsFromJSON(options))
     let params = new URLSearchParams(window.location.search)
     let url = "{% url 'core:fido_auth_end' %}"
     if (params.has('next')) {
@@ -103,7 +102,30 @@
       headers: { "X-CSRFToken": csrf, 'Content-Type': 'application/json'},
       body: JSON.stringify(response),
     })
-    json = await result.json()
+    let json = await result.json()
+
+    // Signal current user information
+    // (updates displayed user name, if supported)
+    if (typeof(PublicKeyCredential.signalCurrentUserDetails) === "function") {
+      await PublicKeyCredential.signalCurrentUserDetails({
+        rpId: options.publicKey.rpId,
+        userId: response.id,
+        name: json.user.name,
+        displayName: json.user.displayName,
+      });
+    }
+
+    // Signal current list of still accepted credentials
+    // (discards dead authenticator credentials, if supported)
+    if (typeof(PublicKeyCredential.signalAllAcceptedCredentials) === "function") {
+      await PublicKeyCredential.signalAllAcceptedCredentials({
+        rpId: options.publicKey.rpId,
+        userId: response.id,
+        allAcceptedCredentialIds:
+          options.publicKey.allowCredentials.map(cred => cred.id),
+      });
+    }
+
     location.href = json.next
   }
   window.useWebAuthn = useWebAuthn


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes #4123 as best as is possible

Current behavior before PR:
PassKeys are created with `b'<username>'` as user name. User name changes are not propagated to authenticators.

Desired behavior after PR is merged:
PassKeys are created with correct user names. The WebAuthn Signal API is used to propagate the current user name and user display name on login to compatible authenticators on compatible browsers (not many), also the current list of accepted credentials is signalled since I was at it.

Notably the authoritative user name and display name are only returned by the server *after* solving the 2FA challenge to give maximum assurance that no private user data is leaked even to attackers knowing a user’s username and password.
