### PR TITLE
Require django-rq>=4.2 to avoid rqcron registration crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,11 @@ dependencies = [
 	"python-magic>=0.4.24",
 	# RQ
 	# rq>=2.11 passes a `name` kwarg to CronScheduler.register() that
-	# django-rq's DjangoCronScheduler.register() does not yet accept,
-	# breaking `manage.py rqcron` (see rq/django-rq#818). Cap until a
-	# django-rq release picks up the fix.
-	"rq>=2.7.0,<2.11",
-	"django-rq>=4.1.1",
+	# django-rq's DjangoCronScheduler.register() did not accept before
+	# 4.2, breaking `manage.py rqcron` (see rq/django-rq#818). Require
+	# the fixed django-rq release instead of capping rq.
+	"rq>=2.7.0",
+	"django-rq>=4.2",
 	# Sieve
 	"sievelib>=1.4.1",
 	# User

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,11 @@ dependencies = [
 	"defusedxml>=0.6.0",
 	"python-magic>=0.4.24",
 	# RQ
-	"rq>=2.7.0",
+	# rq>=2.11 passes a `name` kwarg to CronScheduler.register() that
+	# django-rq's DjangoCronScheduler.register() does not yet accept,
+	# breaking `manage.py rqcron` (see rq/django-rq#818). Cap until a
+	# django-rq release picks up the fix.
+	"rq>=2.7.0,<2.11",
 	"django-rq>=4.1.1",
 	# Sieve
 	"sievelib>=1.4.1",


### PR DESCRIPTION
## Problem

After a fresh install, `rq-scheduler` keeps bouncing between `STARTING` and `RUNNING` under supervisor and never actually schedules any cron job. The logs show:

```
Failed to register job clean_logs from config: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
```

## Root cause

`rq` 2.11 changed `rq.cron.CronScheduler.load_config_from_file()` to always pass a `name` keyword when replaying jobs collected from a cron config file. `django-rq` 4.1.1's `DjangoCronScheduler.register()` (the scheduler class used by `manage.py rqcron`) did not accept that keyword, so every job registration raised and none of the cron jobs got scheduled.

## Fix

~~Cap `rq` to `<2.11` in `pyproject.toml`~~ **Update:** `django-rq` 4.2 has now been released with the fix (rq/django-rq#818, `register()` accepts `name` as of that release — verified against the `v4.2` tag). Requiring `django-rq>=4.2` is the real fix rather than pinning `rq` below the version that exposed the incompatibility. Version-pin-only change; no application code is affected.

Fixes #4145