### PR TITLE
perf(webmail): use a single IMAP connection per request

### DIFF
--- a/modoboa/webmail/lib/__init__.py
+++ b/modoboa/webmail/lib/__init__.py
@@ -4,10 +4,15 @@ from .attachments import (
     AttachmentUploadHandler,
 )
 from .imapemail import ImapEmail, EditModifier, ReplyModifier, ForwardModifier
-from .imaputils import BodyStructure, IMAPconnector, get_imapconnector, separate_mailbox
+from .imaputils import (
+    BodyStructure,
+    IMAPconnector,
+    close_imapconnector,
+    get_imapconnector,
+    separate_mailbox,
+)
 from .signature import EmailSignature
 from .utils import decode_payload
-
 
 __all__ = [
     "AttachmentUploadHandler",
@@ -18,6 +23,7 @@ __all__ = [
     "IMAPconnector",
     "ImapEmail",
     "ReplyModifier",
+    "close_imapconnector",
     "create_mail_attachment",
     "decode_payload",
     "get_imapconnector",

--- a/modoboa/webmail/lib/imapemail.py
+++ b/modoboa/webmail/lib/imapemail.py
@@ -50,7 +50,11 @@ class ImapEmail(Email):
         self.To: list = []
 
     def __del__(self):
-        self.imapc.__exit__()
+        # The connector may not exist yet if __init__ failed, and it is
+        # closed with the request anyway.
+        imapc = getattr(self, "imapc", None)
+        if imapc is not None:
+            imapc.__exit__()
 
     def fetch_headers(self, raw_addresses: bool = False) -> None:
         """Fetch message headers from server."""
@@ -121,6 +125,9 @@ class ImapEmail(Email):
     def fetch_body_structure(self, msg=None):
         """Fetch BODYSTRUCTURE for email."""
         if msg is None:
+            if getattr(self, "bs", None) is not None:
+                # Already loaded with the headers: no need to ask again
+                return
             msg = self.imapc.fetchmail(self.mbox, self.mailid, readonly=False)
         self.bs = BodyStructure(msg["BODYSTRUCTURE"])
         self._find_attachments()

--- a/modoboa/webmail/lib/imaputils.py
+++ b/modoboa/webmail/lib/imaputils.py
@@ -221,15 +221,35 @@ class IMAPconnector:
         self.user = user
         self.password = password
         self.with_namespaces = with_namespaces
+        # Number of opened "with" blocks using this connector
+        self._usage_count = 0
+        # True when the connection lifetime is tied to a request
+        self.managed = False
 
     def __enter__(self):
-        self.login(self.user, self.password)
-        if self.load_namespaces:
-            self.load_namespaces()
+        """Open the connection, or join the one already opened.
+
+        Blocks can be nested (a viewset using a connector while building
+        an ImapEmail, for example): only the outermost one authenticates.
+        """
+        self._usage_count += 1
+        # A request-scoped connector stays open between blocks: only
+        # authenticate when there is no connection yet.
+        if self._usage_count == 1 and not self.connected:
+            self.login(self.user, self.password)
+            if self.with_namespaces:
+                self.load_namespaces()
         return self
 
     def __exit__(self, *args):
-        self.logout()
+        self._usage_count = max(self._usage_count - 1, 0)
+        # A request-scoped connector is closed once the request is over
+        if self._usage_count == 0 and not self.managed:
+            self.logout()
+
+    @property
+    def connected(self) -> bool:
+        return getattr(self, "m", None) is not None
 
     def _cmd(self, name: str, *args, **kwargs) -> list | None:
         """IMAP command wrapper.
@@ -323,6 +343,9 @@ class IMAPconnector:
 
     def logout(self) -> None:
         """Logout from server."""
+        if not self.connected:
+            return
+        self._usage_count = 0
         try:
             self._cmd("CHECK")
         except ImapError:
@@ -959,11 +982,52 @@ def separate_mailbox(fullname: str, sep: str = ".") -> tuple[str, str | None]:
     return fullname, None
 
 
+CONNECTOR_ATTRIBUTE = "_webmail_imapconnector"
+
+
+def _connection_store(request):
+    """Return the object holding the connector of a request.
+
+    DRF wraps the Django request: always use the underlying one so that
+    every caller shares the same connector.
+    """
+    return getattr(request, "_request", request)
+
+
 def get_imapconnector(request, **kwargs) -> IMAPconnector:
-    """Shortcut to create an IMAP connector.
+    """Return the IMAP connector of the given request.
+
+    A single connection is opened per request (and closed by
+    :func:`close_imapconnector`) instead of one per operation: each one
+    costs a TCP connection, a TLS handshake and an authentication.
 
     :param request: a ``Request`` object
     """
-    return IMAPconnector(
-        request.user.username, oauth2.get_access_token(request), **kwargs
-    )
+    if kwargs:
+        # Specific settings: not shareable
+        return IMAPconnector(
+            request.user.username, oauth2.get_access_token(request), **kwargs
+        )
+    store = _connection_store(request)
+    connector = getattr(store, CONNECTOR_ATTRIBUTE, None)
+    if connector is None:
+        connector = IMAPconnector(
+            request.user.username, oauth2.get_access_token(request)
+        )
+        connector.managed = True
+        setattr(store, CONNECTOR_ATTRIBUTE, connector)
+    return connector
+
+
+def close_imapconnector(request) -> None:
+    """Close the connector of a request, if one was opened."""
+    store = _connection_store(request)
+    connector = getattr(store, CONNECTOR_ATTRIBUTE, None)
+    if connector is None:
+        return
+    delattr(store, CONNECTOR_ATTRIBUTE)
+    try:
+        connector.logout()
+    except (ImapError, OSError):
+        # The connection is being dropped anyway
+        pass

--- a/modoboa/webmail/tests/test_connections.py
+++ b/modoboa/webmail/tests/test_connections.py
@@ -1,0 +1,113 @@
+"""Tests for the IMAP connection lifetime (one per request)."""
+
+from unittest import mock
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+from modoboa.webmail.lib import imaputils
+from modoboa.webmail.mocks import IMAP4Mock
+from modoboa.webmail.tests.test_viewsets import WebmailTestCase
+
+
+class RecordingIMAP4Mock(IMAP4Mock):
+    """Fake IMAP4 client recording the commands it receives."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.commands = []
+
+    def _simple_command(self, name, *args, **kwargs):
+        self.commands.append(name)
+        return super()._simple_command(name, *args, **kwargs)
+
+
+class ConnectorReuseTestCase(SimpleTestCase):
+    """A connector is shared, and nested blocks don't close it early."""
+
+    def _connector(self):
+        connector = imaputils.IMAPconnector.__new__(imaputils.IMAPconnector)
+        connector._usage_count = 0
+        connector.managed = False
+        connector.with_namespaces = False
+        connector.user = "user@test.com"
+        connector.password = "token"
+        connector.login = mock.Mock()
+        connector.logout = mock.Mock()
+        return connector
+
+    def test_nested_blocks_login_once(self):
+        connector = self._connector()
+        with connector:
+            with connector:
+                pass
+            connector.logout.assert_not_called()
+        connector.login.assert_called_once()
+        connector.logout.assert_called_once()
+
+    def test_managed_connector_stays_open(self):
+        connector = self._connector()
+        connector.managed = True
+        with connector:
+            pass
+        connector.login.assert_called_once()
+        # Closed with the request, not at the end of the block
+        connector.logout.assert_not_called()
+
+
+class RequestConnectionTestCase(WebmailTestCase):
+    """One connection per request, closed when the request ends."""
+
+    def setUp(self):
+        super().setUp()
+        self.imap = RecordingIMAP4Mock()
+        self.mock_imap4.return_value = self.imap
+        self.authenticate()
+
+    def test_list_opens_a_single_connection(self):
+        url = reverse("v2:webmail-email-list")
+        response = self.client.get(f"{url}?mailbox=INBOX")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.mock_imap4.call_count, 1)
+        self.assertEqual(self.imap.commands.count("LOGOUT"), 1)
+
+    def test_message_view_opens_a_single_connection(self):
+        url = reverse("v2:webmail-email-content")
+        response = self.client.get(f"{url}?mailbox=INBOX&mailid=46931")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.mock_imap4.call_count, 1)
+        self.assertEqual(self.imap.commands.count("LOGOUT"), 1)
+
+    def test_sending_opens_a_single_connection(self):
+        """Sent copy, draft removal and flagging share one connection."""
+        uid = self.client.post(reverse("v2:webmail-compose-session-list")).json()["uid"]
+        self.mock_imap4.reset_mock()
+        self.imap.commands.clear()
+        url = reverse("v2:webmail-compose-session-send", args=[uid])
+        response = self.client.post(
+            url,
+            {
+                "sender": self.user.email,
+                "to": ["test@example.test"],
+                "subject": "test",
+                "body": "Test",
+                "mailid": 11,
+                "original_mailbox": "INBOX",
+                "original_mailid": 46931,
+                "original_action": "reply",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.mock_imap4.call_count, 1)
+        self.assertEqual(self.imap.commands.count("LOGOUT"), 1)
+
+    def test_connection_closed_even_on_error(self):
+        url = reverse("v2:webmail-email-content")
+        with mock.patch(
+            "modoboa.webmail.lib.imaputils.IMAPconnector.fetchmail",
+            side_effect=imaputils.ImapError("boom"),
+        ):
+            response = self.client.get(f"{url}?mailbox=INBOX&mailid=46931")
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(self.imap.commands.count("LOGOUT"), 1)

--- a/modoboa/webmail/viewsets.py
+++ b/modoboa/webmail/viewsets.py
@@ -40,7 +40,21 @@ def _validate_search(value):
     return value
 
 
-class UserMailboxViewSet(viewsets.GenericViewSet):
+class ImapConnectionMixin:
+    """Close the IMAP connection of the request once it is over.
+
+    Every operation of a request shares one connection (see
+    ``get_imapconnector``); it is closed here, even if the view raised.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        try:
+            return super().dispatch(request, *args, **kwargs)
+        finally:
+            lib.close_imapconnector(request)
+
+
+class UserMailboxViewSet(ImapConnectionMixin, viewsets.GenericViewSet):
 
     permission_classes = (IsAuthenticated, HasMailbox)
 
@@ -166,7 +180,7 @@ class UserMailboxViewSet(viewsets.GenericViewSet):
         return response.Response(status=204)
 
 
-class UserEmailViewSet(viewsets.GenericViewSet):
+class UserEmailViewSet(ImapConnectionMixin, viewsets.GenericViewSet):
 
     permission_classes = (IsAuthenticated, HasMailbox)
 
@@ -352,7 +366,7 @@ class UserEmailViewSet(viewsets.GenericViewSet):
         return resp
 
 
-class ComposeSessionViewSet(viewsets.GenericViewSet):
+class ComposeSessionViewSet(ImapConnectionMixin, viewsets.GenericViewSet):
 
     permission_classes = (IsAuthenticated, HasMailbox)
 
@@ -517,6 +531,7 @@ class ComposeSessionViewSet(viewsets.GenericViewSet):
 
 
 class ScheduledMessageViewSet(
+    ImapConnectionMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     mixins.DestroyModelMixin,


### PR DESCRIPTION
Every operation opened its own connection, each costing a TCP connection, a TLS handshake and an authentication: sending a message opened three of them (Sent copy, draft removal, flagging). ImapEmail also opened one in its constructor and only closed it in __del__, so an exception leaked it until garbage collection.

- get_imapconnector returns a connector cached on the request; nested "with" blocks share it and only the first one authenticates.
- Webmail viewsets close that connection when the request ends, even when the view raised.
- The message view no longer fetches BODYSTRUCTURE twice.
- __enter__ tested the load_namespaces method (always true) instead of the with_namespaces flag.
