### PR TITLE
fix(webmail): report refused mailbox operations instead of crashing

### DIFF
--- a/modoboa/webmail/exceptions.py
+++ b/modoboa/webmail/exceptions.py
@@ -11,6 +11,11 @@ class WebmailInternalError(InternalError):
     errorexpr = re.compile(r"\[([^\]]+)\]\s*([^\.]+)")
 
     def __init__(self, reason, ajax=False):
+        # imaplib returns server responses as bytes
+        if isinstance(reason, bytes):
+            reason = reason.decode(errors="replace")
+        else:
+            reason = str(reason)
         match = WebmailInternalError.errorexpr.match(reason)
         if not match:
             self.reason = reason
@@ -22,6 +27,16 @@ class WebmailInternalError(InternalError):
         return self.reason
 
 
+class MailboxOperationError(WebmailInternalError):
+    """The IMAP server refused an operation on a mailbox.
+
+    The mailbox already exists, does not exist, permission denied...:
+    this is a user error, reported with the server's message.
+    """
+
+    http_code = 400
+
+
 class ImapError(ModoboaException):
 
     http_code = 500
@@ -31,3 +46,9 @@ class ImapError(ModoboaException):
 
     def __str__(self):
         return str(self.reason)
+
+
+class InvalidImapArgument(ImapError):
+    """A user supplied value cannot be safely passed to the IMAP server."""
+
+    http_code = 400

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -15,7 +15,12 @@ from modoboa.lib.exceptions import InternalError
 from modoboa.parameters import tools as param_tools
 from modoboa.webmail import constants
 
-from ..exceptions import ImapError, WebmailInternalError
+from ..exceptions import (
+    ImapError,
+    InvalidImapArgument,
+    MailboxOperationError,
+    WebmailInternalError,
+)
 from .fetch_parser import FetchResponseParser
 
 # imaplib.Debug = 4
@@ -25,6 +30,10 @@ from .fetch_parser import FetchResponseParser
 MAXLINE = 1000000
 if hasattr(imaplib, "_MAXLINE") and imaplib._MAXLINE < MAXLINE:
     imaplib._MAXLINE = MAXLINE
+
+# Keep a reference to the real exception class: tests replace
+# imaplib.IMAP4 with a mock, which would also replace IMAP4.error.
+IMAP4Error = imaplib.IMAP4.error
 
 # A message UID set: one or more positive integers separated by commas.
 UID_RE = re.compile(r"^[0-9]+(?:,[0-9]+)*$")
@@ -40,14 +49,14 @@ def validate_imap_uid(value):
     reaching a command must be strictly validated first.
     """
     if value is None or not UID_RE.match(str(value)):
-        raise ImapError(_("Invalid message identifier"))
+        raise InvalidImapArgument(_("Invalid message identifier"))
     return str(value)
 
 
 def validate_imap_partnum(value):
     """Ensure a MIME part number is safe to pass to imaplib."""
     if value is None or not PARTNUM_RE.match(str(value)):
-        raise ImapError(_("Invalid part number"))
+        raise InvalidImapArgument(_("Invalid part number"))
     return str(value)
 
 
@@ -60,7 +69,7 @@ def escape_search_pattern(pattern: str) -> str:
     required by RFC 3501.
     """
     if any(ord(c) < 0x20 or ord(c) == 0x7F for c in pattern):
-        raise ImapError(_("Invalid search pattern"))
+        raise InvalidImapArgument(_("Invalid search pattern"))
     return pattern.replace("\\", "\\\\").replace('"', '\\"')
 
 
@@ -73,7 +82,7 @@ def quote_mailbox_name(name: str) -> bytes:
     arguments. Control characters are rejected.
     """
     if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
-        raise ImapError(_("Invalid mailbox name"))
+        raise InvalidImapArgument(_("Invalid mailbox name"))
     encoded = name.encode("imap4-utf-7")
     return b'"' + encoded.replace(b"\\", b"\\\\").replace(b'"', b'\\"') + b'"'
 
@@ -239,7 +248,7 @@ class IMAPconnector:
         if name in ["FETCH", "SORT", "STORE", "COPY", "SEARCH"]:
             try:
                 typ, data = self.m.uid(name, *args)
-            except imaplib.IMAP4.error as e:
+            except IMAP4Error as e:
                 raise ImapError(e) from None
             if typ == "NO":
                 raise ImapError(data)
@@ -249,7 +258,7 @@ class IMAPconnector:
 
         try:
             typ, data = self.m._simple_command(name, *args)
-        except imaplib.IMAP4.error as e:
+        except IMAP4Error as e:
             raise ImapError(e) from None
         if typ == "NO":
             raise ImapError(data)
@@ -289,7 +298,7 @@ class IMAPconnector:
                 self.m = imaplib.IMAP4_SSL(self.address, self.port)
             else:
                 self.m = imaplib.IMAP4(self.address, self.port)
-        except (OSError, imaplib.IMAP4.error, ssl.SSLError) as error:
+        except (OSError, IMAP4Error, ssl.SSLError) as error:
             raise ImapError(_(f"Connection to IMAP server failed: {error}")) from None
 
         dev_mode = getattr(settings, "WEBMAIL_DEV_MODE", False)
@@ -726,26 +735,33 @@ class IMAPconnector:
         self.select_mailbox(mbox, False)
         self._cmd("EXPUNGE")
 
+    def _mailbox_command(self, command: str, *args) -> None:
+        """Run a mailbox management command (create, rename, delete...).
+
+        The server refusing the operation (NO response) is reported with
+        its message; imaplib raises an exception on BAD responses.
+        """
+        try:
+            typ, data = getattr(self.m, command)(*args)
+        except IMAP4Error as error:
+            raise MailboxOperationError(str(error)) from None
+        if typ == "NO":
+            raise MailboxOperationError(data[0])
+
     def create_folder(self, name: str, parent: str | None = None) -> bool:
         if parent is not None:
             name = f"{parent}{self.hdelimiter}{name}"
-        typ, data = self.m.create(self._encode_mbox_name(name))
-        if typ == "NO":
-            raise WebmailInternalError(str(data[0]))
+        self._mailbox_command("create", self._encode_mbox_name(name))
         return True
 
     def rename_folder(self, oldname: str, newname: str) -> bool:
-        typ, data = self.m.rename(
-            self._encode_mbox_name(oldname), self._encode_mbox_name(newname)
+        self._mailbox_command(
+            "rename", self._encode_mbox_name(oldname), self._encode_mbox_name(newname)
         )
-        if typ == "NO":
-            raise WebmailInternalError(data[0], ajax=True)
         return True
 
     def delete_folder(self, name: str) -> bool:
-        typ, data = self.m.delete(self._encode_mbox_name(name))
-        if typ == "NO":
-            raise WebmailInternalError(data[0])
+        self._mailbox_command("delete", self._encode_mbox_name(name))
         return True
 
     def get_subscription_tree(self) -> list:
@@ -786,15 +802,11 @@ class IMAPconnector:
         return tree
 
     def subscribe_folder(self, name: str) -> bool:
-        typ, data = self.m.subscribe(self._encode_mbox_name(name))
-        if typ == "NO":
-            raise WebmailInternalError(str(data[0]))
+        self._mailbox_command("subscribe", self._encode_mbox_name(name))
         return True
 
     def unsubscribe_folder(self, name: str) -> bool:
-        typ, data = self.m.unsubscribe(self._encode_mbox_name(name))
-        if typ == "NO":
-            raise WebmailInternalError(str(data[0]))
+        self._mailbox_command("unsubscribe", self._encode_mbox_name(name))
         return True
 
     def getquota(self, mailbox: str) -> None:

--- a/modoboa/webmail/tests/test_mailbox_errors.py
+++ b/modoboa/webmail/tests/test_mailbox_errors.py
@@ -1,0 +1,89 @@
+"""Tests for IMAP errors raised by mailbox (folder) operations."""
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+from modoboa.webmail.exceptions import MailboxOperationError, WebmailInternalError
+from modoboa.webmail.lib.imaputils import IMAP4Error
+from modoboa.webmail.mocks import IMAP4Mock
+from modoboa.webmail.tests.test_viewsets import WebmailTestCase
+
+
+class IMAP4MockRefusing(IMAP4Mock):
+    """Fake IMAP server refusing every mailbox operation."""
+
+    def create(self, name):
+        return "NO", [b"[ALREADYEXISTS] Mailbox already exists"]
+
+    def rename(self, oldname, newname):
+        return "NO", [b"[NONEXISTENT] Mailbox doesn't exist: Test"]
+
+    def delete(self, name):
+        return "NO", [b"[NONEXISTENT] Mailbox doesn't exist: Test"]
+
+    def subscribe(self, name):
+        # imaplib raises on BAD responses instead of returning them
+        raise IMAP4Error("SUBSCRIBE command error: BAD [b'Invalid name']")
+
+
+class WebmailInternalErrorTestCase(SimpleTestCase):
+
+    def test_bytes_reason(self):
+        """Server responses are bytes: they must not crash the constructor."""
+        error = WebmailInternalError(b"[ALREADYEXISTS] Mailbox already exists")
+        self.assertEqual(str(error), "Server response: Mailbox already exists")
+
+    def test_unstructured_reason(self):
+        self.assertEqual(str(WebmailInternalError(b"Failure")), "Failure")
+        self.assertEqual(str(WebmailInternalError("Failure")), "Failure")
+
+    def test_mailbox_operation_error_is_a_user_error(self):
+        self.assertEqual(MailboxOperationError(b"No").http_code, 400)
+
+
+class MailboxOperationErrorsTestCase(WebmailTestCase):
+    """A refused folder operation is reported (400), not a crash (500)."""
+
+    def setUp(self):
+        super().setUp()
+        self.mock_imap4.return_value = IMAP4MockRefusing()
+        self.authenticate()
+
+    def test_create_existing_folder(self):
+        url = reverse("v2:webmail-mailbox-list")
+        response = self.client.post(url, {"name": "Test"}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"], "Server response: Mailbox already exists"
+        )
+
+    def test_rename_unknown_folder(self):
+        url = reverse("v2:webmail-mailbox-rename")
+        response = self.client.post(
+            url, {"name": "Renamed", "oldname": "Test"}, format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"], "Server response: Mailbox doesn't exist: Test"
+        )
+
+    def test_delete_unknown_folder(self):
+        url = reverse("v2:webmail-mailbox-delete")
+        response = self.client.post(url, {"name": "Test"}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Mailbox doesn't exist", response.json()["error"])
+
+    def test_bad_response(self):
+        url = reverse("v2:webmail-mailbox-subscriptions")
+        response = self.client.post(
+            url, {"changes": [{"name": "Test", "subscribed": True}]}, format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("BAD", response.json()["error"])
+
+    def test_invalid_mailbox_name(self):
+        """A mailbox name that can't be sent to the server is a bad request."""
+        url = reverse("v2:webmail-email-list")
+        response = self.client.get(url, {"mailbox": "INBOX\r\nA1 DELETE Trash"})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "Invalid mailbox name")


### PR DESCRIPTION
- WebmailInternalError applied a text regex to the raw bytes returned by imaplib: a refused rename or delete (e.g. unknown folder) raised a TypeError, hence a 500. The reason is now decoded first, which also removes the "b'...'" shown in create/subscribe errors.
- Folder operations (create, rename, delete, subscribe, unsubscribe) share a helper turning NO responses and imaplib errors (BAD responses) into MailboxOperationError, a 400 carrying the server message: these are user errors, not internal ones.
- Invalid values that cannot be sent to the IMAP server (mailbox name, UID, part number, search pattern) raise InvalidImapArgument, a 400, instead of a 500.
- The real imaplib exception class is kept in IMAP4Error, so catching it keeps working when tests mock imaplib.IMAP4.