### PR TITLE
perf: speed up super admin creation and promotion

### DIFF
--- a/modoboa/admin/handlers.py
+++ b/modoboa/admin/handlers.py
@@ -1,6 +1,7 @@
 """Django signal handlers for admin."""
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 from django.db.models import signals
 from django.dispatch import receiver
 from django.utils.translation import gettext as _
@@ -267,10 +268,13 @@ def grant_access_to_all_objects(sender, account, role, **kwargs):
         models.Mailbox.objects.all(),
         models.Alias.objects.filter(internal=False),
     ]
-    for queryset in querysets:
-        permissions.grant_access_to_objects(
-            account, queryset, ContentType.objects.get_for_model(queryset.model)
-        )
+    # All or nothing: a partially promoted super admin would silently
+    # lack access to some objects.
+    with transaction.atomic():
+        for queryset in querysets:
+            permissions.grant_access_to_objects(
+                account, queryset, ContentType.objects.get_for_model(queryset.model)
+            )
 
 
 @receiver(admin_signals.import_object)

--- a/modoboa/lib/permissions.py
+++ b/modoboa/lib/permissions.py
@@ -2,6 +2,7 @@
 
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import QuerySet
 from django.utils.translation import gettext as _
 
 from rest_framework import permissions, serializers
@@ -102,11 +103,29 @@ def grant_access_to_objects(user, objects, ct):
     applies to all objects).
 
     :param user: a ``User`` object
-    :param objects: a list of objects
+    :param objects: a list of objects or a ``QuerySet``
     :param ct: the content type
     """
-    for obj in objects:
-        ObjectAccess.objects.get_or_create(user=user, content_type=ct, object_id=obj.id)
+    if isinstance(objects, QuerySet):
+        # Only primary keys are needed: don't build model instances, some
+        # of them query the database on their own to initialize.
+        object_ids = objects.values_list("pk", flat=True)
+    else:
+        object_ids = (obj.id for obj in objects)
+    granted = set(
+        ObjectAccess.objects.filter(user=user, content_type=ct).values_list(
+            "object_id", flat=True
+        )
+    )
+    ObjectAccess.objects.bulk_create(
+        [
+            ObjectAccess(user=user, content_type=ct, object_id=object_id)
+            for object_id in object_ids
+            if object_id not in granted
+        ],
+        batch_size=1000,
+        ignore_conflicts=True,
+    )
 
 
 def ungrant_access_to_object(obj, user=None):


### PR DESCRIPTION
Promoting an account to SuperAdmins grants it access to every object of the instance, through grant_access_to_objects(). That function ran one get_or_create() per object, and was handed full querysets whose model instances were built for their primary key only -- Mailbox.__init__ even queries the database on its own to read full_address.

Load the already granted object ids in a single query, then bulk create what is missing. Querysets are consumed with values_list("pk") so no model instance is built; a plain list of objects is still accepted.

With 414 objects (208 accounts, 204 mailboxes, 2 domains):

  promotion             1874 queries / 198 ms -> 23 queries / 14 ms
  creation              1891 queries          -> 36 queries
  promotion replayed     628 queries          -> 15 queries

The grants are also wrapped in a transaction: a partially promoted super admin would silently lack access to some objects, and ATOMIC_REQUESTS does not cover management commands nor RQ tasks.