### PR TITLE
fix: webmail: escape mailbox names in IMAP commands

### DIFF
--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -64,6 +64,20 @@ def escape_search_pattern(pattern: str) -> str:
     return pattern.replace("\\", "\\\\").replace('"', '\\"')
 
 
+def quote_mailbox_name(name: str) -> bytes:
+    """Encode a mailbox name to imap4-utf-7 and return it as a quoted string.
+
+    Double quotes and backslashes are left untouched by the imap4-utf-7
+    codec, so they must be backslash-escaped, otherwise a crafted name
+    could break out of the quoted string and inject extra command
+    arguments. Control characters are rejected.
+    """
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
+        raise ImapError(_("Invalid mailbox name"))
+    encoded = name.encode("imap4-utf-7")
+    return b'"' + encoded.replace(b"\\", b"\\\\").replace(b'"', b'\\"') + b'"'
+
+
 class BodyStructure:
     """
     BODYSTRUCTURE response parser.
@@ -422,7 +436,7 @@ class IMAPconnector:
         """Encode folder name (str) to imap4-utf-7 and quote it."""
         if not folder:
             return "INBOX"
-        return b'"' + folder.encode("imap4-utf-7") + b'"'
+        return quote_mailbox_name(folder)
 
     def _parse_mailbox_name(self, descr, prefix, delimiter, parts):
         if not len(parts):
@@ -472,9 +486,7 @@ class IMAPconnector:
     ) -> None:
         """Retrieve mailboxes list."""
         pattern = (
-            f'"{topmailbox.encode("imap4-utf-7").decode()}{self.hdelimiter}%"'
-            if topmailbox
-            else "%"
+            quote_mailbox_name(f"{topmailbox}{self.hdelimiter}%") if topmailbox else "%"
         )
         resp = self._cmd(
             "LIST", '""', pattern, "RETURN", "(SUBSCRIBED CHILDREN STATUS (MESSAGES))"

--- a/modoboa/webmail/tests/test_imaputils.py
+++ b/modoboa/webmail/tests/test_imaputils.py
@@ -50,3 +50,27 @@ class EscapeSearchPatternTestCase(SimpleTestCase):
         for value in ["a\r\nb", "a\tb", "a\x00b", "a\x7fb"]:
             with self.assertRaises(ImapError):
                 imaputils.escape_search_pattern(value)
+
+
+class QuoteMailboxNameTestCase(SimpleTestCase):
+    """Tests for quote_mailbox_name."""
+
+    def test_plain_name(self):
+        self.assertEqual(imaputils.quote_mailbox_name("Sent"), b'"Sent"')
+        self.assertEqual(imaputils.quote_mailbox_name("A/B"), b'"A/B"')
+
+    def test_non_ascii_name(self):
+        self.assertEqual(imaputils.quote_mailbox_name("Envoyés"), b'"Envoy&AOk-s"')
+
+    def test_quote_and_backslash_escaped(self):
+        # A double quote would otherwise break out of the quoted string.
+        self.assertEqual(
+            imaputils.quote_mailbox_name('INBOX" (MESSAGES'),
+            b'"INBOX\\" (MESSAGES"',
+        )
+        self.assertEqual(imaputils.quote_mailbox_name("a\\b"), b'"a\\\\b"')
+
+    def test_control_characters_rejected(self):
+        for value in ["INBOX\r\nA1 DELETE Trash", "a\x00b", "a\tb", "a\x7fb"]:
+            with self.assertRaises(ImapError):
+                imaputils.quote_mailbox_name(value)


### PR DESCRIPTION
The imap4-utf-7 codec leaves double quotes and backslashes untouched, and mailbox names were wrapped in quotes without escaping them. A crafted name (e.g. from the "mailbox" request parameter) could break out of the quoted string and inject extra command arguments.

Add quote_mailbox_name(), which rejects control characters and backslash-escapes quotes and backslashes, and use it for every command taking a mailbox name, including the LIST pattern.