### PR TITLE
fix: stop leaving objects without an owner on role downgrade

### DIFF
--- a/modoboa/admin/tests/test_ownership.py
+++ b/modoboa/admin/tests/test_ownership.py
@@ -1,0 +1,133 @@
+"""Tests about object ownership."""
+
+from django.core import management
+
+from modoboa.core.models import User
+from modoboa.lib.permissions import get_object_owner
+from modoboa.lib.tests import ModoTestCase
+from .. import factories, models
+
+
+class OwnershipTestCase(ModoTestCase):
+    """Check that objects never end up without an owner."""
+
+    @classmethod
+    def setUpTestData(cls):  # NOQA:N802
+        """Create some data."""
+        super().setUpTestData()
+        factories.populate_database()
+
+    def _create_super_admin(self, username):
+        """Return a new active super admin."""
+        account = User(username=username, email=f"{username}@test.com")
+        account.set_password("toto")
+        account.is_superuser = True
+        account.is_active = True
+        account.save()
+        return account
+
+    def _create_owned_objects(self, creator):
+        """Return an account and a mailbox owned by creator."""
+        domain = models.Domain.objects.get(name="test.com")
+        account = User(username="owned@test.com", email="owned@test.com")
+        account.save(creator=creator)
+        mbox = models.Mailbox(
+            address="owned", domain=domain, user=account, use_domain_quota=True
+        )
+        mbox.set_quota(override_rules=True)
+        mbox.save(creator=creator)
+        self.assertEqual(get_object_owner(account), creator)
+        self.assertEqual(get_object_owner(mbox), creator)
+        return account, mbox
+
+    def test_downgrade_domain_admin_to_simple_user(self):
+        """Objects owned by a demoted admin must be given to somebody."""
+        admin = User.objects.get(username="admin@test.com")
+        account, mbox = self._create_owned_objects(admin)
+
+        admin.role = "SimpleUsers"
+
+        for obj in (account, mbox):
+            owner = get_object_owner(obj)
+            self.assertIsNotNone(owner)
+            self.assertNotEqual(owner, admin)
+
+    def test_downgrade_super_admin(self):
+        """Same when a super admin loses its role."""
+        sadmin = User.objects.get(username="admin")
+        domain = models.Domain.objects.get(name="test.com")
+        self.assertEqual(get_object_owner(domain), sadmin)
+        self._create_super_admin("other")
+
+        sadmin.role = "DomainAdmins"
+
+        owner = get_object_owner(domain)
+        self.assertIsNotNone(owner)
+        self.assertNotEqual(owner, sadmin)
+
+    def test_downgrade_transfers_to_own_owner(self):
+        """Ownership goes to the account which created the demoted one."""
+        sadmin = User.objects.get(username="admin")
+        admin = User.objects.get(username="admin@test.com")
+        self.assertEqual(get_object_owner(admin), sadmin)
+        account, mbox = self._create_owned_objects(admin)
+
+        admin.role = "SimpleUsers"
+
+        self.assertEqual(get_object_owner(account), sadmin)
+        self.assertEqual(get_object_owner(mbox), sadmin)
+
+    def test_downgrade_keeps_existing_access(self):
+        """An object the new owner could already see stays visible once."""
+        sadmin = User.objects.get(username="admin")
+        admin = User.objects.get(username="admin@test.com")
+        account, mbox = self._create_owned_objects(admin)
+        # sadmin already has a non owner access on both objects
+        self.assertTrue(sadmin.can_access(account))
+        self.assertTrue(sadmin.can_access(mbox))
+
+        admin.role = "SimpleUsers"
+
+        for obj in (account, mbox):
+            self.assertEqual(get_object_owner(obj), sadmin)
+            self.assertEqual(
+                sadmin.objectaccess_set.filter(
+                    content_type__model=obj.__class__.__name__.lower(),
+                    object_id=obj.pk,
+                ).count(),
+                1,
+            )
+
+    def test_promotion_keeps_owners(self):
+        """Promoting somebody must not steal ownership."""
+        sadmin = User.objects.get(username="admin")
+        admin = User.objects.get(username="admin@test.com")
+        account, mbox = self._create_owned_objects(sadmin)
+
+        admin.role = "SuperAdmins"
+
+        self.assertEqual(get_object_owner(account), sadmin)
+        self.assertEqual(get_object_owner(mbox), sadmin)
+
+    def test_delete_self_owned_admin_without_request(self):
+        """The default admin owns itself and is deletable out of a request."""
+        sadmin = User.objects.get(username="admin")
+        self.assertEqual(get_object_owner(sadmin), sadmin)
+        domain = models.Domain.objects.get(name="test.com")
+        other = self._create_super_admin("other")
+
+        sadmin.delete()
+
+        self.assertEqual(get_object_owner(domain), other)
+
+    def test_repair_finds_nothing_after_downgrade(self):
+        """The repair command must have nothing left to fix."""
+        admin = User.objects.get(username="admin@test.com")
+        self._create_owned_objects(admin)
+        admin.role = "SimpleUsers"
+
+        management.call_command("modo", "repair", "--quiet")
+
+        for model in (models.Domain, models.Mailbox):
+            for obj in model.objects.all():
+                self.assertIsNotNone(get_object_owner(obj), f"{obj} has no owner")

--- a/modoboa/core/handlers.py
+++ b/modoboa/core/handlers.py
@@ -89,8 +89,8 @@ def update_permissions(sender, instance, **kwargs):
     """Permissions cleanup."""
     request = get_request()
     # request migth be None (management command context)
-    if request:
-        from_user = request.user
+    from_user = request.user if request else None
+    if from_user is not None:
         if from_user == instance:
             raise exceptions.PermDeniedException(_("You can't delete your own account"))
 
@@ -99,15 +99,14 @@ def update_permissions(sender, instance, **kwargs):
 
     # We send an additional signal before permissions are removed
     core_signals.account_deleted.send(sender="update_permissions", user=instance)
-    owner = permissions.get_object_owner(instance)
-    if owner == instance:
-        # The default admin is being removed...
-        owner = from_user
     # Change ownership of existing objects
-    for ooentry in instance.objectaccess_set.filter(is_owner=True):
-        if ooentry.content_object is not None:
-            permissions.grant_access_to_object(owner, ooentry.content_object, True)
-            permissions.ungrant_access_to_object(ooentry.content_object, instance)
+    owner = permissions.get_object_owner(instance)
+    if owner is None or owner == instance:
+        # The default admin owns itself: fall back on the user asking for
+        # the removal, then (inside transfer_ownership) on any other
+        # active super admin.
+        owner = from_user
+    permissions.transfer_ownership(instance, owner)
     # Remove existing permissions on this user
     permissions.ungrant_access_to_object(instance)
 

--- a/modoboa/core/models.py
+++ b/modoboa/core/models.py
@@ -296,6 +296,12 @@ class User(AbstractUser):
             self.is_superuser = True
         else:
             if self.is_superuser or role == "SimpleUsers":
+                from modoboa.lib.permissions import transfer_ownership
+
+                # The account is about to lose every access it has, so
+                # the objects it owns must be given to somebody else
+                # first, otherwise they end up without any owner.
+                transfer_ownership(self)
                 ObjectAccess.objects.filter(user=self).delete()
             self.is_superuser = False
             try:

--- a/modoboa/lib/permissions.py
+++ b/modoboa/lib/permissions.py
@@ -1,5 +1,7 @@
 """Object level permissions."""
 
+from collections import defaultdict
+
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import QuerySet
@@ -126,6 +128,64 @@ def grant_access_to_objects(user, objects, ct):
         batch_size=1000,
         ignore_conflicts=True,
     )
+
+
+def transfer_ownership(user, new_owner=None):
+    """Give the objects owned by an account to another one.
+
+    Must be called before an account loses its permissions (deletion,
+    role downgrade): its ``ObjectAccess`` entries are then removed, and
+    without this every object it owned would be left without any owner.
+
+    :param user: the current owner
+    :param new_owner: the account to transfer ownership to. Defaults to
+                      the owner of ``user``, then to the first active
+                      super admin.
+    :return: the new owner, or ``None`` if no candidate was found
+    """
+    if new_owner is None or new_owner == user:
+        new_owner = get_object_owner(user)
+    if new_owner is None or new_owner == user:
+        new_owner = (
+            User.objects.filter(is_superuser=True, is_active=True)
+            .exclude(pk=user.pk)
+            .first()
+        )
+    if new_owner is None:
+        return None
+    owned = defaultdict(set)
+    for content_type_id, object_id in user.objectaccess_set.filter(
+        is_owner=True
+    ).values_list("content_type_id", "object_id"):
+        owned[content_type_id].add(object_id)
+    for content_type_id, object_ids in owned.items():
+        # The new owner may already have a non owner access to some of
+        # those objects: update the existing entries, create the others.
+        existing = set(
+            ObjectAccess.objects.filter(
+                user=new_owner,
+                content_type_id=content_type_id,
+                object_id__in=object_ids,
+            ).values_list("object_id", flat=True)
+        )
+        if existing:
+            ObjectAccess.objects.filter(
+                user=new_owner, content_type_id=content_type_id, object_id__in=existing
+            ).update(is_owner=True)
+        ObjectAccess.objects.bulk_create(
+            [
+                ObjectAccess(
+                    user=new_owner,
+                    content_type_id=content_type_id,
+                    object_id=object_id,
+                    is_owner=True,
+                )
+                for object_id in object_ids - existing
+            ],
+            batch_size=1000,
+            ignore_conflicts=True,
+        )
+    return new_owner
 
 
 def ungrant_access_to_object(obj, user=None):


### PR DESCRIPTION
Setting a role deletes every ObjectAccess entry of the account when it loses its privileges (a super admin being demoted, or anybody becoming a SimpleUsers), including the is_owner ones. Nothing was reattributed, so each object the account owned was left without any owner until somebody ran "modo repair".

Add permissions.transfer_ownership(), which gives those objects to another account -- the owner of the demoted one, then any other active super admin -- and call it before the accesses are dropped. Existing non owner entries of the new owner are promoted rather than duplicated.

The account deletion handler now shares that helper, which fixes two of its own problems:

* from_user was only assigned when a request was available, but read unconditionally when the account owned itself. Deleting the default admin outside of a request (management command, RQ task) raised UnboundLocalError instead of working.
* it walked ObjectAccess entries one by one and dereferenced the generic foreign key of each, which instantiates the target object. Deleting a super admin of a large instance meant two queries per owned object, and Mailbox.__init__ queries the database on its own.