### PR TITLE
fix(webmail): repair draft editing

### DIFF
--- a/frontend/src/components/webmail/ComposeEmailForm.vue
+++ b/frontend/src/components/webmail/ComposeEmailForm.vue
@@ -256,7 +256,17 @@ const { $gettext } = useGettext()
 const { displayNotification, reloadData } = useBusStore()
 const authStore = useAuthStore()
 
+// Only the compose view opened from the drafts folder edits a draft: in
+// reply/forward views, route.query.mailid is the original message UID.
+const isEditingDraft =
+  route.name === 'ComposeEmailView' &&
+  route.query.mailbox === constants.DRAFTS_FOLDER &&
+  !!route.query.mailid
+
 const allowedSenders = ref([])
+// UID of the draft being edited, updated on each save so the previous
+// version gets replaced instead of duplicated.
+const draftMailid = ref(isEditingDraft ? route.query.mailid : null)
 const attachmentCount = ref(0)
 const contacts = ref([])
 const editorMode = ref('plain')
@@ -328,8 +338,8 @@ const prepareMessage = () => {
     }
     result.bcc = bcc
   }
-  if (route.query.mailid) {
-    result.mailid = route.query.mailid
+  if (draftMailid.value) {
+    result.mailid = draftMailid.value
   }
   return result
 }
@@ -386,11 +396,12 @@ const lookForContacts = debounce(async (search) => {
 }, 500)
 
 const initialize = async (body) => {
-  if (route.params.mailbox === constants.DRAFTS_FOLDER && route.query.mailid) {
-    // Load draft
+  if (isEditingDraft) {
+    // Load draft (raw body, ready for the editor)
     const draft = await api.getEmailContent(
-      constants.DRAFTS_FOLDER,
-      route.query.mailid
+      route.query.mailbox,
+      route.query.mailid,
+      { context: 'edit', dformat: body.editor_format }
     )
     form.value.sender = draft.data.from_address.address
     if (draft.data.to?.length) {
@@ -439,7 +450,9 @@ const saveDraft = async () => {
   working.value = true
   const body = prepareMessage()
   try {
-    await api.saveComposeSession(route.query.uid, body)
+    const resp = await api.saveComposeSession(route.query.uid, body)
+    draftMailid.value = resp.data.mailid
+    displayNotification({ msg: $gettext('Draft saved') })
   } catch (error) {
     console.log(error)
   } finally {
@@ -463,8 +476,7 @@ watch(
 )
 
 if (!route.query.uid) {
-  const args =
-    route.query.mailbox === constants.DRAFTS_FOLDER ? [route.query.mailid] : []
+  const args = isEditingDraft ? [route.query.mailid] : []
   api.createComposeSession(...args).then((resp) => {
     const query = { ...route.query, uid: resp.data.uid }
     attachmentCount.value = resp.data.attachments?.length || 0

--- a/frontend/src/views/webmail/EmailView.vue
+++ b/frontend/src/views/webmail/EmailView.vue
@@ -361,7 +361,7 @@ const forwardEmail = () => {
 const editDraft = () => {
   router.push({
     name: 'ComposeEmailView',
-    query: { mailid: route.query.mailid },
+    query: { mailbox: route.query.mailbox, mailid: route.query.mailid },
   })
 }
 </script>

--- a/modoboa/webmail/lib/__init__.py
+++ b/modoboa/webmail/lib/__init__.py
@@ -3,7 +3,7 @@ from .attachments import (
     save_attachment,
     AttachmentUploadHandler,
 )
-from .imapemail import ImapEmail, ReplyModifier, ForwardModifier
+from .imapemail import ImapEmail, EditModifier, ReplyModifier, ForwardModifier
 from .imaputils import BodyStructure, IMAPconnector, get_imapconnector, separate_mailbox
 from .signature import EmailSignature
 from .utils import decode_payload
@@ -12,6 +12,7 @@ from .utils import decode_payload
 __all__ = [
     "AttachmentUploadHandler",
     "BodyStructure",
+    "EditModifier",
     "EmailSignature",
     "ForwardModifier",
     "IMAPconnector",

--- a/modoboa/webmail/lib/attachments.py
+++ b/modoboa/webmail/lib/attachments.py
@@ -101,7 +101,7 @@ def save_attachment_from_upload(request, session_uid: str, f) -> Attachment:
 
 
 def save_attachment(
-    request, session_uid: str, filename: str, content_type: str, content: str
+    request, session_uid: str, filename: str, content_type: str, content: str | bytes
 ) -> Attachment:
     """
     Save a new attachment to the filesystem
@@ -117,7 +117,9 @@ def save_attachment(
         fp = NamedTemporaryFile(dir=get_storage_path(""), delete=False)
     except Exception as e:
         raise InternalError(str(e)) from None
-    fp.write(content.encode("utf-8"))
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    fp.write(content)
     fp.close()
 
     session = manager.get_content(session_uid)

--- a/modoboa/webmail/lib/imapemail.py
+++ b/modoboa/webmail/lib/imapemail.py
@@ -51,14 +51,20 @@ class ImapEmail(Email):
 
     def fetch_headers(self, raw_addresses: bool = False) -> None:
         """Fetch message headers from server."""
-        requested_headers = self.headernames
+        # Copy the class attribute: extending it in place would make it
+        # grow on every request.
+        requested_headers = list(self.headernames)
         if self.mbox == constants.MAILBOX_NAME_SCHEDULED:
             requested_headers += [(constants.CUSTOM_HEADER_SCHEDULED_DATETIME, True)]
         header_names = [header[0].upper() for header in requested_headers]
         msg = self.imapc.fetchmail(
             self.mbox, self.mailid, readonly=False, what=" ".join(header_names)
         )
-        headers = msg[f"BODY[HEADER.FIELDS ({' '.join(header_names)})]"]
+        # Servers may return the requested fields in a different order,
+        # so don't rely on the exact data item name.
+        headers = next(
+            value for key, value in msg.items() if key.startswith("BODY[HEADER.FIELDS")
+        )
         self.fetch_body_structure(msg)
         msg = email.message_from_string(headers)
         for hdr in requested_headers:
@@ -126,7 +132,9 @@ class ImapEmail(Email):
                 {
                     "filename": filename,
                     "content_type": attdef["Content-Type"],
-                    "content": content,
+                    # Store the decoded payload: it is encoded again when
+                    # the message is built.
+                    "content": decode_payload(attdef["encoding"], content),
                 }
             )
         return result
@@ -355,3 +363,23 @@ class ForwardModifier(Modifier):
 
     def _header_end_html(self):
         return ""
+
+
+class EditModifier(ImapEmail):
+    """Load a draft message so it can be edited.
+
+    The body is returned as raw content for the editor: plain text is
+    neither escaped nor wrapped in a <pre> block.
+    """
+
+    headernames = ImapEmail.headernames + [("Bcc", True)]
+
+    def __init__(self, request, *args, **kwargs):
+        super().__init__(request, *args, **kwargs)
+        self.fetch_headers()
+
+    def _post_process_plain(self, content):
+        return content.strip()
+
+    def viewmail_plain(self, contents=None, **kwargs):
+        return contents

--- a/modoboa/webmail/lib/imapheader.py
+++ b/modoboa/webmail/lib/imapheader.py
@@ -19,6 +19,7 @@ __all__ = [
     "parse_date",
     "parse_reply_to",
     "parse_cc",
+    "parse_bcc",
     "parse_subject",
 ]
 
@@ -99,6 +100,11 @@ def parse_to(value):
 
 def parse_cc(value):
     """Parse a Cc: header."""
+    return parse_address_list(value)
+
+
+def parse_bcc(value):
+    """Parse a Bcc: header."""
     return parse_address_list(value)
 
 

--- a/modoboa/webmail/serializers.py
+++ b/modoboa/webmail/serializers.py
@@ -217,6 +217,7 @@ class EmailSerializer(serializers.Serializer):
     from_address = EmailAddressSerializer(source="From")
     to = EmailAddressSerializer(source="To", many=True)
     cc = EmailAddressSerializer(source="Cc", many=True, required=False)
+    bcc = EmailAddressSerializer(source="Bcc", many=True, required=False)
     body = serializers.CharField()
     date = serializers.CharField(source="Date")
     message_id = serializers.CharField(source="Message_ID", required=False)
@@ -332,6 +333,8 @@ class SendEmailSerializer(ScheduledDatetimeMixin, BaseEmailSerializer):
     scheduled_datetime = serializers.DateTimeField(required=False)
     request_dsn = serializers.BooleanField(required=False, default=False)
     request_mdn = serializers.BooleanField(required=False, default=False)
+    # UID of the draft this message comes from (deleted once sent)
+    mailid = serializers.IntegerField(required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -349,10 +352,15 @@ class SaveEmailSerializer(BaseEmailSerializer):
         drafts_folder = self.context["request"].user.parameters.get_value(
             "drafts_folder"
         )
+        mime_message = message.message()
+        if validated_data.get("bcc"):
+            # Django never writes Bcc into the MIME message: keep it in
+            # the draft so it is not lost when the draft is reopened.
+            mime_message["Bcc"] = ", ".join(validated_data["bcc"])
         with get_imapconnector(self.context["request"]) as imapc:
             if "mailid" in validated_data:
                 imapc.delete_mail(drafts_folder, validated_data["mailid"])
-            mailid = imapc.push_mail(drafts_folder, message.message())
+            mailid = imapc.push_mail(drafts_folder, mime_message)
             imapc.mark_messages_unread(drafts_folder, [str(mailid)])
             return mailid
 

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -381,6 +381,18 @@ class UserEmailViewSetTestCase(WebmailTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("scheduled_datetime", response.json())
 
+    def test_content_edit_context(self):
+        """Drafts are returned with a raw body, ready for the editor."""
+        self.authenticate()
+        url = reverse("v2:webmail-email-content")
+        response = self.client.get(
+            f"{url}?mailbox=Drafts&mailid=46931&context=edit&dformat=plain"
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()["body"]
+        self.assertNotIn("<pre>", body)
+        self.assertEqual(body, "This is a test message.")
+
     def test_attachment(self):
         self.authenticate()
         url = reverse("v2:webmail-email-attachment")
@@ -417,6 +429,10 @@ class ComposeSessionViewSetTestCase(WebmailTestCase):
         manager = ComposeSessionManager(self.user.username)
         content = manager.get_content(uid)
         self.assertEqual(len(content["attachments"]), 1)
+        # The attachment must be stored decoded, not as base64 text
+        tmpname = content["attachments"][0]["tmpname"]
+        with open(f"{self.workdir}/webmail/{tmpname}", "rb") as fp:
+            self.assertTrue(fp.read().startswith(b"%PDF-1.4"))
 
     def test_get(self):
         self.authenticate()
@@ -529,6 +545,52 @@ class ComposeSessionViewSetTestCase(WebmailTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_save_keeps_bcc(self):
+        self.authenticate()
+        uid = self._create_compose_session()
+        url = reverse("v2:webmail-compose-session-save", args=[uid])
+        with mock.patch(
+            "modoboa.webmail.lib.imaputils.IMAPconnector.push_mail", return_value=12
+        ) as push_mail:
+            response = self.client.post(
+                url,
+                {
+                    "sender": self.user.email,
+                    "to": ["test@example.test"],
+                    "bcc": ["hidden@example.test"],
+                    "subject": "test",
+                    "body": "Test",
+                },
+                format="json",
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["mailid"], 12)
+        self.assertEqual(push_mail.call_args.args[1]["Bcc"], "hidden@example.test")
+
+    def test_send_deletes_draft(self):
+        self.authenticate()
+        data = {
+            "sender": self.user.email,
+            "to": ["test@example.test"],
+            "subject": "test",
+            "body": "Test",
+        }
+        with mock.patch(
+            "modoboa.webmail.lib.imaputils.IMAPconnector.delete_mail"
+        ) as delete_mail:
+            # Not composed from a draft: nothing to delete
+            uid = self._create_compose_session()
+            url = reverse("v2:webmail-compose-session-send", args=[uid])
+            response = self.client.post(url, data, format="json")
+            self.assertEqual(response.status_code, 204)
+            delete_mail.assert_not_called()
+
+            uid = self._create_compose_session()
+            url = reverse("v2:webmail-compose-session-send", args=[uid])
+            response = self.client.post(url, {**data, "mailid": 11}, format="json")
+            self.assertEqual(response.status_code, 204)
+            delete_mail.assert_called_once_with("Drafts", 11)
 
     def test_send(self):
         self.authenticate()

--- a/modoboa/webmail/viewsets.py
+++ b/modoboa/webmail/viewsets.py
@@ -13,6 +13,7 @@ from modoboa.lib import exceptions
 from modoboa.lib.paginator import Paginator
 from modoboa.lib.viewsets import HasMailbox
 from modoboa.webmail import lib, models, serializers
+from modoboa.webmail.exceptions import ImapError
 from modoboa.webmail.lib import attachments
 from modoboa.webmail.lib.imaputils import UID_RE, PARTNUM_RE
 from modoboa.webmail.lib.sendmail import send_mail, schedule_email
@@ -299,7 +300,7 @@ class UserEmailViewSet(viewsets.GenericViewSet):
         if "dformat" in request.GET:
             dformat = request.GET.get("dformat")
         context = self.request.GET.get("context")
-        if context and context in ["reply", "forward"]:
+        if context and context in ["reply", "forward", "edit"]:
             modclass = getattr(lib, f"{context.capitalize()}Modifier")
             email = modclass(
                 request,
@@ -462,12 +463,14 @@ class ComposeSessionViewSet(viewsets.GenericViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         manager = attachments.ComposeSessionManager(request.user.username)
+        draft_mailid = serializer.validated_data.get("mailid")
         if serializer.validated_data.get("scheduled_datetime"):
             schedule_email(
                 request,
                 serializer.validated_data,
                 manager.get_content(pk)["attachments"],
             )
+            self._delete_draft(request, draft_mailid)
             return response.Response(status=204)
 
         status, error = send_mail(
@@ -477,8 +480,21 @@ class ComposeSessionViewSet(viewsets.GenericViewSet):
         )
         if status:
             attachments.remove_attachments_and_session(manager, pk)
+            self._delete_draft(request, draft_mailid)
             return response.Response(status=204)
         return response.Response({"error": error}, status=400)
+
+    def _delete_draft(self, request, mailid: int | None) -> None:
+        """Remove the draft a message was composed from, once sent."""
+        if mailid is None:
+            return
+        drafts_folder = request.user.parameters.get_value("drafts_folder")
+        try:
+            with lib.get_imapconnector(request) as imapc:
+                imapc.delete_mail(drafts_folder, mailid)
+        except ImapError:
+            # The message is already sent: a leftover draft is not an error
+            pass
 
 
 class ScheduledMessageViewSet(


### PR DESCRIPTION
- Opening a draft never loaded it: the compose form checked route.params.mailbox, which no route defines, and the "edit draft" button did not pass the mailbox. Drafts are now loaded through a new "edit" content context returning the raw body (no <pre>, no HTML escaping) and the Bcc header.
- The draft UID is now tracked by the compose form and updated on each save, so saving no longer creates duplicates. It was previously taken from route.query.mailid, which in reply/forward views is the UID of the original message: saving a draft there could delete an unrelated message from the drafts folder.
- The draft is deleted once the message is sent or scheduled.
- Bcc recipients are kept in saved drafts.
- Draft attachments are decoded before being stored, instead of being base64-encoded twice when the message is rebuilt.
- fetch_headers no longer extends the class-level headernames list in place and does not depend on the order of the returned fields.
