### PR TITLE
fix(webmail): flag original messages as answered or forwarded

### DIFF
--- a/frontend/src/components/webmail/ComposeEmailForm.vue
+++ b/frontend/src/components/webmail/ComposeEmailForm.vue
@@ -352,6 +352,12 @@ const prepareMessage = () => {
   if (draftMailid.value) {
     result.mailid = draftMailid.value
   }
+  if (props.originalEmail && route.query.mailbox && route.query.mailid) {
+    // Let the server flag the original message (\Answered, $Forwarded)
+    result.original_mailbox = route.query.mailbox
+    result.original_mailid = route.query.mailid
+    result.original_action = props.forward ? 'forward' : 'reply'
+  }
   return result
 }
 

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -679,11 +679,14 @@ class IMAPconnector:
         self._remove_flag(mbox, msgset, r"(\Flagged)")
 
     def msg_forwarded(self, mailbox: str, mailid: str) -> None:
-        self._add_flag(mailbox, mailid, "($Forwarded)")
+        """Add the $Forwarded flag to this email."""
+        # _add_flag expects a list: joining a plain string would flag
+        # the messages 1, 2, 3 for UID "123".
+        self._add_flag(mailbox, [validate_imap_uid(mailid)], "($Forwarded)")
 
     def msg_answered(self, mailbox: str, mailid: str) -> None:
-        """Add the \Answered flag to this email."""
-        self._add_flag(mailbox, mailid, r"(\Answered)")
+        """Add the \\Answered flag to this email."""
+        self._add_flag(mailbox, [validate_imap_uid(mailid)], r"(\Answered)")
 
     def move(self, msgset, oldmailbox: str, newmailbox: str) -> None:
         """Move messages between mailboxes."""

--- a/modoboa/webmail/serializers.py
+++ b/modoboa/webmail/serializers.py
@@ -336,10 +336,30 @@ class SendEmailSerializer(ScheduledDatetimeMixin, BaseEmailSerializer):
     request_mdn = serializers.BooleanField(required=False, default=False)
     # UID of the draft this message comes from (deleted once sent)
     mailid = serializers.IntegerField(required=False)
+    # Message this one replies to or forwards (flagged once sent)
+    original_mailbox = serializers.CharField(required=False)
+    original_mailid = serializers.IntegerField(required=False, min_value=1)
+    original_action = serializers.ChoiceField(
+        choices=["reply", "forward"], required=False
+    )
+
+    ORIGINAL_MESSAGE_FIELDS = ("original_mailbox", "original_mailid", "original_action")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["to"].required = True
+
+    def validate(self, data):
+        data = super().validate(data)
+        provided = [name for name in self.ORIGINAL_MESSAGE_FIELDS if name in data]
+        if provided and len(provided) != len(self.ORIGINAL_MESSAGE_FIELDS):
+            raise serializers.ValidationError(
+                _(
+                    "original_mailbox, original_mailid and original_action "
+                    "must be provided together"
+                )
+            )
+        return data
 
 
 class SaveEmailSerializer(BaseEmailSerializer):

--- a/modoboa/webmail/tests/test_flags.py
+++ b/modoboa/webmail/tests/test_flags.py
@@ -1,0 +1,93 @@
+"""Tests for the \\Answered and $Forwarded flags set after sending."""
+
+from unittest import mock
+
+from django.core import mail
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+from modoboa.webmail.exceptions import ImapError
+from modoboa.webmail.lib.imaputils import IMAPconnector
+from modoboa.webmail.tests.test_viewsets import WebmailTestCase
+
+ADD_FLAG = "modoboa.webmail.lib.imaputils.IMAPconnector._add_flag"
+
+
+class FlagMethodsTestCase(SimpleTestCase):
+
+    def test_uid_is_passed_as_a_list(self):
+        """A plain string would be joined as "1,2,3" and flag other messages."""
+        imapc = IMAPconnector.__new__(IMAPconnector)
+        imapc._add_flag = mock.Mock()
+        imapc.msg_answered("INBOX", "123")
+        imapc._add_flag.assert_called_once_with("INBOX", ["123"], r"(\Answered)")
+        imapc._add_flag.reset_mock()
+        imapc.msg_forwarded("INBOX", "123")
+        imapc._add_flag.assert_called_once_with("INBOX", ["123"], "($Forwarded)")
+
+
+class FlagAfterSendingTestCase(WebmailTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.authenticate()
+        mail.outbox = []
+
+    def _send(self, **extra):
+        uid = self.client.post(reverse("v2:webmail-compose-session-list")).json()["uid"]
+        url = reverse("v2:webmail-compose-session-send", args=[uid])
+        data = {
+            "sender": self.user.email,
+            "to": ["test@example.test"],
+            "subject": "Re: test",
+            "body": "Test",
+            **extra,
+        }
+        return self.client.post(url, data, format="json")
+
+    def test_reply_flags_original_as_answered(self):
+        with mock.patch(ADD_FLAG) as add_flag:
+            response = self._send(
+                original_mailbox="INBOX", original_mailid=46931, original_action="reply"
+            )
+        self.assertEqual(response.status_code, 204)
+        add_flag.assert_called_once_with("INBOX", ["46931"], r"(\Answered)")
+
+    def test_forward_flags_original_as_forwarded(self):
+        with mock.patch(ADD_FLAG) as add_flag:
+            response = self._send(
+                original_mailbox="Archive",
+                original_mailid=12,
+                original_action="forward",
+            )
+        self.assertEqual(response.status_code, 204)
+        add_flag.assert_called_once_with("Archive", ["12"], "($Forwarded)")
+
+    def test_new_message_flags_nothing(self):
+        with mock.patch(ADD_FLAG) as add_flag:
+            response = self._send()
+        self.assertEqual(response.status_code, 204)
+        add_flag.assert_not_called()
+
+    def test_partial_original_message_is_rejected(self):
+        with mock.patch(ADD_FLAG) as add_flag:
+            response = self._send(original_mailbox="INBOX", original_mailid=46931)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(len(mail.outbox), 0)
+        add_flag.assert_not_called()
+
+    def test_invalid_action_is_rejected(self):
+        response = self._send(
+            original_mailbox="INBOX", original_mailid=46931, original_action="delete"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("original_action", response.json())
+
+    def test_flag_failure_does_not_fail_sending(self):
+        """The message is sent: failing to flag the original is not an error."""
+        with mock.patch(ADD_FLAG, side_effect=ImapError("NO")):
+            response = self._send(
+                original_mailbox="INBOX", original_mailid=46931, original_action="reply"
+            )
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(len(mail.outbox), 1)

--- a/modoboa/webmail/viewsets.py
+++ b/modoboa/webmail/viewsets.py
@@ -13,7 +13,7 @@ from modoboa.lib import exceptions
 from modoboa.lib.paginator import Paginator
 from modoboa.lib.viewsets import HasMailbox
 from modoboa.webmail import lib, models, serializers
-from modoboa.webmail.exceptions import ImapError
+from modoboa.webmail.exceptions import ImapError, WebmailInternalError
 from modoboa.webmail.lib import attachments
 from modoboa.webmail.lib.imaputils import UID_RE, PARTNUM_RE
 from modoboa.webmail.lib.sendmail import send_mail, schedule_email
@@ -481,8 +481,24 @@ class ComposeSessionViewSet(viewsets.GenericViewSet):
         if status:
             attachments.remove_attachments_and_session(manager, pk)
             self._delete_draft(request, draft_mailid)
+            self._flag_original_message(request, serializer.validated_data)
             return response.Response(status=204)
         return response.Response({"error": error}, status=400)
+
+    def _flag_original_message(self, request, data: dict) -> None:
+        """Flag the message this one replies to or forwards, once sent."""
+        if "original_mailid" not in data:
+            return
+        try:
+            with lib.get_imapconnector(request) as imapc:
+                if data["original_action"] == "reply":
+                    flag_message = imapc.msg_answered
+                else:
+                    flag_message = imapc.msg_forwarded
+                flag_message(data["original_mailbox"], str(data["original_mailid"]))
+        except (ImapError, WebmailInternalError):
+            # The message is already sent: a missing flag is not an error
+            pass
 
     def _delete_draft(self, request, mailid: int | None) -> None:
         """Remove the draft a message was composed from, once sent."""


### PR DESCRIPTION
The \Answered and $Forwarded flags were never set: the helpers existed but nothing called them, so replies and forwards never showed up in the message list.

- The compose form sends the mailbox and UID of the message being replied to or forwarded; once the message is sent, the API flags it. The three fields must be provided together. Failing to set the flag does not fail the sending, the message is already gone.
- msg_answered and msg_forwarded passed the UID as a string to a helper joining a list: UID "123" would have flagged messages 1, 2 and 3. They now pass a list of one validated UID.