### PR TITLE
fix(webmail): handle SMTP network errors and stuck scheduled messages

### DIFF
--- a/modoboa/webmail/constants.py
+++ b/modoboa/webmail/constants.py
@@ -1,9 +1,9 @@
 """Webmail constants."""
 
+from datetime import timedelta
 from enum import Enum
 
 from django.utils.translation import gettext_lazy as _
-
 
 MAILBOX_TYPES = ["inbox", "draft", "sent", "scheduled", "junk", "trash", "normal"]
 
@@ -29,6 +29,10 @@ class SchedulingState(Enum):
     SEND_ERROR = "send_error"
     MOVE_ERROR = "move_error"
 
+
+# A scheduled message still in the SENDING state after this delay is
+# considered lost by the queue and flagged as failed.
+SCHEDULED_SENDING_TIMEOUT = timedelta(hours=1)
 
 EMAIL_SCHEDULING_STATES = (
     (SchedulingState.SCHEDULED.value, "scheduled"),

--- a/modoboa/webmail/jobs.py
+++ b/modoboa/webmail/jobs.py
@@ -1,21 +1,51 @@
 """Async (RQ) jobs definition."""
 
+import logging
+
 from django.utils import timezone
+from django.utils.translation import gettext as _
 
 import django_rq
 
 from modoboa.webmail import constants, models
 from modoboa.webmail.lib import sendmail
 
+logger = logging.getLogger("modoboa.jobs")
+
 
 def send_scheduled_message(message_id: int):
-    message = models.ScheduledMessage.objects.get(id=message_id)
-    if sendmail.send_scheduled_message(message):
+    message = models.ScheduledMessage.objects.filter(id=message_id).first()
+    if message is None:
+        # Cancelled while the job was waiting in the queue
+        return
+    if message.status != constants.SchedulingState.SENDING.value:
+        # Flagged as interrupted by send_scheduled_messages: sending it now
+        # could duplicate a message the user has already rescheduled.
+        return
+    try:
+        sent = sendmail.send_scheduled_message(message)
+    except Exception:
+        logger.exception("Failed to send scheduled message %s", message_id)
+        message.status = constants.SchedulingState.SEND_ERROR.value
+        message.error = _("Unexpected error while sending the message")
+        message.save()
+        raise
+    if sent:
         message.delete()
 
 
 def send_scheduled_messages():
     now = timezone.now().replace(second=0, microsecond=0)
+    # A job lost by the queue (worker crash, Redis flush...) would leave
+    # its message in the SENDING state forever: flag it so the user can
+    # reschedule it.
+    models.ScheduledMessage.objects.filter(
+        status=constants.SchedulingState.SENDING.value,
+        scheduled_datetime__lte=now - constants.SCHEDULED_SENDING_TIMEOUT,
+    ).update(
+        status=constants.SchedulingState.SEND_ERROR.value,
+        error=_("Sending was interrupted, please reschedule the message"),
+    )
     messages = models.ScheduledMessage.objects.filter(
         scheduled_datetime__lte=now,
         status=constants.SchedulingState.SCHEDULED.value,

--- a/modoboa/webmail/lib/sendmail.py
+++ b/modoboa/webmail/lib/sendmail.py
@@ -1,3 +1,4 @@
+import logging
 import smtplib
 
 from django.conf import settings
@@ -6,10 +7,31 @@ from django.core import mail
 from modoboa.lib.oauth2 import get_access_token
 from modoboa.parameters import tools as param_tools
 from modoboa.webmail import constants, models
-from modoboa.webmail.exceptions import WebmailInternalError
+from modoboa.webmail.exceptions import ImapError, WebmailInternalError
 from modoboa.webmail.lib.utils import create_message
 
 from . import get_imapconnector
+
+logger = logging.getLogger("modoboa.webmail")
+
+
+def get_smtp_error_message(error: OSError) -> str:
+    """Return a readable message for an SMTP or network error.
+
+    smtplib errors are ``OSError`` subclasses, like the network errors
+    (connection refused, timeout, TLS failure...) raised while talking
+    to the server.
+    """
+    if isinstance(error, smtplib.SMTPRecipientsRefused):
+        return ", ".join(
+            [f"{rcpt}: {reason}" for rcpt, reason in error.recipients.items()]
+        )
+    if isinstance(error, smtplib.SMTPResponseException):
+        smtp_error = error.smtp_error
+        if isinstance(smtp_error, bytes):
+            smtp_error = smtp_error.decode(errors="replace")
+        return str(smtp_error)
+    return str(error) or error.__class__.__name__
 
 
 def send_mail(request, attributes: dict, attachments: list) -> tuple[bool, str | None]:
@@ -61,18 +83,18 @@ def send_mail(request, attributes: dict, attachments: list) -> tuple[bool, str |
             else:
                 msg.connection = connection
                 msg.send()
-    except smtplib.SMTPResponseException as inst:
-        return False, str(inst.smtp_error)
-    except smtplib.SMTPRecipientsRefused as inst:
-        error = ", ".join(
-            [f"{rcpt}: {error}" for rcpt, error in inst.recipients.items()]
-        )
-        return False, error
+    except OSError as error:
+        return False, get_smtp_error_message(error)
 
     # Copy message to sent folder
     sentfolder = request.user.parameters.get_value("sent_folder")
-    with get_imapconnector(request) as imapc:
-        imapc.push_mail(sentfolder, msg.message())
+    try:
+        with get_imapconnector(request) as imapc:
+            imapc.push_mail(sentfolder, msg.message())
+    except (ImapError, WebmailInternalError):
+        # The message is sent: reporting a failure would make the user
+        # send it again.
+        logger.exception("Failed to store a copy of the sent message")
     return True, None
 
 
@@ -161,15 +183,10 @@ def send_scheduled_message(sched_msg: models.ScheduledMessage) -> bool:
             else:
                 msg.connection = connection
                 msg.send()
-    except (smtplib.SMTPResponseException, smtplib.SMTPRecipientsRefused) as inst:
-        if isinstance(inst, smtplib.SMTPRecipientsRefused):
-            error = ", ".join(
-                [f"{rcpt}: {error}" for rcpt, error in inst.recipients.items()]
-            )
-        else:
-            error = str(inst.smtp_error)
+    except OSError as error:
+        max_length = models.ScheduledMessage._meta.get_field("error").max_length
         sched_msg.status = constants.SchedulingState.SEND_ERROR.value
-        sched_msg.error = error
+        sched_msg.error = get_smtp_error_message(error)[:max_length]
         sched_msg.save()
         return False
 

--- a/modoboa/webmail/serializers.py
+++ b/modoboa/webmail/serializers.py
@@ -398,6 +398,10 @@ class ScheduledMessageSerializer(ScheduledDatetimeMixin, serializers.ModelSerial
         read_only_fields = ["error"]
 
     def update(self, instance, validated_data):
+        if instance.status == constants.SchedulingState.SEND_ERROR.value:
+            # Rescheduling a failed message gives it another try
+            instance.status = constants.SchedulingState.SCHEDULED.value
+            instance.error = None
         instance = super().update(instance, validated_data)
         message = instance.to_email_message()
         with get_imapconnector(self.context["request"]) as imapc:

--- a/modoboa/webmail/tests/test_scheduling.py
+++ b/modoboa/webmail/tests/test_scheduling.py
@@ -1,0 +1,159 @@
+"""Tests for SMTP error handling and scheduled messages recovery."""
+
+import smtplib
+from unittest import mock
+
+from dateutil.relativedelta import relativedelta
+
+from django.core import mail
+from django.urls import reverse
+from django.utils import timezone
+
+from modoboa.webmail import constants, factories, jobs
+from modoboa.webmail.exceptions import WebmailInternalError
+from modoboa.webmail.tests.test_viewsets import WebmailTestCase
+
+GET_CONNECTION = "modoboa.webmail.lib.sendmail.mail.get_connection"
+SCHEDULED = constants.SchedulingState.SCHEDULED.value
+SENDING = constants.SchedulingState.SENDING.value
+SEND_ERROR = constants.SchedulingState.SEND_ERROR.value
+
+
+class SendMailErrorsTestCase(WebmailTestCase):
+    """Errors while sending a message directly."""
+
+    def _send(self):
+        uid = self.client.post(reverse("v2:webmail-compose-session-list")).json()["uid"]
+        url = reverse("v2:webmail-compose-session-send", args=[uid])
+        return self.client.post(
+            url,
+            {
+                "sender": self.user.email,
+                "to": ["test@example.test"],
+                "subject": "test",
+                "body": "Test",
+            },
+            format="json",
+        )
+
+    def test_connection_refused(self):
+        self.authenticate()
+        with mock.patch(
+            GET_CONNECTION, side_effect=ConnectionRefusedError("Connection refused")
+        ):
+            response = self._send()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "Connection refused")
+
+    def test_server_disconnected(self):
+        self.authenticate()
+        with mock.patch(
+            GET_CONNECTION,
+            side_effect=smtplib.SMTPServerDisconnected(
+                "Connection unexpectedly closed"
+            ),
+        ):
+            response = self._send()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "Connection unexpectedly closed")
+
+    def test_smtp_error_is_decoded(self):
+        self.authenticate()
+        with mock.patch(
+            GET_CONNECTION,
+            side_effect=smtplib.SMTPSenderRefused(553, b"Sender refused", "a@b.c"),
+        ):
+            response = self._send()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "Sender refused")
+
+    def test_sent_copy_failure_is_not_an_error(self):
+        """The message is sent: a failing Sent copy must not report an error."""
+        self.authenticate()
+        mail.outbox = []
+        with mock.patch(
+            "modoboa.webmail.lib.imaputils.IMAPconnector.push_mail",
+            side_effect=WebmailInternalError("Mailbox does not exist"),
+        ):
+            response = self._send()
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(len(mail.outbox), 1)
+
+
+class ScheduledMessageRecoveryTestCase(WebmailTestCase):
+    """Scheduled messages must never stay stuck in the SENDING state."""
+
+    def _message(self, **kwargs):
+        kwargs.setdefault("scheduled_datetime", timezone.now())
+        return factories.ScheduledMessageFactory(
+            account=self.user, sender=self.user.email, **kwargs
+        )
+
+    def test_network_error_flags_message(self):
+        message = self._message(status=SENDING)
+        with mock.patch(GET_CONNECTION, side_effect=OSError("Network is unreachable")):
+            jobs.send_scheduled_message(message.id)
+        message.refresh_from_db()
+        self.assertEqual(message.status, SEND_ERROR)
+        self.assertEqual(message.error, "Network is unreachable")
+
+    def test_long_error_is_truncated(self):
+        message = self._message(status=SENDING)
+        with mock.patch(GET_CONNECTION, side_effect=OSError("x" * 400)):
+            jobs.send_scheduled_message(message.id)
+        message.refresh_from_db()
+        self.assertEqual(message.status, SEND_ERROR)
+        self.assertEqual(len(message.error), 255)
+
+    def test_unexpected_error_flags_message(self):
+        message = self._message(status=SENDING)
+        with mock.patch(
+            "modoboa.webmail.lib.sendmail.send_scheduled_message",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertRaises(RuntimeError):
+                jobs.send_scheduled_message(message.id)
+        message.refresh_from_db()
+        self.assertEqual(message.status, SEND_ERROR)
+        self.assertTrue(message.error)
+
+    def test_cancelled_message_is_ignored(self):
+        # The message was deleted while its job was waiting in the queue
+        jobs.send_scheduled_message(999999)
+
+    def test_stale_sending_message_is_flagged(self):
+        now = timezone.now()
+        stale = self._message(
+            status=SENDING, scheduled_datetime=now - relativedelta(hours=2)
+        )
+        recent = self._message(
+            status=SENDING, scheduled_datetime=now - relativedelta(minutes=5)
+        )
+        with mock.patch("django_rq.get_queue"):
+            jobs.send_scheduled_messages()
+        stale.refresh_from_db()
+        recent.refresh_from_db()
+        self.assertEqual(stale.status, SEND_ERROR)
+        self.assertTrue(stale.error)
+        self.assertEqual(recent.status, SENDING)
+
+        # The job of the interrupted message, if it runs later, does nothing
+        with mock.patch(GET_CONNECTION) as get_connection:
+            jobs.send_scheduled_message(stale.id)
+        get_connection.assert_not_called()
+
+    def test_reschedule_failed_message(self):
+        self.authenticate()
+        message = self._message(
+            status=SEND_ERROR, error="Connection refused", imap_uid=10
+        )
+        url = reverse("v2:webmail-scheduled-message-detail", args=[message.id])
+        response = self.client.patch(
+            url,
+            {"scheduled_datetime": timezone.now() + relativedelta(days=1)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        message.refresh_from_db()
+        self.assertEqual(message.status, SCHEDULED)
+        self.assertIsNone(message.error)


### PR DESCRIPTION
- Only SMTPResponseException and SMTPRecipientsRefused were caught: a refused connection, a timeout, a disconnection or a TLS failure returned a 500 on direct sending and crashed the scheduled sending job. All SMTP and network errors (OSError) are now reported, and bytes SMTP replies are decoded instead of shown as "b'...'".
- Failing to store a copy in the Sent folder no longer reports an error for a message that has actually been sent (the user would send it again); the failure is logged.
- The scheduled sending job flags the message as failed on any unexpected error, ignores messages cancelled or no longer in the SENDING state, and the error is truncated to the field length.
- Messages left in the SENDING state for more than an hour (job lost by the queue) are flagged as failed so the user can reschedule them.
- Rescheduling a failed message now puts it back in the SCHEDULED state: it was never sent again before.