### PR TITLE
fix(webmail): keep addresses whole when display names contain commas

### DIFF
--- a/modoboa/webmail/lib/imapemail.py
+++ b/modoboa/webmail/lib/imapemail.py
@@ -22,6 +22,9 @@ from . import imapheader
 from .imaputils import get_imapconnector, validate_imap_uid, BodyStructure
 from .utils import decode_payload
 
+# Headers holding addresses, parsed from their raw value
+ADDRESS_HEADERS = ("From", "To", "Cc", "Bcc", "Reply-To")
+
 
 class ImapEmail(Email):
     """
@@ -104,6 +107,10 @@ class ImapEmail(Email):
             setattr(self, f"original_{header.replace('-', '')}", hdrvalue)
         if not hdrvalue:
             return ""
+        if header in ADDRESS_HEADERS:
+            # Parse the raw value: decoding encoded-words first could turn
+            # an encoded comma of a display name into an address separator.
+            hdrvalue = str(msg[header])
         try:
             key = re.sub("-", "_", header).lower()
             hdrvalue = getattr(imapheader, f"parse_{key}")(hdrvalue)

--- a/modoboa/webmail/lib/imapheader.py
+++ b/modoboa/webmail/lib/imapheader.py
@@ -11,7 +11,6 @@ from django.utils.formats import date_format
 from modoboa.lib.email_utils import EmailAddress
 from modoboa.lib.signals import get_request
 
-
 __all__ = [
     "parse_from",
     "parse_to",
@@ -80,11 +79,17 @@ def parse_address(value: str) -> dict:
 
 
 def parse_address_list(values: str) -> list[dict]:
-    """Parse a list of email addresses."""
-    lst = values.split(",")
+    """Parse a list of email addresses.
+
+    Display names may contain commas (``"Doe, John" <john@example.com>``,
+    common with Outlook): the list is split according to the address
+    syntax, not on every comma.
+    """
     result = []
-    for addr in lst:
-        result.append(parse_address(addr))
+    for name, address in email.utils.getaddresses([values]):
+        if not name and not address:
+            continue
+        result.append(parse_address(email.utils.formataddr((name, address))))
     return result
 
 

--- a/modoboa/webmail/tests/test_addresses.py
+++ b/modoboa/webmail/tests/test_addresses.py
@@ -1,0 +1,115 @@
+"""Tests for address lists whose display names contain commas (#2347)."""
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+from modoboa.webmail.lib import imapheader
+from modoboa.webmail.mocks import IMAP4Mock
+from modoboa.webmail.tests import data as tests_data
+from modoboa.webmail.tests.test_viewsets import WebmailTestCase
+
+OUTLOOK_NAME = "Berhane, Kidane T - Eagan, MN"
+
+# Message from an Outlook sender, as described in #2347 (UID 46935)
+_HEADERS = (
+    f'From: "{OUTLOOK_NAME}" <kidane@example.test>\r\n'
+    'To: <user@test.com>, "Doe, Jane" <jane@example.test>\r\n'
+    "Cc: =?utf-8?q?Doe=2C_John?= <john@example.test>, other@example.test\r\n"
+    "Subject: Comma test\r\n"
+    "Date: Wed, 28 Dec 2011 13:29:17 +0100\r\n"
+    f'Reply-To: "{OUTLOOK_NAME}" <kidane@example.test>\r\n'
+    "Message-ID: <comma-test@example.test>\r\n\r\n"
+).encode()
+
+HEADERS_RESPONSE = [
+    (
+        b"855 (UID 46935 "
+        + tests_data.BODYSTRUCTURE_4
+        + b" BODY[HEADER.FIELDS (FROM TO CC DATE SUBJECT REPLY-TO MESSAGE-ID)] {%d}"
+        % len(_HEADERS),
+        _HEADERS,
+    ),
+    b")",
+]
+BODYSTRUCTURE_RESPONSE = [(b"855 (UID 46935 " + tests_data.BODYSTRUCTURE_4), ")"]
+BODY_RESPONSE = [
+    (b"855 (UID 46935 BODY[1.1] {25}", b"This is a test message.\r\n"),
+    b")",
+]
+
+
+class IMAP4MockOutlookSender(IMAP4Mock):
+    """Fake IMAP server serving the message of #2347."""
+
+    def uid(self, command, *args):
+        if command == "FETCH" and int(args[0]) == 46935:
+            if args[1] == "(BODYSTRUCTURE)":
+                return "OK", BODYSTRUCTURE_RESPONSE
+            if "HEADER.FIELDS" in args[1]:
+                return "OK", HEADERS_RESPONSE
+            return "OK", BODY_RESPONSE
+        return super().uid(command, *args)
+
+
+class ParseAddressListTestCase(SimpleTestCase):
+
+    def test_quoted_name_with_commas(self):
+        result = imapheader.parse_address_list(
+            f'"{OUTLOOK_NAME}" <kidane@example.test>, jane@example.test'
+        )
+        self.assertEqual(
+            [addr["address"] for addr in result],
+            ["kidane@example.test", "jane@example.test"],
+        )
+        self.assertEqual(result[0]["name"], OUTLOOK_NAME)
+
+    def test_encoded_name_with_comma(self):
+        result = imapheader.parse_address_list(
+            "=?utf-8?q?Doe=2C_John?= <john@example.test>"
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["address"], "john@example.test")
+        self.assertEqual(result[0]["name"], "Doe, John")
+
+    def test_non_ascii_name(self):
+        result = imapheader.parse_address_list(
+            "=?utf-8?q?Ren=C3=A9?= <rene@example.test>"
+        )
+        self.assertEqual(result[0]["name"], "René")
+
+    def test_folded_header(self):
+        result = imapheader.parse_address_list("a@example.test,\r\n b@example.test")
+        self.assertEqual(
+            [addr["address"] for addr in result], ["a@example.test", "b@example.test"]
+        )
+
+    def test_empty(self):
+        self.assertEqual(imapheader.parse_address_list(""), [])
+
+
+class ReplyToOutlookSenderTestCase(WebmailTestCase):
+    """Replying to a sender whose name contains commas (#2347)."""
+
+    def test_reply_keeps_addresses_whole(self):
+        self.mock_imap4.return_value = IMAP4MockOutlookSender()
+        self.authenticate()
+        url = reverse("v2:webmail-email-content")
+        response = self.client.get(f"{url}?mailbox=INBOX&mailid=46935&context=reply")
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+
+        self.assertEqual(content["from_address"]["address"], "kidane@example.test")
+        self.assertEqual(content["from_address"]["name"], OUTLOOK_NAME)
+        self.assertEqual(
+            [(rcpt["address"], rcpt.get("name")) for rcpt in content["reply_to"]],
+            [("kidane@example.test", OUTLOOK_NAME)],
+        )
+        self.assertEqual(
+            [(rcpt["address"], rcpt.get("name")) for rcpt in content["to"]],
+            [("user@test.com", None), ("jane@example.test", "Doe, Jane")],
+        )
+        # Encoded display name: the comma only appears once decoded
+        self.assertEqual(
+            [(rcpt["address"], rcpt.get("name")) for rcpt in content["cc"]],
+            [("john@example.test", "Doe, John"), ("other@example.test", None)],
+        )


### PR DESCRIPTION
Address lists were split on every comma, so a display name such as "Berhane, Kidane T - Eagan, MN" (common with Outlook) produced several invalid addresses: replying to such a message filled the recipient fields with fragments that failed validation.

- parse_address_list now relies on email.utils.getaddresses, which follows the address syntax (quoted names, folding).
- The message view parses address headers from their raw value: decoding encoded-words first turned an encoded comma (=?utf-8?q?Doe=2C_John?=) into an address separator.

Closes #2347