### PR TITLE
fix(webmail): store attachments privately and clean up resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ test_project/cert.crt
 test_project/cert.key
 test_project/envfile
 test_project/media
+test_project/webmail_attachments
 
 # Docker
 docker/collections

--- a/modoboa/core/commands/templates/cron_config.py.tpl
+++ b/modoboa/core/commands/templates/cron_config.py.tpl
@@ -7,6 +7,7 @@ from modoboa.core import jobs as core_jobs
 from modoboa.admin import jobs as admin_jobs
 from modoboa.maillog import jobs as maillog_jobs
 from modoboa.webmail import jobs as webmail_jobs
+from modoboa.webmail.lib import attachments as webmail_attachments
 
 
 register(core_jobs.clean_logs, queue_name="modoboa", cron="0 0 * * *")
@@ -26,6 +27,11 @@ register(maillog_jobs.update_statistics, queue_name="modoboa", cron="0 * * * *")
 register(calendars_jobs.generate_rights, queue_name="privileged", cron="*/2 * * * *")
 
 register(webmail_jobs.send_scheduled_messages, queue_name="modoboa", cron="* * * * *")
+register(
+    webmail_attachments.cleanup_orphan_attachments,
+    queue_name="modoboa",
+    cron="17 * * * *",
+)
 
 if "modoboa.amavis" in settings.MODOBOA_APPS:
     from modoboa.amavis import jobs as amavis_jobs

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -211,6 +211,10 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'sitestatic')
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
+# Webmail attachments (messages being written, scheduled messages): this
+# directory must NOT be served by the web server.
+WEBMAIL_ATTACHMENTS_ROOT = os.path.join(BASE_DIR, 'webmail_attachments')
+
 # oAuth2 settings
 
 OAUTH2_PROVIDER = {

--- a/modoboa/webmail/lib/attachments.py
+++ b/modoboa/webmail/lib/attachments.py
@@ -1,15 +1,19 @@
+from datetime import timedelta
 from email import encoders
 from email.mime.base import MIMEBase
 import json
 import os
 from tempfile import NamedTemporaryFile
+import time
 from typing import TypedDict
 import uuid
 
 
 from django.conf import settings
+from django.core.files.storage import FileSystemStorage
 from django.core.files.uploadhandler import FileUploadHandler, SkipFile
 from django.http import Http404
+from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext as _
 
 from modoboa.lib.exceptions import InternalError
@@ -19,52 +23,113 @@ from modoboa.parameters import tools as param_tools
 
 from .rfc6266 import build_header
 
-
 Attachment = TypedDict(
     "Attachment", {"fname": str, "content-type": str, "size": int, "tmpname": str}
 )
 
+# Compose sessions expire after this delay without activity
+COMPOSE_SESSION_TTL = timedelta(days=1)
+# Files younger than this are never considered orphans (upload in progress)
+ORPHAN_GRACE_PERIOD = timedelta(hours=1)
+
+COMPOSE_SESSION_KEY_PREFIX = "webmail:compose"
+
 
 class ComposeSessionManager:
+    """Compose sessions, stored in Redis with an expiration delay.
+
+    A session keeps track of the attachments uploaded for a message being
+    written. Each session has its own key so that abandoned sessions
+    expire instead of piling up.
+    """
 
     def __init__(self, username: str):
-        self.hash = f"webmail-{username}"
+        self.username = username
         self.rclient = get_redis_connection(bytes)
+
+    def _key(self, uid: str) -> str:
+        return f"{COMPOSE_SESSION_KEY_PREFIX}:{self.username}:{uid}"
 
     def create(self) -> str:
         """
         Initialize a new "compose" session.
 
-        It is used to keep track of attachments defined with a new
-        message. Each new message will be associated with a unique ID (in
-        order to avoid conflicts between users).
+        Each new message will be associated with a unique ID (in order to
+        avoid conflicts between users).
         """
-        randid = str(uuid.uuid4()).replace("-", "")
-        self.rclient.hset(self.hash, randid, json.dumps({"attachments": []}))
+        randid = uuid.uuid4().hex
+        self.set_content(randid, {"attachments": []})
         return randid
 
     def delete(self, uid: str) -> None:
-        self.rclient.hdel(self.hash, uid)
+        self.rclient.delete(self._key(uid))
 
     def exists(self, uid: str) -> bool:
-        return self.rclient.hexists(self.hash, uid)
+        return bool(self.rclient.exists(self._key(uid)))
 
     def get_content(self, uid: str) -> dict:
-        if not self.exists(uid):
+        content = self.rclient.get(self._key(uid))
+        if content is None:
             raise Http404
-        content = self.rclient.hget(self.hash, uid)
+        # Keep a session in use alive
+        self.rclient.expire(self._key(uid), COMPOSE_SESSION_TTL)
         return json.loads(content.decode())
 
     def set_content(self, uid: str, content: dict):
-        return self.rclient.hset(self.hash, uid, json.dumps(content))
+        return self.rclient.set(
+            self._key(uid), json.dumps(content), ex=COMPOSE_SESSION_TTL
+        )
+
+
+def get_attachments_dir() -> str:
+    """Return the directory holding webmail attachments.
+
+    It contains the files of messages being written and the attachments
+    of scheduled messages: it must never be served by the web server, so
+    it defaults to a directory next to MEDIA_ROOT, not inside it.
+    """
+    return getattr(settings, "WEBMAIL_ATTACHMENTS_ROOT", None) or os.path.join(
+        settings.BASE_DIR, "webmail_attachments"
+    )
 
 
 def get_storage_path(filename):
-    """Return a path to store a file."""
-    storage_dir = os.path.join(settings.MEDIA_ROOT, "webmail")
+    """Return the path of an attachment file.
+
+    Only the file name is kept: a stored name can never point outside
+    the attachments directory.
+    """
+    storage_dir = get_attachments_dir()
     if not filename:
         return storage_dir
-    return os.path.join(storage_dir, filename)
+    return os.path.join(storage_dir, os.path.basename(filename))
+
+
+@deconstructible(path="modoboa.webmail.lib.attachments.WebmailAttachmentStorage")
+class WebmailAttachmentStorage(FileSystemStorage):
+    """Private storage for webmail attachments: files have no URL."""
+
+    @property
+    def base_location(self):
+        return get_attachments_dir()
+
+    @property
+    def location(self):
+        return os.path.abspath(self.base_location)
+
+    @property
+    def base_url(self):
+        return None
+
+
+def _create_attachment_file():
+    """Create a new file with a random name in the attachments directory."""
+    storage_dir = get_attachments_dir()
+    try:
+        os.makedirs(storage_dir, mode=0o700, exist_ok=True)
+        return NamedTemporaryFile(dir=storage_dir, delete=False)
+    except OSError as e:
+        raise InternalError(str(e)) from None
 
 
 def save_attachment_from_upload(request, session_uid: str, f) -> Attachment:
@@ -80,10 +145,7 @@ def save_attachment_from_upload(request, session_uid: str, f) -> Attachment:
     manager = ComposeSessionManager(request.user.username)
     if not manager.exists(session_uid):
         raise Http404
-    try:
-        fp = NamedTemporaryFile(dir=get_storage_path(""), delete=False)
-    except Exception as e:
-        raise InternalError(str(e)) from None
+    fp = _create_attachment_file()
     for chunk in f.chunks():
         fp.write(chunk)
     fp.close()
@@ -113,10 +175,7 @@ def save_attachment(
     manager = ComposeSessionManager(request.user.username)
     if not manager.exists(session_uid):
         raise Http404
-    try:
-        fp = NamedTemporaryFile(dir=get_storage_path(""), delete=False)
-    except Exception as e:
-        raise InternalError(str(e)) from None
+    fp = _create_attachment_file()
     if isinstance(content, str):
         content = content.encode("utf-8")
     fp.write(content)
@@ -140,7 +199,7 @@ def remove_attachment(request, session_uid: str, name: str) -> str | None:
     for att in session["attachments"]:
         if att["tmpname"] == name:
             session["attachments"].remove(att)
-            fullpath = os.path.join(settings.MEDIA_ROOT, "webmail", att["tmpname"])
+            fullpath = get_storage_path(att["tmpname"])
             try:
                 os.remove(fullpath)
             except OSError as e:
@@ -161,6 +220,46 @@ def remove_attachments_and_session(
         except OSError:
             pass
     manager.delete(session_uid)
+
+
+def cleanup_orphan_attachments() -> int:
+    """Delete attachment files no longer used by anything.
+
+    A file is kept while a compose session or a scheduled message refers
+    to it. Others come from abandoned or expired sessions and are removed,
+    except very recent ones (the session may not reference them yet).
+
+    :return: the number of removed files
+    """
+    from modoboa.webmail.models import MessageAttachment
+
+    storage_dir = get_attachments_dir()
+    if not os.path.isdir(storage_dir):
+        return 0
+    used = {
+        os.path.basename(name)
+        for name in MessageAttachment.objects.values_list("file", flat=True)
+    }
+    rclient = get_redis_connection(bytes)
+    for key in rclient.scan_iter(match=f"{COMPOSE_SESSION_KEY_PREFIX}:*"):
+        content = rclient.get(key)
+        if content is None:
+            continue
+        for att in json.loads(content.decode()).get("attachments", []):
+            used.add(att["tmpname"])
+    limit = time.time() - ORPHAN_GRACE_PERIOD.total_seconds()
+    removed = 0
+    for entry in os.scandir(storage_dir):
+        if not entry.is_file() or entry.name in used:
+            continue
+        if entry.stat().st_mtime > limit:
+            continue
+        try:
+            os.remove(entry.path)
+        except OSError:
+            continue
+        removed += 1
+    return removed
 
 
 def create_mail_attachment(attdef, payload=None):

--- a/modoboa/webmail/lib/utils.py
+++ b/modoboa/webmail/lib/utils.py
@@ -13,7 +13,10 @@ from django.conf import settings
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 
 from modoboa.core import models as core_models
-from modoboa.webmail.lib.attachments import create_mail_attachment
+from modoboa.webmail.lib.attachments import (
+    create_mail_attachment,
+    get_attachments_dir,
+)
 
 
 def html2plaintext(content: str) -> str:
@@ -73,6 +76,12 @@ def make_body_images_inline(body: str) -> tuple[str, list]:
     html = lxml.html.fromstring(body)
     parts = []
     root = Path(settings.BASE_DIR).resolve()
+    # Never embed private files: attachments of any user, and the legacy
+    # webmail media directory (inline images and uploads of other users).
+    private_dirs = [
+        Path(get_attachments_dir()).resolve(),
+        (Path(settings.MEDIA_ROOT) / "webmail").resolve(),
+    ]
     for tag in html.iter("img"):
         src = tag.get("src")
         if src is None:
@@ -88,6 +97,8 @@ def make_body_images_inline(body: str) -> tuple[str, list]:
         try:
             candidate.relative_to(root)
         except ValueError:
+            continue
+        if any(candidate.is_relative_to(private) for private in private_dirs):
             continue
         if not candidate.is_file():
             continue

--- a/modoboa/webmail/migrations/0003_move_attachments_out_of_media.py
+++ b/modoboa/webmail/migrations/0003_move_attachments_out_of_media.py
@@ -1,0 +1,41 @@
+import os
+import shutil
+
+from django.conf import settings
+from django.db import migrations, models
+
+import modoboa.webmail.lib.attachments
+
+
+def move_attachments_out_of_media(apps, schema_editor):
+    """Move the files of existing scheduled messages out of MEDIA_ROOT."""
+    MessageAttachment = apps.get_model("webmail", "MessageAttachment")
+    legacy_dir = os.path.join(settings.MEDIA_ROOT, "webmail")
+    target_dir = modoboa.webmail.lib.attachments.get_attachments_dir()
+    for name in MessageAttachment.objects.values_list("file", flat=True):
+        name = os.path.basename(name)
+        source = os.path.join(legacy_dir, name)
+        target = os.path.join(target_dir, name)
+        if not os.path.isfile(source) or os.path.exists(target):
+            continue
+        os.makedirs(target_dir, mode=0o700, exist_ok=True)
+        shutil.move(source, target)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("webmail", "0002_scheduledmessage_request_dsn_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="messageattachment",
+            name="file",
+            field=models.FileField(
+                storage=modoboa.webmail.lib.attachments.WebmailAttachmentStorage(),
+                upload_to="",
+            ),
+        ),
+        migrations.RunPython(move_attachments_out_of_media, migrations.RunPython.noop),
+    ]

--- a/modoboa/webmail/models.py
+++ b/modoboa/webmail/models.py
@@ -2,11 +2,16 @@
 Webmail related models.
 """
 
+import os
+
 from django.core.mail import EmailMessage
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 from modoboa.lib import dovecot
 from modoboa.webmail import constants
+from modoboa.webmail.lib.attachments import WebmailAttachmentStorage, get_storage_path
 from modoboa.webmail.lib.utils import create_message
 
 
@@ -96,7 +101,8 @@ class MessageAttachment(models.Model):
     message = models.ForeignKey(
         ScheduledMessage, on_delete=models.CASCADE, related_name="attachments"
     )
-    file = models.FileField()
+    # Private storage: never inside MEDIA_ROOT, which may be served
+    file = models.FileField(storage=WebmailAttachmentStorage())
     content_type = models.CharField(max_length=150)
     filename = models.CharField(max_length=255)
 
@@ -109,3 +115,18 @@ class MessageAttachment(models.Model):
             "tmpname": self.file.name,
             "fname": self.filename,
         }
+
+
+@receiver(post_delete, sender=MessageAttachment)
+def remove_attachment_file(sender, instance, **kwargs):
+    """Delete the file of an attachment along with its record.
+
+    Also triggered when the scheduled message is deleted (once sent or
+    cancelled), through the cascade.
+    """
+    if not instance.file.name:
+        return
+    try:
+        os.remove(get_storage_path(instance.file.name))
+    except FileNotFoundError:
+        pass

--- a/modoboa/webmail/tests/test_attachments_storage.py
+++ b/modoboa/webmail/tests/test_attachments_storage.py
@@ -1,0 +1,187 @@
+"""Tests for the private attachments storage and resources cleanup."""
+
+import importlib
+import os
+import time
+
+from dateutil.relativedelta import relativedelta
+
+from django.apps import apps
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from modoboa.webmail import factories, models
+from modoboa.webmail.lib import attachments
+from modoboa.webmail.lib.utils import make_body_images_inline
+from modoboa.webmail.tests.test_viewsets import WebmailTestCase, get_gif
+
+
+def _write_file(path: str, content: bytes = b"x", age: int = 0) -> str:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fp:
+        fp.write(content)
+    if age:
+        past = time.time() - age
+        os.utime(path, (past, past))
+    return path
+
+
+class AttachmentStorageTestCase(WebmailTestCase):
+    """Attachments are stored outside MEDIA_ROOT and never served."""
+
+    def setUp(self):
+        super().setUp()
+        self.attachments_dir = f"{self.workdir}/attachments"
+        self.media_root = f"{self.workdir}/media"
+
+    def test_default_directory_is_outside_media_root(self):
+        with override_settings(
+            WEBMAIL_ATTACHMENTS_ROOT=None,
+            BASE_DIR=self.workdir,
+            MEDIA_ROOT=self.media_root,
+        ):
+            path = attachments.get_attachments_dir()
+        self.assertEqual(path, f"{self.workdir}/webmail_attachments")
+
+    def test_storage_path_keeps_the_file_name_only(self):
+        self.assertEqual(
+            attachments.get_storage_path("../../etc/passwd"),
+            f"{self.attachments_dir}/passwd",
+        )
+
+    def test_files_have_no_url(self):
+        with self.assertRaises(ValueError):
+            attachments.WebmailAttachmentStorage().url("tmpfile")
+
+    def test_upload_is_stored_in_private_directory(self):
+        self.authenticate()
+        uid = self.client.post(reverse("v2:webmail-compose-session-list")).json()["uid"]
+        url = reverse("v2:webmail-compose-session-attachments", args=[uid])
+        with self.settings(MEDIA_ROOT=self.media_root):
+            response = self.client.post(url, {"attachment": get_gif()})
+        self.assertEqual(response.status_code, 200)
+        tmpname = response.json()["tmpname"]
+        self.assertTrue(os.path.isfile(f"{self.attachments_dir}/{tmpname}"))
+        self.assertFalse(os.path.exists(self.media_root))
+
+    def test_body_images_never_embed_private_files(self):
+        """Another user's attachment can't be embedded by referencing its path."""
+        _write_file(f"{self.attachments_dir}/tmpimage", get_gif().read())
+        _write_file(f"{self.media_root}/webmail/tmplegacy", get_gif().read())
+        _write_file(f"{self.workdir}/static/icon.gif", get_gif().read())
+        with override_settings(BASE_DIR=self.workdir, MEDIA_ROOT=self.media_root):
+            _, parts = make_body_images_inline(
+                '<p><img src="/attachments/tmpimage">'
+                '<img src="/media/webmail/tmplegacy"></p>'
+            )
+            self.assertEqual(parts, [])
+            # A regular local image is still embedded
+            _, parts = make_body_images_inline('<p><img src="/static/icon.gif"></p>')
+            self.assertEqual(len(parts), 1)
+
+    def test_migration_moves_existing_files(self):
+        migration = importlib.import_module(
+            "modoboa.webmail.migrations.0003_move_attachments_out_of_media"
+        )
+        _write_file(f"{self.media_root}/webmail/tmplegacy", b"legacy")
+        message = factories.ScheduledMessageFactory(
+            account=self.user, scheduled_datetime=timezone.now()
+        )
+        models.MessageAttachment.objects.create(
+            message=message,
+            file="tmplegacy",
+            content_type="text/plain",
+            filename="a.txt",
+        )
+        with override_settings(MEDIA_ROOT=self.media_root):
+            migration.move_attachments_out_of_media(apps, None)
+        self.assertFalse(os.path.exists(f"{self.media_root}/webmail/tmplegacy"))
+        with open(f"{self.attachments_dir}/tmplegacy", "rb") as fp:
+            self.assertEqual(fp.read(), b"legacy")
+
+
+class ResourcesCleanupTestCase(WebmailTestCase):
+    """Compose sessions expire and unused files are removed."""
+
+    def setUp(self):
+        super().setUp()
+        self.attachments_dir = f"{self.workdir}/attachments"
+        self.manager = attachments.ComposeSessionManager(self.user.username)
+
+    def test_compose_session_expires(self):
+        uid = self.manager.create()
+        self.addCleanup(self.manager.delete, uid)
+        key = self.manager._key(uid)
+        ttl = self.manager.rclient.ttl(key)
+        self.assertGreater(ttl, 0)
+        self.assertLessEqual(ttl, attachments.COMPOSE_SESSION_TTL.total_seconds())
+        # An active session is kept alive
+        self.manager.rclient.expire(key, 10)
+        self.manager.get_content(uid)
+        self.assertGreater(self.manager.rclient.ttl(key), 10)
+
+    def test_scheduling_drops_session_and_keeps_files(self):
+        self.authenticate()
+        uid = self.client.post(reverse("v2:webmail-compose-session-list")).json()["uid"]
+        url = reverse("v2:webmail-compose-session-attachments", args=[uid])
+        tmpname = self.client.post(url, {"attachment": get_gif()}).json()["tmpname"]
+        path = f"{self.attachments_dir}/{tmpname}"
+
+        url = reverse("v2:webmail-compose-session-send", args=[uid])
+        response = self.client.post(
+            url,
+            {
+                "sender": self.user.email,
+                "to": ["test@example.test"],
+                "subject": "test",
+                "body": "Test",
+                "scheduled_datetime": (
+                    timezone.now() + relativedelta(hours=1)
+                ).isoformat(),
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(self.manager.exists(uid))
+        self.assertTrue(os.path.isfile(path))
+
+        # Deleting the scheduled message (sent or cancelled) removes its files
+        models.ScheduledMessage.objects.get().delete()
+        self.assertFalse(os.path.exists(path))
+
+    def test_cleanup_orphan_attachments(self):
+        orphan = _write_file(f"{self.attachments_dir}/tmporphan", age=7200)
+        recent = _write_file(f"{self.attachments_dir}/tmprecent", age=60)
+        scheduled = _write_file(f"{self.attachments_dir}/tmpscheduled", age=7200)
+        in_session = _write_file(f"{self.attachments_dir}/tmpsession", age=7200)
+
+        message = factories.ScheduledMessageFactory(
+            account=self.user, scheduled_datetime=timezone.now()
+        )
+        models.MessageAttachment.objects.create(
+            message=message,
+            file="tmpscheduled",
+            content_type="text/plain",
+            filename="a.txt",
+        )
+        uid = self.manager.create()
+        self.addCleanup(self.manager.delete, uid)
+        self.manager.set_content(
+            uid,
+            {
+                "attachments": [
+                    {
+                        "fname": "b.txt",
+                        "content-type": "text/plain",
+                        "size": 1,
+                        "tmpname": "tmpsession",
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(attachments.cleanup_orphan_attachments(), 1)
+        self.assertFalse(os.path.exists(orphan))
+        for path in (recent, scheduled, in_session):
+            self.assertTrue(os.path.exists(path), path)

--- a/modoboa/webmail/tests/test_viewsets.py
+++ b/modoboa/webmail/tests/test_viewsets.py
@@ -74,6 +74,11 @@ class WebmailTestCase(ModoAPITestCase):
         self.set_global_parameter("imap_port", 1435)
         self.workdir = tempfile.mkdtemp()
         os.mkdir(f"{self.workdir}/webmail")
+        attachments_root = self.settings(
+            WEBMAIL_ATTACHMENTS_ROOT=f"{self.workdir}/attachments"
+        )
+        attachments_root.enable()
+        self.addCleanup(attachments_root.disable)
         self.set_global_parameter("update_scheme", False, app="core")
 
     def tearDown(self):
@@ -456,7 +461,7 @@ class ComposeSessionViewSetTestCase(WebmailTestCase):
         self.assertEqual(len(content["attachments"]), 1)
         # The attachment must be stored decoded, not as base64 text
         tmpname = content["attachments"][0]["tmpname"]
-        with open(f"{self.workdir}/webmail/{tmpname}", "rb") as fp:
+        with open(f"{self.workdir}/attachments/{tmpname}", "rb") as fp:
             self.assertTrue(fp.read().startswith(b"%PDF-1.4"))
 
     def test_get(self):
@@ -512,7 +517,7 @@ class ComposeSessionViewSetTestCase(WebmailTestCase):
         content = manager.get_content(uid)
         self.assertEqual(len(content["attachments"]), 1)
         name = content["attachments"][0]["tmpname"]
-        path = f"{self.workdir}/webmail/{name}"
+        path = f"{self.workdir}/attachments/{name}"
         self.assertTrue(os.path.exists(path))
 
         url = reverse("v2:webmail-compose-session-delete-attachment", args=[uid, name])

--- a/modoboa/webmail/viewsets.py
+++ b/modoboa/webmail/viewsets.py
@@ -470,6 +470,9 @@ class ComposeSessionViewSet(viewsets.GenericViewSet):
                 serializer.validated_data,
                 manager.get_content(pk)["attachments"],
             )
+            # The files now belong to the scheduled message: only drop the
+            # compose session.
+            manager.delete(pk)
             self._delete_draft(request, draft_mailid)
             return response.Response(status=204)
 

--- a/test_project/test_project/cron_config.py
+++ b/test_project/test_project/cron_config.py
@@ -8,7 +8,7 @@ from modoboa.core import jobs as core_jobs
 from modoboa.admin import jobs as admin_jobs
 from modoboa.maillog import jobs as maillog_jobs
 from modoboa.webmail import jobs as webmail_jobs
-
+from modoboa.webmail.lib import attachments as webmail_attachments
 
 register(core_jobs.clean_logs, queue_name="modoboa", cron="0 0 * * *")
 
@@ -28,6 +28,11 @@ register(maillog_jobs.update_statistics, queue_name="modoboa", cron="0 * * * *")
 register(calendars_jobs.generate_rights, queue_name="modoboa", cron="*/2 * * * *")
 
 register(webmail_jobs.send_scheduled_messages, queue_name="modoboa", cron="* * * * *")
+register(
+    webmail_attachments.cleanup_orphan_attachments,
+    queue_name="modoboa",
+    cron="17 * * * *",
+)
 
 if "modoboa.amavis" in settings.MODOBOA_APPS:
     register(amavis_jobs.qcleanup, queue_name="modoboa", cron="0 0 * * *")


### PR DESCRIPTION
Attachments were stored in MEDIA_ROOT/webmail, which the web server may serve publicly, and nothing was ever cleaned up.

- Attachments (messages being written, scheduled messages) now live in WEBMAIL_ATTACHMENTS_ROOT, by default BASE_DIR/webmail_attachments, next to MEDIA_ROOT and never inside it. The storage gives files no URL and stored names can't point outside the directory. A migration moves the files of existing scheduled messages.
- Compose sessions get one Redis key each, expiring after a day without activity, instead of a hash per user growing forever.
- An hourly job deletes files no compose session nor scheduled message refers to anymore; deleting a scheduled attachment (sent or cancelled message) deletes its file; scheduling a message drops its compose session.
- make_body_images_inline no longer embeds files from the attachments directory or the legacy media/webmail one: a user knowing the name of another user's upload could send it to themselves.
