### PR TITLE
fix(webmail): webmail fix reply to forward

### DIFF
--- a/frontend/src/components/webmail/ComposeEmailForm.vue
+++ b/frontend/src/components/webmail/ComposeEmailForm.vue
@@ -247,6 +247,11 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // Forwarding: recipients must be chosen by the user
+  forward: {
+    type: Boolean,
+    default: false,
+  },
 })
 const emit = defineEmits(['onToggleHtmlMode'])
 
@@ -281,20 +286,26 @@ const initForm = () => {
     request_mdn: false,
   }
   if (props.originalEmail) {
-    form.value.to = props.originalEmail.reply_to
-      ? [props.originalEmail.reply_to]
-      : [props.originalEmail.from_address.address]
+    if (!props.forward) {
+      // Reply to every Reply-To address if any, to the sender otherwise
+      form.value.to = props.originalEmail.reply_to?.length
+        ? props.originalEmail.reply_to.map((rcpt) => rcpt.address)
+        : [props.originalEmail.from_address.address]
+    }
     if (props.replyAll) {
-      let addresses = props.originalEmail.to
-        .filter((rcpt) => rcpt.address !== authStore.authUser.username)
-        .map((rcpt) => rcpt.fulladdress)
-      if (props.originalEmail.cc && props.originalEmail.cc.length) {
-        addresses = addresses.concat(
-          props.originalEmail.cc.map((rcpt) => rcpt.fulladdress)
-        )
-      }
-      form.value.cc = addresses
-      showCcField.value = true
+      // Bare addresses only: the API rejects "Name <address>" values
+      const excluded = new Set([
+        authStore.authUser.username,
+        ...(form.value.to || []),
+      ])
+      const addresses = [
+        ...props.originalEmail.to,
+        ...(props.originalEmail.cc || []),
+      ]
+        .map((rcpt) => rcpt.address)
+        .filter((address) => !excluded.has(address))
+      form.value.cc = [...new Set(addresses)]
+      showCcField.value = form.value.cc.length > 0
     }
     form.value.subject = props.originalEmail.subject
     form.value.body = props.originalEmail.body

--- a/frontend/src/views/webmail/ForwardEmailView.vue
+++ b/frontend/src/views/webmail/ForwardEmailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <ComposeEmailForm :original-email="email" />
+  <ComposeEmailForm :original-email="email" forward />
 </template>
 
 <script setup>

--- a/modoboa/webmail/mocks.py
+++ b/modoboa/webmail/mocks.py
@@ -77,6 +77,13 @@ class IMAP4Mock:
                     data = tests_data.BODYSTRUCTURE_SAMPLE_9
                 else:
                     data = tests_data.BODYSTRUCTURE_SAMPLE_10
+            elif uid == 46933:
+                if args[1] == "(BODYSTRUCTURE)":
+                    data = tests_data.BODYSTRUCTURE_ONLY_REPLY_TO
+                elif "HEADER.FIELDS" in args[1]:
+                    data = tests_data.BODYSTRUCTURE_SAMPLE_REPLY_TO
+                else:
+                    data = tests_data.BODY_PLAIN_REPLY_TO
             elif uid == 33:
                 if args[1] == "(BODYSTRUCTURE)":
                     data = tests_data.BODYSTRUCTURE_EMPTY_MAIL

--- a/modoboa/webmail/serializers.py
+++ b/modoboa/webmail/serializers.py
@@ -220,7 +220,8 @@ class EmailSerializer(serializers.Serializer):
     body = serializers.CharField()
     date = serializers.CharField(source="Date")
     message_id = serializers.CharField(source="Message_ID", required=False)
-    reply_to = serializers.EmailField(source="Reply_To", required=False)
+    # Reply-To may contain several addresses (parsed as a list)
+    reply_to = EmailAddressSerializer(source="Reply_To", many=True, required=False)
     attachments = serializers.SerializerMethodField()
 
     scheduled_datetime = serializers.DateTimeField(

--- a/modoboa/webmail/tests/data.py
+++ b/modoboa/webmail/tests/data.py
@@ -48,6 +48,34 @@ BODY_PLAIN_4 = [
     b")",
 ]
 
+# Message with a multi-address Reply-To header (UID 46933)
+_REPLY_TO_HEADERS = (
+    b"From: Sender <sender@example.test>\r\n"
+    b"To: <user@test.com>\r\n"
+    b"Subject: Reply-To test\r\n"
+    b"Date: Wed, 28 Dec 2011 13:29:17 +0100\r\n"
+    b"Reply-To: Support <support@example.test>, other@example.test\r\n"
+    b"Message-ID: <reply-to-test@example.test>\r\n\r\n"
+)
+
+BODYSTRUCTURE_SAMPLE_REPLY_TO = [
+    (
+        b"855 (UID 46933 "
+        + BODYSTRUCTURE_4
+        + b" BODY[HEADER.FIELDS (FROM TO CC DATE SUBJECT REPLY-TO MESSAGE-ID)] {%d}"
+        % len(_REPLY_TO_HEADERS),
+        _REPLY_TO_HEADERS,
+    ),
+    b")",
+]
+
+BODYSTRUCTURE_ONLY_REPLY_TO = [(b"855 (UID 46933 " + BODYSTRUCTURE_4), ")"]
+
+BODY_PLAIN_REPLY_TO = [
+    (b"855 (UID 46933 BODY[1.1] {25}", b"This is a test message.\r\n"),
+    b")",
+]
+
 BODYSTRUCTURE_SAMPLE_5 = [
     (
         b'856 (UID 46936 BODYSTRUCTURE (("text" "plain" ("charset" "ISO-8859-1") NIL NIL "quoted-printable" 724 22 NIL NIL NIL NIL)("text" "html" ("charset" "ISO-8859-1") NIL NIL "quoted-printable" 2662 48 NIL NIL NIL NIL) "alternative" ("boundary" "----=_Part_1326887_254624357.1325083973970") NIL NIL NIL) BODY[HEADER.FIELDS (DATE FROM TO CC SUBJECT)] {258}',

--- a/modoboa/webmail/tests/test_imapemail.py
+++ b/modoboa/webmail/tests/test_imapemail.py
@@ -21,7 +21,8 @@ def _make_email(inlines, links=True):
     email.mailid = "3"
     email.mbox = "INBOX"
     email.bs = mock.Mock(inlines=inlines)
-    email.imapc = mock.Mock()
+    # MagicMock: ImapEmail.__del__ calls imapc.__exit__()
+    email.imapc = mock.MagicMock()
     email.imapc.fetchpart.return_value = (
         None,
         base64.b64encode(PNG_BYTES).decode(),

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -381,6 +381,19 @@ class UserEmailViewSetTestCase(WebmailTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("scheduled_datetime", response.json())
 
+    def test_content_reply_to(self):
+        """Every Reply-To address is returned as a structured address."""
+        self.authenticate()
+        url = reverse("v2:webmail-email-content")
+        response = self.client.get(f"{url}?mailbox=INBOX&mailid=46933&context=reply")
+        self.assertEqual(response.status_code, 200)
+        reply_to = response.json()["reply_to"]
+        self.assertEqual(
+            [rcpt["address"] for rcpt in reply_to],
+            ["support@example.test", "other@example.test"],
+        )
+        self.assertEqual(reply_to[0]["name"], "Support")
+
     def test_attachment(self):
         self.authenticate()
         url = reverse("v2:webmail-email-attachment")


### PR DESCRIPTION
- Reply-To was serialized with an EmailField while it is parsed as a
  list of addresses: the API returned the Python list as a string,
  which the compose form then used as the recipient. It is now a list
  of structured addresses and replies target every Reply-To address.
- Forwarding pre-filled the recipient with the original sender; the
  form now leaves recipients empty when forwarding.
- "Reply all" put "Name <address>" values in Cc, which the API rejects
  (EmailField): it now uses bare addresses, without duplicates or
  addresses already in To.
