### PR TITLE
Webmail: sandbox message display and embed inline images

### DIFF
--- a/frontend/src/views/webmail/EmailView.vue
+++ b/frontend/src/views/webmail/EmailView.vue
@@ -242,13 +242,13 @@ const emailDocument = computed(() => {
     "style-src 'unsafe-inline'",
     "form-action 'none'",
   ].join('; ')
-  return (
-    '<!DOCTYPE html><html><head><meta charset="utf-8">' +
-    `<meta http-equiv="Content-Security-Policy" content="${csp}">` +
-    '<base target="_blank"></head><body>' +
-    email.value.body +
-    '</body></html>'
-  )
+  return `
+    <!DOCTYPE html><html><head><meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    <base target="_blank"></head><body>
+    ${email.value.body}
+    </body></html>
+  `
 })
 
 const resizeEmailIframe = () => {

--- a/frontend/src/views/webmail/EmailView.vue
+++ b/frontend/src/views/webmail/EmailView.vue
@@ -154,7 +154,18 @@
       {{ $gettext('Message scheduled at:') }}
       {{ $date(email.scheduled_datetime) }}
     </v-alert>
-    <iframe class="email-frame" />
+    <!--
+      The message body is untrusted: render it in a sandboxed iframe
+      (no scripts, opaque origin) so it can never reach the application
+      context, even if the server-side HTML cleaner is bypassed.
+    -->
+    <iframe
+      ref="emailFrame"
+      class="email-frame"
+      sandbox="allow-popups allow-popups-to-escape-sandbox"
+      referrerpolicy="no-referrer"
+      :srcdoc="emailDocument"
+    />
   </div>
   <v-dialog v-model="showEmailSource" max-width="1200">
     <v-card :title="$gettext('Message source')">
@@ -173,7 +184,7 @@
 </template>
 
 <script setup>
-import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
 import { useBusStore } from '@/stores'
@@ -188,6 +199,7 @@ const router = useRouter()
 
 const enableLinks = ref(false)
 const email = ref(null)
+const emailFrame = ref(null)
 const emailSource = ref(null)
 const headers = ref(null)
 const loaded = ref(false)
@@ -215,8 +227,35 @@ const close = () => {
   })
 }
 
+const emailDocument = computed(() => {
+  if (!email.value?.body) {
+    return ''
+  }
+  // Remote content (images, fonts, etc.) is only allowed when links are
+  // enabled, which also prevents tracking pixels from loading by default.
+  const remoteSrc = enableLinks.value ? ' https: http:' : ''
+  const csp = [
+    "default-src 'none'",
+    `img-src data:${remoteSrc}`,
+    `media-src data:${remoteSrc}`,
+    `font-src data:${remoteSrc}`,
+    "style-src 'unsafe-inline'",
+    "form-action 'none'",
+  ].join('; ')
+  return (
+    '<!DOCTYPE html><html><head><meta charset="utf-8">' +
+    `<meta http-equiv="Content-Security-Policy" content="${csp}">` +
+    '<base target="_blank"></head><body>' +
+    email.value.body +
+    '</body></html>'
+  )
+})
+
 const resizeEmailIframe = () => {
-  const iframe = document.querySelector('iframe')
+  const iframe = emailFrame.value
+  if (!iframe || !headers.value) {
+    return
+  }
   let rect
   if (schedulingInfo.value) {
     rect = schedulingInfo.value.$el.getBoundingClientRect()
@@ -238,18 +277,8 @@ const fetchMailContent = () => {
     .then((resp) => {
       reloadMailboxCounters()
       email.value = resp.data
-      nextTick(() => {
-        const iframe = document.createElement('iframe')
-        iframe.classList.add('email-frame')
-        document.querySelector('iframe').replaceWith(iframe)
-        if (email.value.body) {
-          const iframeDoc = iframe.contentDocument
-          iframeDoc.write(email.value.body)
-          iframeDoc.close()
-        }
-        loaded.value = true
-        nextTick(resizeEmailIframe)
-      })
+      loaded.value = true
+      nextTick(resizeEmailIframe)
     })
 }
 

--- a/modoboa/webmail/constants.py
+++ b/modoboa/webmail/constants.py
@@ -12,6 +12,16 @@ MAILBOX_NAME_SCHEDULED = "Scheduled"
 CUSTOM_HEADER_SCHEDULED_ID = "X-Scheduled-ID"
 CUSTOM_HEADER_SCHEDULED_DATETIME = "X-Scheduled-Datetime"
 
+# Inline images embedded as data: URIs when displaying a message
+# (SVG is excluded on purpose: it can carry active content).
+INLINE_IMAGE_MIME_TYPES = (
+    "image/bmp",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+)
+
 
 class SchedulingState(Enum):
     SCHEDULED = "scheduled"

--- a/modoboa/webmail/lib/imapemail.py
+++ b/modoboa/webmail/lib/imapemail.py
@@ -2,16 +2,14 @@
 Set of classes to manipulate/display emails inside the webmail.
 """
 
-import os
+import base64
 import re
 import email
+from urllib.parse import unquote
 
 from charset_normalizer import detect as charset_detect
 
 from django.apps import apps
-from django.conf import settings
-from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.utils.encoding import smart_str
 from django.utils.html import conditional_escape
 from django.utils.translation import gettext as _
@@ -21,7 +19,6 @@ from modoboa.lib.email_utils import Email
 from modoboa.webmail import constants
 
 from . import imapheader
-from .attachments import get_storage_path
 from .imaputils import get_imapconnector, validate_imap_uid, BodyStructure
 from .utils import decode_payload
 
@@ -219,27 +216,34 @@ class ImapEmail(Email):
             self.attachments[att["pnum"]] = smart_str(attname)
 
     def _fetch_inlines(self):
-        """Store inline images on filesystem to display them."""
-        for cid, params in list(self.bs.inlines.items()):
-            if re.search(r"\.\.", cid):
+        """Embed inline images into the body as data: URIs.
+
+        Images are never written to disk: storing them in a shared,
+        publicly served directory leaked them to other users (message
+        UIDs are only unique per mailbox).
+        """
+        if not self.links:
+            # cid: references are only rewritten when links are enabled
+            return
+        for params in self.bs.inlines.values():
+            content_type = params.get("Content-Type", "")
+            encoding = (params.get("encoding") or "").lower()
+            if content_type not in constants.INLINE_IMAGE_MIME_TYPES:
                 continue
-            fname = f"{self.mailid}_{cid}"
-            path = os.path.relpath(get_storage_path(fname), settings.MEDIA_ROOT)
-            params["fname"] = os.path.join(
-                settings.MEDIA_URL, os.path.basename(get_storage_path("")), fname
-            )
-            if default_storage.exists(path):
+            if encoding not in ("base64", "quoted-printable"):
                 continue
             pdef, content = self.imapc.fetchpart(self.mailid, self.mbox, params["pnum"])
-            default_storage.save(
-                path, ContentFile(decode_payload(params["encoding"], content))
+            payload = decode_payload(encoding, content)
+            params["data_uri"] = (
+                f"data:{content_type};base64,{base64.b64encode(payload).decode()}"
             )
 
     def _map_cid(self, url):
-        m = re.match(".*cid:(.+)", url)
-        if m:
-            if m.group(1) in self.bs.inlines:
-                return self.bs.inlines[m.group(1)]["fname"]
+        if url[:4].lower() != "cid:":
+            return url
+        params = self.bs.inlines.get(unquote(url[4:]))
+        if params and "data_uri" in params:
+            return params["data_uri"]
         return url
 
     def fetch_attachment(self, pnum):

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -129,6 +129,7 @@ class BodyStructure:
                 self.contents[subtype].append(params)
             return
         elif multisubtype in ["related"]:
+            params["Content-Type"] = ftype
             self.inlines[params["cid"].strip("<>")] = params
             return
 

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -284,7 +284,10 @@ class IMAPconnector:
             data = self._cmd("AUTHENTICATE", b"OAUTHBEARER", token)
         else:
             user = bytes(settings.WEBMAIL_DEV_USERNAME, "utf-8")
-            passwd = bytes(self.m._quote(settings.WEBMAIL_DEV_PASSWORD), "utf-8")
+            passwd = self.m._quote(settings.WEBMAIL_DEV_PASSWORD)
+            # Starting with Python 3.13, _quote() returns bytes
+            if not isinstance(passwd, bytes):
+                passwd = bytes(passwd, "utf-8")
             data = self._cmd("LOGIN", user, passwd)
         self.m.state = "AUTH"
         if "CAPABILITY" in self.m.untagged_responses:
@@ -376,7 +379,7 @@ class IMAPconnector:
         cmdname = "SORT"
         data = self._cmd(
             cmdname,
-            bytearray(f"({criterion})", "utf-8"),
+            f"({criterion})",
             b"UTF-8",
             b"(NOT DELETED)",
             *self.criterions,

--- a/modoboa/webmail/tests/test_imapemail.py
+++ b/modoboa/webmail/tests/test_imapemail.py
@@ -1,0 +1,100 @@
+"""Tests for inline images handling in ImapEmail."""
+
+import base64
+import os
+import tempfile
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from modoboa.webmail.lib.imapemail import ImapEmail
+from modoboa.webmail.lib.imaputils import BodyStructure
+from modoboa.webmail.lib.fetch_parser import FetchResponseParser
+from modoboa.webmail.tests import data as tests_data
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfake"
+
+
+def _make_email(inlines, links=True):
+    email = ImapEmail.__new__(ImapEmail)
+    email.links = links
+    email.mailid = "3"
+    email.mbox = "INBOX"
+    email.bs = mock.Mock(inlines=inlines)
+    email.imapc = mock.Mock()
+    email.imapc.fetchpart.return_value = (
+        None,
+        base64.b64encode(PNG_BYTES).decode(),
+    )
+    return email
+
+
+class InlineImagesTestCase(SimpleTestCase):
+    def test_bodystructure_inlines_have_content_type(self):
+        parsed = FetchResponseParser().parse(tests_data.BODYSTRUCTURE_SAMPLE_6)
+        bs = BodyStructure(parsed[3]["BODYSTRUCTURE"])
+        self.assertEqual(
+            bs.inlines["image005.png@01CC6CAA.4FADC490"]["Content-Type"], "image/png"
+        )
+        self.assertEqual(
+            bs.inlines["image006.jpg@01CC6CAA.4FADC490"]["Content-Type"],
+            "image/jpeg",
+        )
+
+    def test_inline_image_embedded_as_data_uri(self):
+        email = _make_email(
+            {
+                "img@x": {
+                    "pnum": "2",
+                    "encoding": "base64",
+                    "Content-Type": "image/png",
+                }
+            }
+        )
+        with tempfile.TemporaryDirectory() as workdir:
+            with override_settings(MEDIA_ROOT=workdir):
+                email._fetch_inlines()
+                # Nothing must be written to the (public) media directory
+                self.assertEqual(os.listdir(workdir), [])
+        expected = "data:image/png;base64," + base64.b64encode(PNG_BYTES).decode()
+        self.assertEqual(email._map_cid("cid:img@x"), expected)
+        self.assertEqual(email._map_cid("CID:img%40x"), expected)
+
+    def test_unsafe_inline_types_ignored(self):
+        email = _make_email(
+            {
+                "svg@x": {
+                    "pnum": "2",
+                    "encoding": "base64",
+                    "Content-Type": "image/svg+xml",
+                },
+                "html@x": {
+                    "pnum": "3",
+                    "encoding": "base64",
+                    "Content-Type": "text/html",
+                },
+            }
+        )
+        email._fetch_inlines()
+        email.imapc.fetchpart.assert_not_called()
+        self.assertEqual(email._map_cid("cid:svg@x"), "cid:svg@x")
+        self.assertEqual(email._map_cid("cid:html@x"), "cid:html@x")
+
+    def test_inlines_not_fetched_without_links(self):
+        email = _make_email(
+            {
+                "img@x": {
+                    "pnum": "2",
+                    "encoding": "base64",
+                    "Content-Type": "image/png",
+                }
+            },
+            links=False,
+        )
+        email._fetch_inlines()
+        email.imapc.fetchpart.assert_not_called()
+
+    def test_other_urls_untouched(self):
+        email = _make_email({})
+        url = "https://example.com/a.png"
+        self.assertEqual(email._map_cid(url), url)


### PR DESCRIPTION
Render message bodies in a sandboxed iframe (srcdoc, no scripts,
opaque origin) with a restrictive CSP, so untrusted HTML can never
reach the application context even if the server-side cleaner is
bypassed. Remote content is only allowed when links are enabled.

Inline images are no longer written to the shared, publicly served
media/webmail directory (UIDs are only unique per mailbox, so images
could leak between users). They are now embedded as data: URIs,
restricted to safe raster image types.