### PR TITLE
fix(webmail): escape sender name in HTML reply header

### DIFF
--- a/modoboa/webmail/lib/imapemail.py
+++ b/modoboa/webmail/lib/imapemail.py
@@ -299,7 +299,9 @@ class ReplyModifier(Modifier):
         sender = self.From.get("name", self.From["address"])
         textheader = f"{sender} {_('wrote:')}"
         if self.dformat == "html":
-            textheader = f"<p>{textheader}</p>"
+            # The sender name comes from the message: escape it before
+            # injecting it into HTML content.
+            textheader = f"<p>{conditional_escape(textheader)}</p>"
         else:
             textheader = f"{textheader}\n"
         self.body = textheader + self.body

--- a/modoboa/webmail/mocks.py
+++ b/modoboa/webmail/mocks.py
@@ -77,6 +77,13 @@ class IMAP4Mock:
                     data = tests_data.BODYSTRUCTURE_SAMPLE_9
                 else:
                     data = tests_data.BODYSTRUCTURE_SAMPLE_10
+            elif uid == 46934:
+                if args[1] == "(BODYSTRUCTURE)":
+                    data = tests_data.BODYSTRUCTURE_ONLY_HTML_SENDER
+                elif "HEADER.FIELDS" in args[1]:
+                    data = tests_data.BODYSTRUCTURE_SAMPLE_HTML_SENDER
+                else:
+                    data = tests_data.BODY_HTML_HTML_SENDER
             elif uid == 46933:
                 if args[1] == "(BODYSTRUCTURE)":
                     data = tests_data.BODYSTRUCTURE_ONLY_REPLY_TO

--- a/modoboa/webmail/tests/data.py
+++ b/modoboa/webmail/tests/data.py
@@ -76,6 +76,35 @@ BODY_PLAIN_REPLY_TO = [
     b")",
 ]
 
+# Message whose sender name contains HTML (UID 46934)
+_HTML_SENDER_HEADERS = (
+    b'From: "<img src=x onerror=alert(1)>" <evil@example.test>\r\n'
+    b"To: <user@test.com>\r\n"
+    b"Subject: HTML sender test\r\n"
+    b"Date: Wed, 28 Dec 2011 13:29:17 +0100\r\n"
+    b"Message-ID: <html-sender-test@example.test>\r\n\r\n"
+)
+
+BODYSTRUCTURE_SAMPLE_HTML_SENDER = [
+    (
+        b"855 (UID 46934 "
+        + BODYSTRUCTURE_4
+        + b" BODY[HEADER.FIELDS (FROM TO CC DATE SUBJECT REPLY-TO MESSAGE-ID)] {%d}"
+        % len(_HTML_SENDER_HEADERS),
+        _HTML_SENDER_HEADERS,
+    ),
+    b")",
+]
+
+BODYSTRUCTURE_ONLY_HTML_SENDER = [(b"855 (UID 46934 " + BODYSTRUCTURE_4), ")"]
+
+_HTML_SENDER_BODY = b"<p>Hello</p>"
+
+BODY_HTML_HTML_SENDER = [
+    (b"855 (UID 46934 BODY[1.2] {%d}" % len(_HTML_SENDER_BODY), _HTML_SENDER_BODY),
+    b")",
+]
+
 BODYSTRUCTURE_SAMPLE_5 = [
     (
         b'856 (UID 46936 BODYSTRUCTURE (("text" "plain" ("charset" "ISO-8859-1") NIL NIL "quoted-printable" 724 22 NIL NIL NIL NIL)("text" "html" ("charset" "ISO-8859-1") NIL NIL "quoted-printable" 2662 48 NIL NIL NIL NIL) "alternative" ("boundary" "----=_Part_1326887_254624357.1325083973970") NIL NIL NIL) BODY[HEADER.FIELDS (DATE FROM TO CC SUBJECT)] {258}',

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -393,6 +393,19 @@ class UserEmailViewSetTestCase(WebmailTestCase):
             ["support@example.test", "other@example.test"],
         )
         self.assertEqual(reply_to[0]["name"], "Support")
+
+    def test_content_reply_escapes_sender_name(self):
+        """A sender name containing HTML must not be injected as markup."""
+        self.authenticate()
+        url = reverse("v2:webmail-email-content")
+        response = self.client.get(
+            f"{url}?mailbox=INBOX&mailid=46934&context=reply&dformat=html"
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()["body"]
+        self.assertIn("&lt;img src=x onerror=alert(1)&gt;", body)
+        self.assertNotIn("<img", body)
+
     def test_content_edit_context(self):
         """Drafts are returned with a raw body, ready for the editor."""
         self.authenticate()


### PR DESCRIPTION
When replying in HTML mode, the sender name was injected unescaped in the "<name> wrote:" header prepended to the quoted message. A crafted display name (e.g. '"<img src=x onerror=...>" <evil@example.test>') ended up as markup in the reply body loaded into the HTML editor.
